### PR TITLE
Make "no Safes" copy only break to two lines on mobile view

### DIFF
--- a/src/pages/home/MySafes.tsx
+++ b/src/pages/home/MySafes.tsx
@@ -25,7 +25,9 @@ export function MySafes() {
         {/* SAFES CONTENT */}
         {favoritesList.length === 0 ? (
           <Flex
-            direction="column"
+            direction={{ base: 'column', md: 'row' }}
+            columnGap="0.5rem"
+            justifyContent="center"
             p="1rem"
             maxW="100%"
             my="0.5rem"


### PR DESCRIPTION
Fixes #1875 

![Screenshot 2024-05-30 at 8 50 47 AM](https://github.com/decentdao/decent-interface/assets/706929/ef2ae774-ab91-45dc-be81-f441feaa20ba)
![Screenshot 2024-05-30 at 8 50 55 AM](https://github.com/decentdao/decent-interface/assets/706929/c9e658c9-43c1-4ae6-98b7-05186c32aa01)
![Screenshot 2024-05-30 at 8 51 05 AM](https://github.com/decentdao/decent-interface/assets/706929/903d97a9-1c81-477f-a62b-802344a3e647)
![Screenshot 2024-05-30 at 8 51 21 AM](https://github.com/decentdao/decent-interface/assets/706929/5785b24f-5368-4d3c-96c7-584f53a00fd3)
