### PR TITLE
`1598` Support empty strings

### DIFF
--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -46,6 +46,12 @@ export const encodeFunction = (
     } else if (param.endsWith(')')) {
       (parametersFixed!![tupleIndex!] as string[]).push(param.replace(')', ''));
       tupleIndex = undefined;
+    } else if (
+      (param.startsWith('"') && param.endsWith('"')) ||
+      (param.startsWith("'") && param.endsWith("'"))
+    ) {
+      // Only remove outer quotes if the entire string is quoted
+      return parametersFixed!!.push(param.substring(1, param.length - 1));
     } else {
       parametersFixed!!.push(param);
     }


### PR DESCRIPTION
Fixes #1598

So I think I figured out a simple solution. If quotes are wrapping the text in the input field by a user simple remove the quotes.

I deployed and verified a simple contract to do some testing on Sepolia

Address: `0xEDFF6156e85ae11d2767Fc9Ec6E17352A928D0b7`

One function, a public state, and an event that check if its a empty string (for funsies).

I've tested:

`"foo"` -> foo
`'foo'` -> foo
`""` ->
`''` ->
`Foo'bar` -> `Foo'bar`
`"Foo'bar"` -> `Foo'bar`

Let me know yall's thoughts on this update