### PR TITLE
Formik-ify more send asset modal form fields

### DIFF
--- a/src/components/pages/DAOTreasury/sendAssets.ts
+++ b/src/components/pages/DAOTreasury/sendAssets.ts
@@ -46,7 +46,7 @@ export const sendAssets = async ({
     calldatas,
     metaData: {
       title: t(isEth ? 'sendEth' : 'sendToken', { ns: 'proposalMetadata' }),
-      description: description,
+      description,
       documentationUrl: '',
     },
   };

--- a/src/components/pages/DaoSettings/components/Signers/hooks/useAddSigner.ts
+++ b/src/components/pages/DaoSettings/components/Signers/hooks/useAddSigner.ts
@@ -44,7 +44,7 @@ const useAddSigner = () => {
         calldatas,
         metaData: {
           title: 'Add Signer',
-          description: description,
+          description,
           documentationUrl: '',
         },
       };

--- a/src/components/pages/DaoSettings/components/Signers/hooks/useRemoveSigner.ts
+++ b/src/components/pages/DaoSettings/components/Signers/hooks/useRemoveSigner.ts
@@ -46,7 +46,7 @@ const useRemoveSigner = ({
       calldatas,
       metaData: {
         title: 'Remove Signers',
-        description: description,
+        description,
         documentationUrl: '',
       },
     };

--- a/src/components/ui/forms/BigIntInput.tsx
+++ b/src/components/ui/forms/BigIntInput.tsx
@@ -19,6 +19,7 @@ export interface BigIntInputProps
   min?: string;
   max?: string;
   maxValue?: bigint;
+  currentValue?: BigIntValuePair;
 }
 /**
  * This component will add a chakra Input component that accepts and sets a bigint
@@ -39,6 +40,7 @@ export function BigIntInput({
   min,
   max,
   maxValue,
+  currentValue,
   ...rest
 }: BigIntInputProps) {
   const { t } = useTranslation('common');
@@ -141,6 +143,13 @@ export function BigIntInput({
     },
     [decimalPlaces, min, onChange],
   );
+
+  // if the parent Formik value prop changes, need to update the value
+  useEffect(() => {
+    if (!inputValue || inputValue === currentValue?.value ) return;
+    if (currentValue?.bigintValue === 0n) 
+      setInputValue('');
+  }, [currentValue, inputValue]);
 
   // if the decimalPlaces change, need to update the value
   useEffect(() => {

--- a/src/components/ui/forms/BigIntInput.tsx
+++ b/src/components/ui/forms/BigIntInput.tsx
@@ -146,9 +146,8 @@ export function BigIntInput({
 
   // if the parent Formik value prop changes, need to update the value
   useEffect(() => {
-    if (!inputValue || inputValue === currentValue?.value ) return;
-    if (currentValue?.bigintValue === 0n) 
-      setInputValue('');
+    if (!inputValue || inputValue === currentValue?.value) return;
+    if (currentValue?.bigintValue === 0n) setInputValue('');
   }, [currentValue, inputValue]);
 
   // if the decimalPlaces change, need to update the value

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -32,11 +32,6 @@ export function SendAssetsModal({ close }: { close: () => void }) {
   const { t } = useTranslation(['modals', 'common']);
 
   const fungibleAssetsWithBalance = assetsFungible.filter(asset => parseFloat(asset.balance) > 0);
-
-  const [selectedAsset, setSelectedAsset] = useState<SafeBalanceResponse>(
-    fungibleAssetsWithBalance[0],
-  );
-  const [inputAmount, setInputAmount] = useState<BigIntValuePair>();
   const [nonceInput, setNonceInput] = useState<number | undefined>(safe!.nonce);
 
   const { submitProposal } = useSubmitProposal();
@@ -89,7 +84,8 @@ export function SendAssetsModal({ close }: { close: () => void }) {
           console.log(values);
 
           const overDraft =
-            Number(values.inputAmount?.value || '0') > formatCoinUnitsFromAsset(values.selectedAsset);
+            Number(values.inputAmount?.value || '0') >
+            formatCoinUnitsFromAsset(values.selectedAsset);
 
           // @dev next couple of lines are written like this, to keep typing equivalent during the conversion from BN to bigint
           const inputBigint = values.inputAmount?.bigintValue;
@@ -120,10 +116,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
                           iconSize="1.5rem"
                           icon={<CaretDown />}
                           onChange={e => {
-                            setFieldValue(
-                              'inputAmount',
-                              { value: '0', bigintValue: 0n },
-                            );
+                            setFieldValue('inputAmount', { value: '0', bigintValue: 0n });
                             setFieldValue(
                               'selectedAsset',
                               fungibleAssetsWithBalance[Number(e.target.value)],
@@ -152,7 +145,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
                       <LabelWrapper label={t('amountLabel')}>
                         <BigIntInput
                           {...field}
-                          onChange={(value) => {
+                          onChange={value => {
                             setFieldValue('inputAmount', value);
                           }}
                           currentValue={values.inputAmount}

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -80,8 +80,6 @@ export function SendAssetsModal({ close }: { close: () => void }) {
         validationSchema={sendAssetsValidationSchema}
       >
         {({ errors, values, setFieldValue }) => {
-          console.log(values);
-
           const overDraft =
             Number(values.inputAmount?.value || '0') >
             formatCoinUnitsFromAsset(values.selectedAsset);

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -61,7 +61,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
         token: Yup.object().shape({
           name: Yup.string().required(),
           symbol: Yup.string().required(),
-          decimals: Yup.number().required()
+          decimals: Yup.number().required(),
         }),
         balance: Yup.string().required(),
       })

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -142,6 +142,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
                       <LabelWrapper label={t('amountLabel')}>
                         <BigIntInput
                           {...field}
+                          value={(field.value as BigIntValuePair)?.bigintValue}
                           onChange={value => {
                             setFieldValue('inputAmount', value);
                           }}

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Select, HStack, Text, Button } from '@chakra-ui/react';
 import { LabelWrapper } from '@decent-org/fractal-ui';
 import { CaretDown } from '@phosphor-icons/react';
 import { SafeBalanceResponse } from '@safe-global/safe-service-client';
-import { Field, FieldAttributes, Form, Formik } from 'formik';
+import { Field, FieldAttributes, FieldProps, Form, Formik } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
@@ -98,7 +98,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
               <Flex>
                 {/* ASSET SELECT */}
                 <Field name="selectedAsset">
