### PR TITLE
Remove docs link from home page

### DIFF
--- a/src/i18n/locales/en/home.json
+++ b/src/i18n/locales/en/home.json
@@ -1,6 +1,5 @@
 {
   "createCTA": "Create Safe",
-  "docsCTA": "Learn More",
   "mySafes": "My Safes",
   "audit": "Audit",
   "viewAll": "View All"

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -75,11 +75,9 @@ export default function HomePage() {
       <Flex
         direction="column"
         w="full"
-        gap="0.5rem"
       >
         <MySafes />
       </Flex>
-      <ExternalLink href={URL_DOCS}>{t('docsCTA')}</ExternalLink>
     </Flex>
   );
 }

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -3,11 +3,9 @@ import { DecentSignature } from '@decent-org/fractal-ui';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import ExternalLink from '../../components/ui/links/ExternalLink';
 import { ModalType } from '../../components/ui/modals/ModalProvider';
 import { useFractalModal } from '../../components/ui/modals/useFractalModal';
 import { BASE_ROUTES } from '../../constants/routes';
-import { URL_DOCS } from '../../constants/url';
 import { useFractal } from '../../providers/App/AppProvider';
 import { MySafes } from './MySafes';
 


### PR DESCRIPTION
Closes https://github.com/decentdao/decent-interface/issues/1880

Simply removes the docs link from the home page, as decided upon (see issue thread).