### PR TITLE
Exclude spam tokens from Treasury page

### DIFF
--- a/src/hooks/DAO/loaders/useFractalTreasury.ts
+++ b/src/hooks/DAO/loaders/useFractalTreasury.ts
@@ -28,7 +28,7 @@ export const useFractalTreasury = () => {
       return;
     }
     const [assetsFungible, assetsNonFungible, transfers] = await Promise.all([
-      safeAPI.getBalances(daoAddress).catch(e => {
+      safeAPI.getBalances(daoAddress, { excludeSpamTokens: true }).catch(e => {
         logError(e);
         return [];
       }),


### PR DESCRIPTION
Closes #1403

Only able to "`excludeSpamToken`" in this PR, not "only include `trusted` tokens".

For more context, see
- https://github.com/decentdao/decent-interface/issues/1403#issuecomment-1976885673
- https://github.com/decentdao/decent-interface/issues/1403#issuecomment-1976970672
- https://github.com/decentdao/decent-interface/issues/1403#issuecomment-1976970672

@decentdao/engineering, please take a look at https://github.com/decentdao/decent-interface/issues/1267 and let me know if you have any ideas...