### PR TITLE
`1902` Update Signers UX for Multisig

### DIFF
--- a/src/components/pages/DaoSettings/components/Signers/modals/RemoveSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/RemoveSignerModal.tsx
@@ -124,7 +124,7 @@ function RemoveSignerModal({
               key={thresholdOption}
               value={thresholdOption}
             >
-              <Box key={thresholdOption}>{thresholdOption}</Box>
+              {thresholdOption}
             </option>
           ))}
         </Select>

--- a/src/components/pages/DaoSettings/components/Signers/modals/RemoveSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/RemoveSignerModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, HStack, Select, Text, Icon } from '@chakra-ui/react';
+import { Box, Button, Flex, HStack, Select, Text, Icon, Input } from '@chakra-ui/react';
 import { WarningDiamond, WarningCircle } from '@phosphor-icons/react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -64,20 +64,11 @@ function RemoveSignerModal({
   return (
     <Box>
       <Text textStyle="label-base">{t('removeSignerLabel', { ns: 'modals' })}</Text>
-
-      <Text
-        border="1px"
-        borderColor="red-0"
-        color="red-0"
-        bgColor="red--3"
-        px="1rem"
-        py="0.5rem"
+      <Input
+        value={ensName ? ensName : selectedSigner}
+        disabled={true}
         my="0.5rem"
-        rounded="sm"
-      >
-        {ensName ? ensName : selectedSigner}
-      </Text>
-
+      />
       <HStack>
         <Icon
           weight="fill"


### PR DESCRIPTION
Fixes #1902 

![image](https://github.com/decentdao/decent-interface/assets/38386583/db384bc6-12cf-400d-b561-ada86170aadb)

## Dev notes
- I move the modal opening `useFractalModal` into the `Signer` Component passing the needed props through. Because of how the modal consumes the address, I was able to use the current state setup in this way, so removed that. 
- I use `Button` component with a `Icon` inside as the size property. `icon-sm` and `icon-lg` for IconButton didn't fit with figma design of `20x20` for Icon. 