### PR TITLE
New create safe button

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@chakra-ui/react';
+import { Box, Flex, Button, Text, Spacer } from '@chakra-ui/react';
 import { DecentSignature } from '@decent-org/fractal-ui';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -31,7 +31,7 @@ export default function HomePage() {
   return (
     <Flex
       direction="column"
-      gap="1rem"
+      gap="1.5rem"
       alignItems="center"
     >
       <DecentSignature
@@ -57,25 +57,27 @@ export default function HomePage() {
       </Box>
 
       <Flex
+        w="100%"
+        alignItems="flex-end"
+      >
+        <Text textStyle="display-lg">{t('mySafes')}</Text>
+        <Spacer />
+        <Link to={BASE_ROUTES.create}>
+          <Button
+            variant="secondary"
+            size="sm"
+            cursor="pointer"
+          >
+            <Text textStyle="button-small">{t('createCTA')}</Text>
+          </Button>
+        </Link>
+      </Flex>
+
+      <Flex
         direction="column"
         w="full"
         gap="0.5rem"
       >
-        <Link to={BASE_ROUTES.create}>
-          <Box
-            w="full"
-            px="1rem"
-            pt="2rem"
-            pb="1rem"
-            bgColor="neutral-3"
-            border="1px"
-            borderColor="neutral-4"
-            borderRadius="8px"
-          >
-            {t('createCTA')}
-          </Box>
-        </Link>
-
         <MySafes />
       </Flex>
       <ExternalLink href={URL_DOCS}>{t('docsCTA')}</ExternalLink>

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -3,6 +3,7 @@ import { DecentSignature } from '@decent-org/fractal-ui';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { useAccount } from 'wagmi';
 import ExternalLink from '../../components/ui/links/ExternalLink';
 import { ModalType } from '../../components/ui/modals/ModalProvider';
 import { useFractalModal } from '../../components/ui/modals/useFractalModal';
@@ -16,6 +17,8 @@ export default function HomePage() {
     node: { daoAddress },
     action,
   } = useFractal();
+  
+  const { isConnected } = useAccount();
 
   const { t } = useTranslation('home');
 
@@ -67,6 +70,7 @@ export default function HomePage() {
             variant="secondary"
             size="sm"
             cursor="pointer"
+            isDisabled={!isConnected}
           >
             <Text textStyle="button-small">{t('createCTA')}</Text>
           </Button>

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -17,7 +17,7 @@ export default function HomePage() {
     node: { daoAddress },
     action,
   } = useFractal();
-  
+
   const { isConnected } = useAccount();
 
   const { t } = useTranslation('home');

--- a/src/pages/home/MySafes.tsx
+++ b/src/pages/home/MySafes.tsx
@@ -21,16 +21,6 @@ export function MySafes() {
         borderColor="neutral-4"
         borderRadius="8px"
       >
-        {/* SAFES HEADER (might be removed from design) */}
-        <Box p="1rem 0.75rem">
-          <Text
-            color="neutral-7"
-            textStyle="button-small"
-          >
-            {t('mySafes')}
-          </Text>
-        </Box>
-
         {/* SAFES CONTENT */}
         {favoritesList.length === 0 ? (
           <Flex


### PR DESCRIPTION
closes #1799 

This PR only moves the create home button and "my safes" header. 
<img width="1408" alt="Screenshot 2024-05-22 at 15 48 36" src="https://github.com/decentdao/decent-interface/assets/7101382/f8b39e45-d81a-4a67-ada6-f0dad68e3836">

<img width="512" alt="Screenshot 2024-05-22 at 15 49 09" src="https://github.com/decentdao/decent-interface/assets/7101382/593bfb82-c179-45b9-9db4-7e0aa872a44a">

Safe row card redesign happens in a different PR that @Da-Colon's cooking