### PR TITLE
convert to number before performing operations to get percentage

### DIFF
--- a/src/components/Proposals/ProposalVotes/index.tsx
+++ b/src/components/Proposals/ProposalVotes/index.tsx
@@ -15,14 +15,14 @@ import ProgressBar from '../../ui/utils/ProgressBar';
 import ProposalERC20VoteItem from './ProposalERC20VoteItem';
 import ProposalERC721VoteItem from './ProposalERC721VoteItem';
 
-export function VotesPercentage({ label, percentage }: { label: string; percentage: number }) {
+export function VotesPercentage({ label, percentage }: { label: string; percentage: string }) {
   return (
     <Flex
       flexWrap="wrap"
       marginTop={2}
     >
       <ProgressBar
-        value={percentage}
+        value={Number(percentage)}
         label={label}
       />
     </Flex>
@@ -54,11 +54,11 @@ function ProposalVotes({
   );
 
   const getVotesPercentage = useCallback(
-    (voteTotal: bigint): number => {
+    (voteTotal: bigint): string => {
       if (totalVotesCasted === 0n) {
-        return 0;
+        return '0';
       }
-      return Number((voteTotal * 100n) / totalVotesCasted);
+      return ((Number(voteTotal) * 100) / Number(totalVotesCasted)).toFixed(2);
     },
     [totalVotesCasted],
   );

--- a/src/components/Proposals/ProposalVotes/index.tsx
+++ b/src/components/Proposals/ProposalVotes/index.tsx
@@ -15,14 +15,14 @@ import ProgressBar from '../../ui/utils/ProgressBar';
 import ProposalERC20VoteItem from './ProposalERC20VoteItem';
 import ProposalERC721VoteItem from './ProposalERC721VoteItem';
 
-export function VotesPercentage({ label, percentage }: { label: string; percentage: string }) {
+export function VotesPercentage({ label, percentage }: { label: string; percentage: number }) {
   return (
     <Flex
       flexWrap="wrap"
       marginTop={2}
     >
       <ProgressBar
-        value={Number(percentage)}
+        value={percentage}
         label={label}
       />
     </Flex>
@@ -54,11 +54,11 @@ function ProposalVotes({
   );
 
   const getVotesPercentage = useCallback(
-    (voteTotal: bigint): string => {
+    (voteTotal: bigint): number => {
       if (totalVotesCasted === 0n) {
-        return '0';
+        return 0;
       }
-      return ((Number(voteTotal) * 100) / Number(totalVotesCasted)).toFixed(2);
+      return Number((voteTotal * 10000n) / totalVotesCasted) / 100;
     },
     [totalVotesCasted],
   );

--- a/src/components/Proposals/ProposalVotes/index.tsx
+++ b/src/components/Proposals/ProposalVotes/index.tsx
@@ -58,7 +58,7 @@ function ProposalVotes({
       if (totalVotesCasted === 0n) {
         return 0;
       }
-      return Number((voteTotal * 100000n) / totalVotesCasted) / 1000;
+      return Number((Number((voteTotal * 100000n) / totalVotesCasted) / 1000).toFixed(2));
     },
     [totalVotesCasted],
   );
@@ -71,9 +71,9 @@ function ProposalVotes({
     );
   }
 
-  const yesVotesPercentage = getVotesPercentage(yes).toFixed(2);
-  const noVotesPercentage = getVotesPercentage(no).toFixed(2);
-  const abstainVotesPercentage = getVotesPercentage(abstain).toFixed(2);
+  const yesVotesPercentage = getVotesPercentage(yes);
+  const noVotesPercentage = getVotesPercentage(no);
+  const abstainVotesPercentage = getVotesPercentage(abstain);
 
   return (
     <Flex
@@ -89,16 +89,16 @@ function ProposalVotes({
           <GridItem rowGap={4}>
             <VotesPercentage
               label={t('yes')}
-              percentage={Number(yesVotesPercentage)}
+              percentage={yesVotesPercentage}
             />
             <VotesPercentage
               label={t('no')}
-              percentage={Number(noVotesPercentage)}
+              percentage={noVotesPercentage}
             />
 
             <VotesPercentage
               label={t('abstain')}
-              percentage={Number(abstainVotesPercentage)}
+              percentage={abstainVotesPercentage}
             />
           </GridItem>
         </Grid>

--- a/src/components/Proposals/ProposalVotes/index.tsx
+++ b/src/components/Proposals/ProposalVotes/index.tsx
@@ -58,7 +58,7 @@ function ProposalVotes({
       if (totalVotesCasted === 0n) {
         return 0;
       }
-      return Number((voteTotal * 10000n) / totalVotesCasted) / 100;
+      return Number((voteTotal * 100000n) / totalVotesCasted) / 1000;
     },
     [totalVotesCasted],
   );

--- a/src/components/Proposals/ProposalVotes/index.tsx
+++ b/src/components/Proposals/ProposalVotes/index.tsx
@@ -71,9 +71,9 @@ function ProposalVotes({
     );
   }
 
-  const yesVotesPercentage = getVotesPercentage(yes);
-  const noVotesPercentage = getVotesPercentage(no);
-  const abstainVotesPercentage = getVotesPercentage(abstain);
+  const yesVotesPercentage = getVotesPercentage(yes).toFixed(2);
+  const noVotesPercentage = getVotesPercentage(no).toFixed(2);
+  const abstainVotesPercentage = getVotesPercentage(abstain).toFixed(2);
 
   return (
     <Flex
@@ -89,16 +89,16 @@ function ProposalVotes({
           <GridItem rowGap={4}>
             <VotesPercentage
               label={t('yes')}
-              percentage={yesVotesPercentage}
+              percentage={Number(yesVotesPercentage)}
             />
             <VotesPercentage
               label={t('no')}
-              percentage={noVotesPercentage}
+              percentage={Number(noVotesPercentage)}
             />
 
             <VotesPercentage
               label={t('abstain')}
-              percentage={abstainVotesPercentage}
+              percentage={Number(abstainVotesPercentage)}
             />
           </GridItem>
         </Grid>

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVotes.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVotes.tsx
@@ -64,7 +64,7 @@ export default function SnapshotProposalVotes({ proposal }: ISnapshotProposalVot
                 <VotesPercentage
                   key={choice}
                   label={choice}
-                  percentage={choicePercentageFromTotal.toFixed(1)}
+                  percentage={Number(choicePercentageFromTotal.toFixed(1))}
                 />
               );
             })}
@@ -92,10 +92,7 @@ export default function SnapshotProposalVotes({ proposal }: ISnapshotProposalVot
                 >
                   {t('shutterVotesHidden')} |
                 </Text>
-                <ProposalCountdown
-                  proposal={proposal}
-                  showIcon={false}
-                />
+                <ProposalCountdown proposal={proposal} />
               </Flex>
             ) : (
               votes.map(vote => (

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVotes.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVotes.tsx
@@ -92,7 +92,10 @@ export default function SnapshotProposalVotes({ proposal }: ISnapshotProposalVot
                 >
                   {t('shutterVotesHidden')} |
                 </Text>
-                <ProposalCountdown proposal={proposal} />
+                <ProposalCountdown
+                  proposal={proposal}
+                  showIcon={false}
+                />
               </Flex>
             ) : (
               votes.map(vote => (

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVotes.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVotes.tsx
@@ -64,7 +64,7 @@ export default function SnapshotProposalVotes({ proposal }: ISnapshotProposalVot
                 <VotesPercentage
                   key={choice}
                   label={choice}
-                  percentage={Number(choicePercentageFromTotal.toFixed(1))}
+                  percentage={choicePercentageFromTotal.toFixed(1)}
                 />
               );
             })}


### PR DESCRIPTION
Fixes #1872

Found that `bigint` doesn't support decimals directly. If there is a better way to convert and get these values let me know

![localhost_3000_proposals_17_dao=eth_0x36bD3044ab68f600f6d3e081056F34f2a58432c4(Desktop)](https://github.com/decentdao/decent-interface/assets/38386583/a8f53376-84d7-4ec8-81d4-39e0bf67d73a)
