### PR TITLE
`1536` prevent execute if not next nonce

### DIFF
--- a/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
@@ -31,7 +31,7 @@ export function AzoriusGovernance(props: ICreationStepProps) {
 
   useEffect(() => {
     if (showCustomNonce === undefined && safe && mode === DAOCreateMode.EDIT) {
-      setFieldValue('multisig.customNonce', safe.nonce);
+      setFieldValue('multisig.customNonce', safe.nextNonce);
       setShowCustomNonce(true);
     }
   }, [setFieldValue, safe, showCustomNonce, mode]);

--- a/src/components/DaoCreator/formComponents/GuardDetails.tsx
+++ b/src/components/DaoCreator/formComponents/GuardDetails.tsx
@@ -45,7 +45,7 @@ function GuardDetails(props: ICreationStepProps) {
 
   useEffect(() => {
     if (showCustomNonce === undefined && !dao?.isAzorius && isSubDAO && safe) {
-      setFieldValue('multisig.customNonce', safe.nonce);
+      setFieldValue('multisig.customNonce', safe.nextNonce);
       setShowCustomNonce(true);
     }
   }, [isSubDAO, azoriusContractAddress, type, setFieldValue, safe, dao, showCustomNonce]);

--- a/src/components/ProposalBuilder/index.tsx
+++ b/src/components/ProposalBuilder/index.tsx
@@ -160,7 +160,7 @@ export function ProposalBuilder({
                       ) : (
                         <ProposalTransactionsForm
                           pendingTransaction={pendingCreateTx}
-                          safeNonce={safe?.nonce}
+                          safeNonce={safe?.nextNonce}
                           mode={mode}
                           {...formikProps}
                         />

--- a/src/components/ProposalTemplates/ProposalTemplateCard.tsx
+++ b/src/components/ProposalTemplates/ProposalTemplateCard.tsx
@@ -52,7 +52,7 @@ export default function ProposalTemplateCard({
     }
   }, [navigate, daoAddress, addressPrefix]);
 
-  const nonce = safe?.nonce;
+  const nonce = safe?.nextNonce;
   const handleRemoveTemplate = useCallback(async () => {
     const proposalData = await prepareRemoveProposalTemplateProposal(templateIndex);
     if (!!proposalData) {

--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text, Flex } from '@chakra-ui/react';
+import { Box, Button, Text, Flex, Tooltip } from '@chakra-ui/react';
 import { TypedDataSigner } from '@ethersproject/abstract-signer';
 import { SafeMultisigTransactionWithTransfersResponse } from '@safe-global/safe-service-client';
 import { Signer } from 'ethers';
@@ -247,14 +247,20 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
         <ProposalCountdown proposal={proposal} />
       </Flex>
       <Box marginTop={4}>
-        <Button
-          w="full"
-          rightIcon={buttonProps[proposal.state!].icon}
-          isDisabled={isButtonDisabled}
-          onClick={buttonProps[proposal.state!].action}
+        <Tooltip
+          placement="top-start"
+          label={t('notActiveNonceTooltip')}
+          isDisabled={isActiveNonce}
         >
-          {t(buttonProps[proposal.state!].text, { ns: 'common' })}
-        </Button>
+          <Button
+            w="full"
+            rightIcon={buttonProps[proposal.state!].icon}
+            isDisabled={isButtonDisabled}
+            onClick={buttonProps[proposal.state!].action}
+          >
+            {t(buttonProps[proposal.state!].text, { ns: 'common' })}
+          </Button>
+        </Tooltip>
       </Box>
     </ContentBox>
   );

--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -192,7 +192,6 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
   const hasSigned = proposal.confirmations.find(confirm => confirm.owner === user.address);
   const isOwner = safe?.owners?.includes(user.address || '');
   const isPending = asyncRequestPending || contractCallPending;
-
   if (
     (proposal.state === FractalProposalState.ACTIVE && (hasSigned || !isOwner)) ||
     proposal.state === FractalProposalState.REJECTED ||
@@ -237,7 +236,9 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
       icon: undefined,
     },
   };
-  const isButtonDisabled = isPending || proposal.state === FractalProposalState.TIMELOCKED;
+  const isActiveNonce = !!safe && multisigTx.nonce === safe.nonce;
+  const isButtonDisabled =
+    isPending || proposal.state === FractalProposalState.TIMELOCKED || !isActiveNonce;
 
   return (
     <ContentBox containerBoxProps={{ bg: BACKGROUND_SEMI_TRANSPARENT }}>

--- a/src/components/pages/DaoSettings/components/MetadataContainer.tsx
+++ b/src/components/pages/DaoSettings/components/MetadataContainer.tsx
@@ -84,7 +84,7 @@ export function MetadataContainer() {
 
     submitProposal({
       proposalData,
-      nonce: safe?.nonce,
+      nonce: safe?.nextNonce,
       pendingToastMessage: t('proposalCreatePendingToastMessage', { ns: 'proposal' }),
       successToastMessage: t('proposalCreateSuccessToastMessage', { ns: 'proposal' }),
       failedToastMessage: t('proposalCreateFailureToastMessage', { ns: 'proposal' }),
@@ -117,7 +117,7 @@ export function MetadataContainer() {
 
     submitProposal({
       proposalData,
-      nonce: safe?.nonce,
+      nonce: safe?.nextNonce,
       pendingToastMessage: t('proposalCreatePendingToastMessage', { ns: 'proposal' }),
       successToastMessage: t('proposalCreateSuccessToastMessage', { ns: 'proposal' }),
       failedToastMessage: t('proposalCreateFailureToastMessage', { ns: 'proposal' }),

--- a/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
@@ -57,7 +57,7 @@ function AddSignerModal({
     address: Yup.string().test(addressValidationTest).test(newSignerValidationTest),
     nonce: Yup.number()
       .required()
-      .moreThan((!!safe && safe.nonce - 1) || 0),
+      .moreThan((!!safe && safe.nonce - 1) || 0), // ? @todo Is this correct? or should this be nextNonce?
     threshold: Yup.number().required(),
     thresholdOptions: Yup.array().of(Yup.number()).required(),
   });
@@ -67,7 +67,7 @@ function AddSignerModal({
       <Formik
         initialValues={{
           address: '',
-          nonce: safe?.nonce || 0,
+          nonce: safe?.nextNonce || 0,
           threshold: currentThreshold,
           thresholdOptions: Array.from({ length: signers.length + 1 }, (_, i) => i + 1),
         }}

--- a/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
@@ -57,7 +57,7 @@ function AddSignerModal({
     address: Yup.string().test(addressValidationTest).test(newSignerValidationTest),
     nonce: Yup.number()
       .required()
-      .moreThan((!!safe && safe.nonce - 1) || 0), // ? @todo Is this correct? or should this be nextNonce?
+      .moreThan((!!safe && safe.nonce - 1) || 0),
     threshold: Yup.number().required(),
     thresholdOptions: Yup.array().of(Yup.number()).required(),
   });

--- a/src/components/pages/DaoSettings/components/Signers/modals/RemoveSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/RemoveSignerModal.tsx
@@ -28,7 +28,7 @@ function RemoveSignerModal({
   const [thresholdOptions, setThresholdOptions] = useState<number[]>();
   const [prevSigner, setPrevSigner] = useState<string>('');
   const [threshold, setThreshold] = useState<number>(currentThreshold);
-  const [nonce, setNonce] = useState<number | undefined>(safe!.nonce);
+  const [nonce, setNonce] = useState<number | undefined>(safe!.nextNonce);
   const { chain } = useNetworkConfig();
   const { data: ensName } = useEnsName({
     address: selectedSigner as Address,

--- a/src/components/ui/forms/CustomNonceInput.tsx
+++ b/src/components/ui/forms/CustomNonceInput.tsx
@@ -25,7 +25,7 @@ export function CustomNonceInput({
   } = useFractal();
   const { t } = useTranslation(['proposal', 'common']);
   const errorMessage =
-    nonce !== undefined && safe && nonce < safe.nonce ? t('customNonceError') : undefined;
+    nonce !== undefined && safe && nonce < safe.nonce ? t('customNonceError') : undefined; // ? @todo Is this correct? or should this also be minus 1?
 
   const tooltipContainer = useRef<HTMLDivElement>(null);
   if (dao?.isAzorius) return null;

--- a/src/components/ui/forms/CustomNonceInput.tsx
+++ b/src/components/ui/forms/CustomNonceInput.tsx
@@ -25,7 +25,7 @@ export function CustomNonceInput({
   } = useFractal();
   const { t } = useTranslation(['proposal', 'common']);
   const errorMessage =
-    nonce !== undefined && safe && nonce < safe.nonce ? t('customNonceError') : undefined; // ? @todo Is this correct? or should this also be minus 1?
+    nonce !== undefined && safe && nonce < safe.nonce ? t('customNonceError') : undefined;
 
   const tooltipContainer = useRef<HTMLDivElement>(null);
   if (dao?.isAzorius) return null;

--- a/src/components/ui/modals/ProposalTemplateModal.tsx
+++ b/src/components/ui/modals/ProposalTemplateModal.tsx
@@ -31,7 +31,7 @@ export default function ProposalTemplateModal({
   const { addressPrefix } = useNetworkConfig();
 
   const [filledProposalTransactions, setFilledProposalTransactions] = useState(transactions);
-  const [nonce, setNonce] = useState<number | undefined>(safe!.nonce);
+  const [nonce, setNonce] = useState<number | undefined>(safe!.nextNonce);
   const [showAll, setShowAll] = useState(false);
   const { t } = useTranslation(['proposalTemplate', 'proposal']);
   const navigate = useNavigate();

--- a/src/components/ui/modals/SendAssetsModal.tsx
+++ b/src/components/ui/modals/SendAssetsModal.tsx
@@ -31,7 +31,7 @@ export function SendAssetsModal({ close }: { close: () => void }) {
     fungibleAssetsWithBalance[0],
   );
   const [inputAmount, setInputAmount] = useState<BigIntValuePair>();
-  const [nonceInput, setNonceInput] = useState<number | undefined>(safe!.nonce);
+  const [nonceInput, setNonceInput] = useState<number | undefined>(safe!.nextNonce);
 
   const { submitProposal } = useSubmitProposal();
 

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -111,7 +111,7 @@
   "customNonce": "Custom Nonce (advanced)",
   "customNonceTrimmed": "Custom Nonce",
   "customNonceTooltip": "Optionally set a custom proposal nonce to avoid collisions.",
-  "notActiveNonceTooltip": "Proposals must be executed in order based on their nonce.",
+  "notActiveNonceTooltip": "There is proposal with a lower nonce that must be executed first.",
   "nonce": "Nonce",
   "votingTooltip": "Time remaining to cast your vote.",
   "timeLockedTooltip": "This proposal can be executed once its timelock period has passed.",

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -111,6 +111,7 @@
   "customNonce": "Custom Nonce (advanced)",
   "customNonceTrimmed": "Custom Nonce",
   "customNonceTooltip": "Optionally set a custom proposal nonce to avoid collisions.",
+  "notActiveNonceTooltip": "Proposals must be executed in order based on their nonce.",
   "nonce": "Nonce",
   "votingTooltip": "Time remaining to cast your vote.",
   "timeLockedTooltip": "This proposal can be executed once its timelock period has passed.",

--- a/src/pages/daos/[daoAddress]/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/new/index.tsx
@@ -23,7 +23,7 @@ export default function SubDaoCreate() {
 
   const proposeSubDAO = (daoData: SafeMultisigDAO | AzoriusGovernanceDAO | SubDAO) => {
     const subDAOData = daoData as SubDAO;
-    proposeDao(subDAOData, subDAOData.customNonce || safe?.nonce, successCallback);
+    proposeDao(subDAOData, subDAOData.customNonce || safe?.nextNonce, successCallback);
   };
 
   return (

--- a/src/pages/daos/[daoAddress]/proposals/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/new/index.tsx
@@ -48,7 +48,7 @@ export default function CreateProposalPage() {
 
   return (
     <ProposalBuilder
-      initialValues={{ ...DEFAULT_PROPOSAL, nonce: safe.nonce }}
+      initialValues={{ ...DEFAULT_PROPOSAL, nonce: safe.nextNonce }}
       mode={ProposalBuilderMode.PROPOSAL}
       prepareProposalData={prepareProposal}
     />

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -209,10 +209,10 @@ class CachingSafeServiceClient extends SafeServiceClient {
     return value;
   }
 
-  async getSafeData(safeAddress: string): Promise<SafeInfoResponse> {
+  async getSafeData(safeAddress: string): Promise<SafeInfoResponse & { nextNonce: number }> {
     const safeInfoResponse = await this.getSafeInfo(safeAddress);
     const nextNonce = await this.getNextNonce(safeAddress);
-    const safeInfo = { ...safeInfoResponse, nonce: nextNonce };
+    const safeInfo = { ...safeInfoResponse, nextNonce };
     return safeInfo;
   }
 }

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -29,7 +29,7 @@ import {
   setIndexedDBValue,
 } from '../../../hooks/utils/cache/useLocalDB';
 import useSignerOrProvider from '../../../hooks/utils/useSignerOrProvider';
-import { SafeMultisigTransactionResponse } from '../../../types';
+import { SafeInfoResponseWithGuard, SafeMultisigTransactionResponse } from '../../../types';
 import { useNetworkConfig } from '../../NetworkConfig/NetworkConfigProvider';
 
 class CachingSafeServiceClient extends SafeServiceClient {
@@ -209,7 +209,7 @@ class CachingSafeServiceClient extends SafeServiceClient {
     return value;
   }
 
-  async getSafeData(safeAddress: string): Promise<SafeInfoResponse & { nextNonce: number }> {
+  async getSafeData(safeAddress: string): Promise<SafeInfoResponseWithGuard> {
     const safeInfoResponse = await this.getSafeInfo(safeAddress);
     const nextNonce = await this.getNextNonce(safeAddress);
     const safeInfo = { ...safeInfoResponse, nextNonce };

--- a/src/types/safeGlobal.ts
+++ b/src/types/safeGlobal.ts
@@ -28,6 +28,7 @@ export declare type DataDecoded = {
 };
 
 export type SafeInfoResponseWithGuard = SafeInfoResponse & {
+  nextNonce: number;
   guard?: string;
 };
 


### PR DESCRIPTION
Fixes #1536

I left two comments (I'll point them out) on some logic around nonce.

Basically just slightly reverted the change where safe.nonce is replaced by nextNonce. I've added a new property to the typing and place `nextNonce` as its own property so that we still have current nonce on hand that we can use to prevent execution of other proposals of higher nonce