### PR TITLE
Breakdown progress bars cleanup

### DIFF
--- a/src/components/Proposals/ProposalVotes/index.tsx
+++ b/src/components/Proposals/ProposalVotes/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Grid, GridItem, Text } from '@chakra-ui/react';
+import { Box, Flex, Grid, GridItem, Text, Progress } from '@chakra-ui/react';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFractal } from '../../../providers/App/AppProvider';
@@ -18,8 +18,8 @@ import ProposalERC721VoteItem from './ProposalERC721VoteItem';
 export function VotesPercentage({ label, percentage }: { label: string; percentage: number }) {
   return (
     <Flex
-      flexWrap="wrap"
       marginTop={2}
+      width="100%"
     >
       <ProgressBar
         value={percentage}
@@ -85,23 +85,18 @@ function ProposalVotes({
     >
       <ContentBox containerBoxProps={{ bg: 'transparent', width: '100%', my: 0 }}>
         <Text textStyle="display-lg">{t('breakdownTitle', { ns: 'proposal' })}</Text>
-        <Grid>
-          <GridItem rowGap={4}>
-            <VotesPercentage
-              label={t('yes')}
-              percentage={yesVotesPercentage}
-            />
-            <VotesPercentage
-              label={t('no')}
-              percentage={noVotesPercentage}
-            />
-
-            <VotesPercentage
-              label={t('abstain')}
-              percentage={abstainVotesPercentage}
-            />
-          </GridItem>
-        </Grid>
+        <VotesPercentage
+          label={t('yes')}
+          percentage={yesVotesPercentage}
+        />
+        <VotesPercentage
+          label={t('no')}
+          percentage={noVotesPercentage}
+        />
+        <VotesPercentage
+          label={t('abstain')}
+          percentage={abstainVotesPercentage}
+        />
       </ContentBox>
       {votes.length !== 0 && (
         <ContentBox containerBoxProps={{ bg: 'transparent', width: '100%', my: 0, paddingTop: 0 }}>

--- a/src/components/ui/utils/ProgressBar.tsx
+++ b/src/components/ui/utils/ProgressBar.tsx
@@ -9,8 +9,6 @@ interface ProgressBarProps {
   max?: number;
   unit?: string;
   label: string;
-  labelWidth?: string;
-  bg?: string;
 }
 export default function ProgressBar({
   value,
@@ -18,24 +16,25 @@ export default function ProgressBar({
   max = 100,
   unit = '%',
   label,
-  labelWidth,
-  bg,
 }: ProgressBarProps) {
   return (
     <Box
       width="full"
       position="relative"
     >
+      <Progress
+        width="full"
+        value={max !== 100 ? value : Math.min(value, 100)}
+        max={max}
+      />
       <Flex
         justifyContent="space-between"
         alignItems="center"
         position="absolute"
-        zIndex={2}
         top={0}
-        width={labelWidth ? labelWidth : value > 16 ? `${Math.min(value, 100)}%` : '20%'}
+        width="100%"
         px="1rem"
-        py="2px"
-        height="24px"
+        height="100%"
       >
         <Text textStyle="label-small">{label}</Text>
         {customValueComponent ? (
@@ -53,12 +52,6 @@ export default function ProgressBar({
           </Text>
         )}
       </Flex>
-      <Progress
-        value={max !== 100 ? value : Math.min(value, 100)}
-        max={max}
-        maxWidth="100%"
-        bg={bg}
-      />
     </Box>
   );
 }
@@ -87,8 +80,6 @@ export function QuorumProgressBar({
         max={totalQuorum}
         unit={unit}
         label={t('quorum', { ns: 'common' })}
-        bg="neutral-4"
-        labelWidth="100%"
         customValueComponent={
           totalQuorum ? (
             <Text

--- a/src/components/ui/utils/ProgressBar.tsx
+++ b/src/components/ui/utils/ProgressBar.tsx
@@ -91,7 +91,11 @@ export function QuorumProgressBar({
         labelWidth="100%"
         customValueComponent={
           totalQuorum ? (
-            <Text textStyle="label-small">
+            <Text
+              textStyle="label-small"
+              whiteSpace="nowrap"
+              overflow="clip"
+            >
               {reachedQuorum >= totalQuorum && (
                 <Icon
                   color="lilac-0"


### PR DESCRIPTION
Closes #1934 
Closes #1935 

See the two above linked issues to get an idea of what was broken.

Now see some screenshots of how it looks due to the changes in this PR

<img width="671" alt="Screenshot 2024-05-28 at 4 41 35 PM" src="https://github.com/decentdao/decent-interface/assets/706929/f515a5a7-8be1-408a-b570-85300bfe85be">
<img width="673" alt="Screenshot 2024-05-28 at 4 41 42 PM" src="https://github.com/decentdao/decent-interface/assets/706929/f0e751a2-959f-40d4-bb7f-bec1862fd940">
<img width="639" alt="Screenshot 2024-05-28 at 4 42 05 PM" src="https://github.com/decentdao/decent-interface/assets/706929/bc51ee14-e5ea-4b77-9679-26b8d54dae24">
<img width="679" alt="Screenshot 2024-05-28 at 4 42 09 PM" src="https://github.com/decentdao/decent-interface/assets/706929/dc8da16d-4279-4f47-9f0e-dd843225218a">
