### PR TITLE
Finish renaming hierarchy

### DIFF
--- a/src/i18n/locales/en/breadcrumbs.json
+++ b/src/i18n/locales/en/breadcrumbs.json
@@ -2,7 +2,7 @@
   "headerTitle": "{{daoName}} {{subject}}",
   "proposals": "All Proposals",
   "proposalNew": "New Proposal",
-  "nodes": "Hierarchy",
+  "nodes": "Organization",
   "treasury": "Treasury",
   "proposal": "#{{proposalId}} {{proposalTitle}}",
   "proposalTemplates": "Proposal Templates",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -84,7 +84,6 @@
   "abi": "ABI",
   "abiSelectorHelper": "Select from the contract's pre-defined functions",
   "abiSelectorDescription": "Autopopulate with verified functions",
-  "titleNodes": "Hierarchy",
   "404Title": "Page not found",
   "404Button": "Decent App Home",
   "signers": "Signers",


### PR DESCRIPTION
On the renamed "Organization" page, we were still using the word "Hierarchy" in two places:
1. Main `H1` page title
2. Breadcrumb

This fixes that to use the word "Organization" as it should.

No issue, I just noticed it and decided to fix it right quick.