### PR TITLE
`1867` mobile submit buttons are bold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/client": "^3.7.10",
         "@chakra-ui/react": "^2.8.2",
-        "@decent-org/fractal-ui": "^0.3.5",
+        "@decent-org/fractal-ui": "^0.3.7",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@decent-org/fractal-ui": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@decent-org/fractal-ui/-/fractal-ui-0.3.5.tgz",
-      "integrity": "sha512-tnZNk2/5Ks7r8IsxBQ+59Kfxpiprdrs9Zipzv3L3cuYnBFTvbVJdNt4tb4D7gR7pcxrqS6qK1/3CNtSYkuBgtg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@decent-org/fractal-ui/-/fractal-ui-0.3.7.tgz",
+      "integrity": "sha512-w3S2iR6nJSoHTr/0gs1q7inFd614Tty9seXPyfMx/OuSYBcXOI0TZ/DAztXrz/F+g8U1+jVxDWIWQaozwhxYiQ==",
       "peerDependencies": {
         "@chakra-ui/react": "^2.3.4",
         "@phosphor-icons/react": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/client": "^3.7.10",
         "@chakra-ui/react": "^2.8.2",
-        "@decent-org/fractal-ui": "^0.3.7",
+        "@decent-org/fractal-ui": "^0.3.8",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@decent-org/fractal-ui": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@decent-org/fractal-ui/-/fractal-ui-0.3.7.tgz",
-      "integrity": "sha512-w3S2iR6nJSoHTr/0gs1q7inFd614Tty9seXPyfMx/OuSYBcXOI0TZ/DAztXrz/F+g8U1+jVxDWIWQaozwhxYiQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@decent-org/fractal-ui/-/fractal-ui-0.3.8.tgz",
+      "integrity": "sha512-LA3MTl/IwzIPZnCA6OQEpzVHPa7VYIAtpwn4ZIfJHYoVtbrjV4VuYzQTFi257xV7AUIwntE3BG/VpEMYPBQWbg==",
       "peerDependencies": {
         "@chakra-ui/react": "^2.3.4",
         "@phosphor-icons/react": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.10",
     "@chakra-ui/react": "^2.8.2",
-    "@decent-org/fractal-ui": "^0.3.7",
+    "@decent-org/fractal-ui": "^0.3.8",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@ethersproject/abstract-signer": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.10",
     "@chakra-ui/react": "^2.8.2",
-    "@decent-org/fractal-ui": "^0.3.5",
+    "@decent-org/fractal-ui": "^0.3.7",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@ethersproject/abstract-signer": "^5.7.0",
@@ -59,7 +59,7 @@
     "lint:check": "eslint . --ext .ts,.tsx",
     "pretty": "prettier . --write",
     "pretty:check": "prettier . --check",
-    "dev": "vite --force",
+    "dev": "vite --force --host",
     "start": "vite start",
     "preview": "vite preview",
     "build": "NODE_OPTIONS=--max-old-space-size=8192 vite build",


### PR DESCRIPTION
Fixes #1867 

Found that there was a missing pretext on the `apply` property for all custom component. this now fixes the messed up typography on the custom component, (buttons, inputs)