### PR TITLE
`1924` Favorites Drawer reload

### DIFF
--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -10,7 +10,8 @@ import {
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../constants/common';
-import { useAccountFavorites } from '../../hooks/DAO/loaders/useFavorites';
+import { CacheKeys } from '../../hooks/utils/cache/cacheDefaults';
+import { useLocalStorage } from '../../hooks/utils/cache/useLocalStorage';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { SafeDisplayRow } from './SafeDisplayRow';
 
@@ -22,8 +23,9 @@ interface AllSafesDrawerProps {
 
 export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
   const { addressPrefix } = useNetworkConfig();
-  const { favoritesList } = useAccountFavorites();
+
   const { t } = useTranslation('home');
+  const { getValue } = useLocalStorage();
   const [drawerHeight, setDrawerHeight] = useState('50%');
   const [isDragging, setIsDragging] = useState(false);
   const startY = useRef(0);
@@ -134,7 +136,7 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           </Box>
         </DrawerHeader>
         <DrawerBody padding="0">
-          {favoritesList.map(favorite => (
+          {getValue(CacheKeys.FAVORITES).map((favorite: string) => (
             <SafeDisplayRow
               key={favorite}
               network={addressPrefix}


### PR DESCRIPTION
Fixes #1924 

## Dev notes
So there is some difference on how the `Menu` component is mounted/unmounted and the `Drawer` component. I'm not entirely sure why when the `Drawer` component is closed, it appears that component isn't getting unmounted and/or is getting cached, the `useAccountFavorites` hook never refreshes between opening and closing. As it works fine in the Menu on desktop.

After many attempts with `useEffect` a `reloadFavorites` function `onOpen`, ultimately the cleanest solution ended up being just replacing the use of `favoritesList` out of `useAccountFavorites` and get the list directly in the component. 
