### PR TITLE
`1932`  adds fallback compatibility for older and mobile browsers

### DIFF
--- a/src/hooks/utils/useCopyText.ts
+++ b/src/hooks/utils/useCopyText.ts
@@ -1,14 +1,36 @@
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
 
+/**
+ * Custom hook to copy text to the clipboard.
+ * Uses the Clipboard API if available and falls back to a textarea method for older browsers.
+ */
 export function useCopyText() {
   const { t } = useTranslation('common');
-  const copyTextToClipboard = (textToCopy?: string) => {
+
+
+  const copyTextToClipboard = async (textToCopy?: string) => {
     if (!textToCopy) return;
-    toast(t('toastClipboardCopy'), {
-      onOpen: () => navigator.clipboard.writeText(textToCopy),
-      autoClose: 1000,
-    });
+
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        // Use the Clipboard API if available and the context is secure (HTTPS)
+        await navigator.clipboard.writeText(textToCopy);
+      } else {
+        // Fallback method for older browsers (and mobile devices)
+        const textArea = document.createElement('textarea');
+        textArea.value = textToCopy;
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+      }
+      toast(t('toastClipboardCopy'), { autoClose: 1000 });
+    } catch (error) {
+      console.error('Failed to copy text to clipboard: ', error);
+      toast(t('toastClipboardCopyError'), { autoClose: 1000 });
+    }
   };
 
   return copyTextToClipboard;

--- a/src/hooks/utils/useCopyText.ts
+++ b/src/hooks/utils/useCopyText.ts
@@ -8,7 +8,6 @@ import { toast } from 'react-toastify';
 export function useCopyText() {
   const { t } = useTranslation('common');
 
-
   const copyTextToClipboard = async (textToCopy?: string) => {
     if (!textToCopy) return;
 

--- a/src/hooks/utils/useCopyText.ts
+++ b/src/hooks/utils/useCopyText.ts
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
+import { logError } from '../../helpers/errorLogging';
 
 /**
  * Custom hook to copy text to the clipboard.
@@ -27,8 +28,8 @@ export function useCopyText() {
       }
       toast(t('toastClipboardCopy'), { autoClose: 1000 });
     } catch (error) {
-      console.error('Failed to copy text to clipboard: ', error);
-      toast(t('toastClipboardCopyError'), { autoClose: 1000 });
+      logError(`unable to copy text to clipboard: ${error}`);
+      toast(t('errorCopyToClipboard'), { autoClose: 1000 });
     }
   };
 

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -50,6 +50,7 @@
   "errorSentryFallbackTitle": "Oops! Something went wrong",
   "errorSentryFallbackMessage": "We apologize for the inconvenience. Please try again later.",
   "errorGeneral": "An unexpected error occurred. Please try again later.",
+  "errorCopyToClipboard": "Unable to copy text to clipboard!",
   "labelNowishAgo": "just now",
   "labelMinutesAgo": "{{count}} minutes ago",
   "labelHoursAgo_one": "{{count}} hour ago",


### PR DESCRIPTION
Fixes #1932 

See: https://stackoverflow.com/questions/51805395/navigator-clipboard-is-undefined