### PR TITLE
Feedback button mobile

### DIFF
--- a/src/components/ui/page/Footer.tsx
+++ b/src/components/ui/page/Footer.tsx
@@ -11,8 +11,6 @@ export function Footer() {
       flexWrap="wrap"
       justifyContent="center"
       alignItems="center"
-      p="3rem"
-      pt="1.5rem"
       gap={{ base: 4, md: 8 }}
     >
       <Flex gap={4}>

--- a/src/components/ui/page/Layout/index.tsx
+++ b/src/components/ui/page/Layout/index.tsx
@@ -62,16 +62,10 @@ export default function Layout() {
           <NavigationLinks />
         </Show>
       </GridItem>
-      <GridItem
-        area="main"
-        mx="1.5rem"
-      >
+      <GridItem area="main">
         <Container
-          display="grid"
           maxWidth={MAX_CONTENT_WIDTH}
-          px="0"
           minH={CONTENT_HEIGHT}
-          paddingBottom="2rem"
         >
           <ErrorBoundary
             fallback={<TopErrorFallback />}

--- a/src/components/ui/page/Layout/index.tsx
+++ b/src/components/ui/page/Layout/index.tsx
@@ -81,7 +81,11 @@ export default function Layout() {
           </ErrorBoundary>
         </Container>
       </GridItem>
-      <GridItem area="footer">
+      <GridItem
+        area="footer"
+        pt="3rem"
+        pb={{ base: '5rem', md: '3rem' }}
+      >
         <Footer />
       </GridItem>
     </Grid>


### PR DESCRIPTION
Closes #1874 

In lieu of new designs, this PR does two things to address the various issues with the Report a Bug button covering stuff.

1. Increases the `z-index` of the toast element so that _it_ covers the "Report a Bug" button, which is the actual bug report referenced in #1874.
![Screenshot 2024-05-23 at 5 21 03 PM](https://github.com/decentdao/decent-interface/assets/706929/944afbea-33a8-4539-a031-fbd3350e7dfb)

2. On mobile, adds extra padding to the footer, so that the "Report a Bug" button simply doesn't cover anything. I don't think we have an explicit issue about this, but it's been called out in the past.
![Screenshot 2024-05-23 at 5 18 54 PM](https://github.com/decentdao/decent-interface/assets/706929/e953f366-ea31-41d9-aedc-ac8d155fc755)


