### PR TITLE
move blur and bg to box to ensure proper application

### DIFF
--- a/src/components/ui/menus/OptionMenu/index.tsx
+++ b/src/components/ui/menus/OptionMenu/index.tsx
@@ -1,4 +1,4 @@
-import { Menu, MenuButton, MenuList, As, MenuProps, Tooltip, Portal } from '@chakra-ui/react';
+import { Menu, MenuButton, MenuList, As, MenuProps, Tooltip, Portal, Box } from '@chakra-ui/react';
 import { MouseEvent, ReactNode, RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
@@ -38,21 +38,24 @@ export function OptionMenu({
       borderWidth="1px"
       borderColor="neutral-3"
       borderRadius="0.75rem"
-      bg={NEUTRAL_2_82_TRANSPARENT}
-      backdropFilter="auto"
-      backdropBlur="10px"
       mr={menuListMr || ['auto', '1rem']}
       zIndex={1000}
     >
-      {children}
-      <OptionsList
-        options={options}
-        showOptionSelected={showOptionSelected}
-        closeOnSelect={closeOnSelect}
-        showOptionCount={showOptionCount}
-        namespace={namespace}
-        titleKey={titleKey}
-      />
+      <Box
+        bg={NEUTRAL_2_82_TRANSPARENT}
+        backdropFilter="auto"
+        backdropBlur="10px"
+      >
+        {children}
+        <OptionsList
+          options={options}
+          showOptionSelected={showOptionSelected}
+          closeOnSelect={closeOnSelect}
+          showOptionCount={showOptionCount}
+          namespace={namespace}
+          titleKey={titleKey}
+        />
+      </Box>
     </MenuList>
   );
   return (


### PR DESCRIPTION
Fixes #1888 

Was able to recreate on IOS, Chrome. There seem to be some other configuration on `MenuList` that was overriding this effect on Mobile. Moving the blur properties to a `Box` component as a child fixes this issue on mobile.