-                  {({ field }: FieldAttributes<any>) => (
+                  {({ field }: FieldAttributes<FieldProps<SafeBalanceResponse>>) => (
                     <Box
                       width="40%"
                       marginEnd="0.75rem"
@@ -137,12 +137,12 @@ export function SendAssetsModal({ close }: { close: () => void }) {
 
                 {/* SEND AMOUNT INPUT */}
                 <Field name="inputAmount">
-                  {({ field }: FieldAttributes<any>) => (
+                  {({ field }: FieldAttributes<FieldProps<BigIntValuePair | undefined>>) => (
                     <Box width="60%">
                       <LabelWrapper label={t('amountLabel')}>
                         <BigIntInput
                           {...field}
-                          value={(field.value as BigIntValuePair)?.bigintValue}
+                          value={field.value?.bigintValue}
                           onChange={value => {
                             setFieldValue('inputAmount', value);
                           }}
@@ -181,7 +181,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
 
               {/* DESTINATION ADDRESS INPUT */}
               <Field name={'destinationAddress'}>
-                {({ field }: FieldAttributes<any>) => (
+                {({ field }: FieldAttributes<FieldProps<string>>) => (
                   <LabelWrapper
                     label={t('destinationLabel')}
                     subLabel={t('destinationSublabel')}

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -61,8 +61,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
         token: Yup.object().shape({
           name: Yup.string().required(),
           symbol: Yup.string().required(),
-          decimals: Yup.number().required(),
-          logoUri: Yup.string().required(),
+          decimals: Yup.number().required()
         }),
         balance: Yup.string().required(),
       })


### PR DESCRIPTION
Closes #1945 

See also: https://github.com/decentdao/decent-interface/pull/1928#discussion_r1619245208

I have chosen not to formik-ify the custom nonce input as it's got its own validation and wouldn't make sense to force that back outside to be handled by Formik/Yup