### PR TITLE
1675 proposals card updates

### DIFF
--- a/src/components/pages/DaoDashboard/Activities/hooks/useActivities.ts
+++ b/src/components/pages/DaoDashboard/Activities/hooks/useActivities.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useFractal } from '../../../../../providers/App/AppProvider';
-import { Activity, ActivityEventType, SortBy } from '../../../../../types';
+import { Activity, SortBy } from '../../../../../types';
 
 export const useActivities = (sortBy: SortBy) => {
   const {
@@ -12,20 +12,14 @@ export const useActivities = (sortBy: SortBy) => {
    * updates when a different sort is selected
    */
   const sortedActivities: Activity[] = useMemo(() => {
-    return (
-      (proposals || [])
-        // Do not display Module transactions for now
-        // https://github.com/decentdao/fractal-interface/issues/1712
-        .filter(activity => activity.eventType !== ActivityEventType.Module)
-        .sort((a, b) => {
-          const dataA = new Date(a.eventDate).getTime();
-          const dataB = new Date(b.eventDate).getTime();
-          if (sortBy === SortBy.Oldest) {
-            return dataA - dataB;
-          }
-          return dataB - dataA;
-        })
-    );
+    return (proposals || []).sort((a, b) => {
+      const dataA = new Date(a.eventDate).getTime();
+      const dataB = new Date(b.eventDate).getTime();
+      if (sortBy === SortBy.Oldest) {
+        return dataA - dataB;
+      }
+      return dataB - dataA;
+    });
   }, [sortBy, proposals]);
 
   return { sortedActivities };

--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -33,21 +33,28 @@ const totalProposalsCount = (
 
   switch (type) {
     case GovernanceType.MULTISIG: {
+      // Multisig proposals (onchain) and Snapshot proposals (offchain)
+      // are all loaded "at once", so just return the length of this set.
       return proposals.length;
     }
     case GovernanceType.AZORIUS_ERC20:
     case GovernanceType.AZORIUS_ERC721: {
+      // First, we want to first filter out all of the Snapshot proposals...
       const nonSnapshot = nonSnapshotProposals(proposals);
+
+      // Then, find the highest ID from the Azorius proposals...
       const highestNonSnapshotProposalId = nonSnapshot.reduce((p, c) => {
-        // Proposal IDs are zero indexed!
+        // Remember, proposal IDs are one-indexed!
         const propId = Number(c.proposalId) + 1;
         if (propId > p) {
           return propId;
         }
         return p;
       }, 0);
-      const snapshotProposalCount = proposals.length - nonSnapshot.length;
-      return highestNonSnapshotProposalId + snapshotProposalCount;
+
+      // Then, return the highest Azorius proposal ID
+      // plus the number of Snapshot proposals.
+      return highestNonSnapshotProposalId + proposals.length - nonSnapshot.length;
     }
     default: {
       return 0;

--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -54,7 +54,8 @@ const totalProposalsCount = (
     case GovernanceType.AZORIUS_ERC721: {
       const nonSnapshot = nonSnapshotProposals(proposals);
       const highestNonSnapshotProposalId = nonSnapshot.reduce((p, c) => {
-        const propId = Number(c.proposalId);
+        // Proposal IDs are zero indexed!
+        const propId = Number(c.proposalId) + 1;
         if (propId > p) {
           return propId;
         }

--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -91,15 +91,11 @@ const allActiveProposalsCount = (
     }
     case GovernanceType.AZORIUS_ERC20:
     case GovernanceType.AZORIUS_ERC721: {
-      const nonSnapshot = nonSnapshotProposals(proposals);
-      const activeNonSnapshotProposals = activeProposals(nonSnapshot);
-      const anyNonActiveNonSnapshotProposals = nonActiveProposals(nonSnapshot).length > 0;
-      const totalNonSnapshotProposalsCount = totalProposalsCount(nonSnapshot, type);
+      const allNonSnapshotProposals = nonSnapshotProposals(proposals);
+      const activeNonSnapshotProposals = activeProposals(allNonSnapshotProposals);
+      const activeSnapshotProposals = activeProposals(snapshotProposals(proposals));
 
-      const allSnapshotProposals = snapshotProposals(proposals);
-      const activeSnapshotProposals = activeProposals(allSnapshotProposals);
-
-      if (anyNonActiveNonSnapshotProposals) {
+      if (nonActiveProposals(allNonSnapshotProposals).length > 0) {
         // If we're here, we've loaded proposals to a point where at least one is not active,
         // which means the chances are pretty darn low that there are any more
         // active proposals after this one. So return a value!
@@ -107,6 +103,7 @@ const allActiveProposalsCount = (
       } else {
         // Getting here means that all of the loaded proposals so far are active
         // or there are no non-Snapshot proposals.
+        const totalNonSnapshotProposalsCount = totalProposalsCount(allNonSnapshotProposals, type);
         if (totalNonSnapshotProposalsCount === activeNonSnapshotProposals.length) {
           // If we're here, then all of the proposals on this Safe are active, or there are zero of them!
           return activeNonSnapshotProposals.length + activeSnapshotProposals.length;

--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -23,21 +23,6 @@ const nonSnapshotProposals = (proposals: FractalProposal[]) => {
   return proposals.filter(proposal => !isSnapshotProposal(proposal));
 };
 
-const isActiveProposal = (proposal: FractalProposal) => {
-  return (
-    proposal.state === FractalProposalState.ACTIVE ||
-    proposal.state === FractalProposalState.EXECUTABLE
-  );
-};
-
-const activeProposals = (proposals: FractalProposal[]) => {
-  return proposals.filter(proposal => isActiveProposal(proposal));
-};
-
-const nonActiveProposals = (proposals: FractalProposal[]) => {
-  return proposals.filter(proposal => !isActiveProposal(proposal));
-};
-
 const totalProposalsCount = (
   proposals: FractalProposal[] | null,
   type: GovernanceType | undefined,
@@ -68,6 +53,21 @@ const totalProposalsCount = (
       return 0;
     }
   }
+};
+
+const isActiveProposal = (proposal: FractalProposal) => {
+  return (
+    proposal.state === FractalProposalState.ACTIVE ||
+    proposal.state === FractalProposalState.EXECUTABLE
+  );
+};
+
+const activeProposals = (proposals: FractalProposal[]) => {
+  return proposals.filter(proposal => isActiveProposal(proposal));
+};
+
+const nonActiveProposals = (proposals: FractalProposal[]) => {
+  return proposals.filter(proposal => !isActiveProposal(proposal));
 };
 
 const allActiveProposalsCount = (

--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -1,18 +1,55 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 import { Scroll } from '@phosphor-icons/react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFractal } from '../../../../providers/App/AppProvider';
-import { FractalProposalState } from '../../../../types';
+import {
+  FractalProposal,
+  FractalProposalState,
+  GovernanceType,
+  SnapshotProposal,
+} from '../../../../types';
 import { BarLoader } from '../../../ui/loaders/BarLoader';
 
-interface IDAOGovernance {}
+const isSnapshotProposal = (proposal: FractalProposal) => {
+  const snapshotProposal = proposal as SnapshotProposal;
+  return !!snapshotProposal.snapshotProposalId;
+};
 
-export function InfoProposals({}: IDAOGovernance) {
+export function InfoProposals() {
   const { t } = useTranslation('dashboard');
   const {
     node: { daoAddress },
     governance: { proposals, type },
   } = useFractal();
+
+  const totalProposals = useMemo(() => {
+    if (!proposals) {
+      return '...';
+    }
+
+    switch (type) {
+      case GovernanceType.MULTISIG: {
+        return proposals.length.toString();
+      }
+      case GovernanceType.AZORIUS_ERC20:
+      case GovernanceType.AZORIUS_ERC721: {
+        const nonSnapshotProposals = proposals.filter(proposal => !isSnapshotProposal(proposal));
+        const highestNonSnapshotProposalId = nonSnapshotProposals.reduce((p, c) => {
+          const propId = Number(c.proposalId);
+          if (propId > p) {
+            return propId;
+          }
+          return p;
+        }, 0);
+        const snapshotProposalCount = proposals.length - nonSnapshotProposals.length;
+        return (highestNonSnapshotProposalId + snapshotProposalCount).toString();
+      }
+      default: {
+        return '0';
+      }
+    }
+  }, [proposals, type]);
 
   if (!daoAddress || !type) {
     return (
@@ -26,9 +63,6 @@ export function InfoProposals({}: IDAOGovernance) {
       </Flex>
     );
   }
-  const passed = !proposals
-    ? 0
-    : proposals.filter(proposal => proposal.state === FractalProposalState.EXECUTED).length;
 
   const active = !proposals
     ? 0
@@ -55,16 +89,17 @@ export function InfoProposals({}: IDAOGovernance) {
         mb="0.25rem"
         gap="0.5rem"
       >
-        <Text color="neutral-7">{t('titlePending')}</Text>
-        <Text>{active}</Text>
+        <Text color="neutral-7">{t('titleTotal')}</Text>
+        <Text>{totalProposals}</Text>
       </Flex>
       <Flex
         alignItems="center"
         justifyContent="space-between"
         mb="0.25rem"
+        gap="0.5rem"
       >
-        <Text color="neutral-7">{t('titlePassed')}</Text>
-        <Text>{passed}</Text>
+        <Text color="neutral-7">{t('titlePending')}</Text>
+        <Text>{active}</Text>
       </Flex>
     </Box>
   );

--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -1,6 +1,5 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 import { Scroll } from '@phosphor-icons/react';
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import {
@@ -16,40 +15,40 @@ const isSnapshotProposal = (proposal: FractalProposal) => {
   return !!snapshotProposal.snapshotProposalId;
 };
 
+const totalProposals = (proposals: FractalProposal[] | null, type: GovernanceType | undefined) => {
+  if (!proposals) {
+    return '...';
+  }
+
+  switch (type) {
+    case GovernanceType.MULTISIG: {
+      return proposals.length.toString();
+    }
+    case GovernanceType.AZORIUS_ERC20:
+    case GovernanceType.AZORIUS_ERC721: {
+      const nonSnapshotProposals = proposals.filter(proposal => !isSnapshotProposal(proposal));
+      const highestNonSnapshotProposalId = nonSnapshotProposals.reduce((p, c) => {
+        const propId = Number(c.proposalId);
+        if (propId > p) {
+          return propId;
+        }
+        return p;
+      }, 0);
+      const snapshotProposalCount = proposals.length - nonSnapshotProposals.length;
+      return (highestNonSnapshotProposalId + snapshotProposalCount).toString();
+    }
+    default: {
+      return '0';
+    }
+  }
+};
+
 export function InfoProposals() {
   const { t } = useTranslation('dashboard');
   const {
     node: { daoAddress },
     governance: { proposals, type },
   } = useFractal();
-
-  const totalProposals = useMemo(() => {
-    if (!proposals) {
-      return '...';
-    }
-
-    switch (type) {
-      case GovernanceType.MULTISIG: {
-        return proposals.length.toString();
-      }
-      case GovernanceType.AZORIUS_ERC20:
-      case GovernanceType.AZORIUS_ERC721: {
-        const nonSnapshotProposals = proposals.filter(proposal => !isSnapshotProposal(proposal));
-        const highestNonSnapshotProposalId = nonSnapshotProposals.reduce((p, c) => {
-          const propId = Number(c.proposalId);
-          if (propId > p) {
-            return propId;
-          }
-          return p;
-        }, 0);
-        const snapshotProposalCount = proposals.length - nonSnapshotProposals.length;
-        return (highestNonSnapshotProposalId + snapshotProposalCount).toString();
-      }
-      default: {
-        return '0';
-      }
-    }
-  }, [proposals, type]);
 
   if (!daoAddress || !type) {
     return (
@@ -90,7 +89,7 @@ export function InfoProposals() {
         gap="0.5rem"
       >
         <Text color="neutral-7">{t('titleTotal')}</Text>
-        <Text>{totalProposals}</Text>
+        <Text>{totalProposals(proposals, type)}</Text>
       </Flex>
       <Flex
         alignItems="center"

--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -28,21 +28,15 @@ export function InfoProposals({}: IDAOGovernance) {
   }
   const passed = !proposals
     ? 0
-    : proposals.reduce(
-        (prev, proposal) => (proposal.state === FractalProposalState.EXECUTED ? prev + 1 : prev),
-        0,
-      );
+    : proposals.filter(proposal => proposal.state === FractalProposalState.EXECUTED).length;
 
   const active = !proposals
     ? 0
-    : proposals.reduce(
-        (prev, proposal) =>
+    : proposals.filter(
+        proposal =>
           proposal.state === FractalProposalState.ACTIVE ||
-          proposal.state === FractalProposalState.EXECUTABLE
-            ? prev + 1
-            : prev,
-        0,
-      );
+          proposal.state === FractalProposalState.EXECUTABLE,
+      ).length;
 
   return (
     <Box data-testid="dashboard-daoProposals">

--- a/src/i18n/locales/en/dashboard.json
+++ b/src/i18n/locales/en/dashboard.json
@@ -11,7 +11,7 @@
   "titleQuorum": "Quorum",
   "titleProposals": "Proposals",
   "titlePending": "Pending",
-  "titlePassed": "Passed",
+  "titleTotal": "Total",
   "titleTreasury": "Treasury",
   "noActivity": "No Activity",
   "proposalDescription_one": "Proposal to execute {{count}} transaction",

--- a/src/i18n/locales/en/dashboard.json
+++ b/src/i18n/locales/en/dashboard.json
@@ -10,7 +10,7 @@
   "titleVotingPeriod": "Voting Period",
   "titleQuorum": "Quorum",
   "titleProposals": "Proposals",
-  "titlePending": "Pending",
+  "titleActive": "Active",
   "titleTotal": "Total",
   "titleTreasury": "Treasury",
   "noActivity": "No Activity",

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -168,7 +168,6 @@ export type ActivityTransactionType =
 export enum ActivityEventType {
   Treasury,
   Governance,
-  Module,
 }
 
 export enum SafeTransferType {


### PR DESCRIPTION
Closes https://github.com/decentdao/decent-interface/issues/1675

Renames the two properties in the Governance card on DAO Dashboard to be

- Total
- Active

This one was a lot of work to deal with all of the potential permutations of azorius/multisig and snapshot/nonsnapshot.

But I think I got it.

Displays both values as quickly as able to.

## Total

### Onchain governance

- Multisig proposals are loaded in all at once, so we know this total number pretty quickly.
- Azorius proposals are loaded in one at a time, but from newest to oldest, and the proposal ID is incremented by one each time, so we know the total number of proposals as soon as the first one comes in by looking at it's ID.

### Offchain governance

- Snapshot proposals are loaded in all at once, so we know this total number pretty quickly.

### Cumulative

- Finally, we add the total number of Snapshot proposals (if linked) to the total number of onchain governance proposals, to get the total number.

## Active

### Onchain governance
- Multisig proposals are loaded in all at once, so we know the number of active proposals pretty quickly.
- Azorius proposals are loaded in one at a time, but from newest to oldest, and the proposal ID is incremented by one each time. Naively, we would say that we don't know the number of active proposals until each one is loaded in so we can look at its state. However, we can be clever here and notice when the _first non-active_ proposal is loaded. At that point, the chances are super low (but not zero*) that all remaining proposals are completed. So we can simply use this as our trigger point to display a value instead of "...".

### Offchain governance

- Snapshot proposals are loaded in all at once, so we know the number of active proposals pretty quickly.

### Cumulative

- Finally, we add the total number of active Snapshot proposals with the total number of active onchain governance proposals, to get the total number of active proposals.

## Footnote

\* "Active proposals" in this component is defined as "votable + executable". There's a chance that an "executable" proposal may be further back in time than an "executed" proposal, which will result in the "Active" number displaying a value before we truly know the actual number. However, it will update to its correct number as the new "executable" proposal is loaded in.