### PR TITLE
`1568` nonce page refresh

### DIFF
--- a/src/hooks/utils/useUpdateSafeData.ts
+++ b/src/hooks/utils/useUpdateSafeData.ts
@@ -1,0 +1,32 @@
+import { useRef, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useFractal } from '../../providers/App/AppProvider';
+import { useSafeAPI } from '../../providers/App/hooks/useSafeAPI';
+import { NodeAction } from '../../providers/App/node/action';
+
+export const useUpdateSafeData = () => {
+  const {
+    action,
+    node: { daoAddress },
+  } = useFractal();
+  const safeAPI = useSafeAPI();
+  const location = useLocation();
+  const prevPathname = useRef(location.pathname);
+
+  useEffect(() => {
+    if (!safeAPI || !daoAddress) {
+      return;
+    }
+
+    if (prevPathname.current !== location.pathname) {
+      (async () => {
+        const safeInfo = await safeAPI.getSafeData(daoAddress);
+        action.dispatch({
+          type: NodeAction.SET_SAFE_INFO,
+          payload: safeInfo,
+        });
+      })();
+      prevPathname.current = location.pathname;
+    }
+  }, [action, daoAddress, safeAPI, location]);
+};

--- a/src/pages/DAOController.tsx
+++ b/src/pages/DAOController.tsx
@@ -1,11 +1,13 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import useDAOController from '../hooks/DAO/useDAOController';
+import { useUpdateSafeData } from '../hooks/utils/useUpdateSafeData';
 import { useFractal } from '../providers/App/AppProvider';
 import LoadingProblem from './LoadingProblem';
 
 export default function DAOController() {
   const { errorLoading, wrongNetwork, invalidQuery } = useDAOController();
+  useUpdateSafeData();
   const {
     node: { daoName },
   } = useFractal();

--- a/src/pages/daos/[daoAddress]/proposals/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/new/index.tsx
@@ -16,8 +16,6 @@ export default function CreateProposalPage() {
 
   const HEADER_HEIGHT = useHeaderHeight();
 
-
-
   if (!type || !daoAddress || !safe) {
     return (
       <Center minH={`calc(100vh - ${HEADER_HEIGHT})`}>

--- a/src/pages/daos/[daoAddress]/proposals/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/new/index.tsx
@@ -1,42 +1,22 @@
 import { Center } from '@chakra-ui/react';
-import { useRef, useEffect } from 'react';
 import { ProposalBuilder } from '../../../../../components/ProposalBuilder';
 import { DEFAULT_PROPOSAL } from '../../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../../components/ui/loaders/BarLoader';
 import { useHeaderHeight } from '../../../../../constants/common';
 import { usePrepareProposal } from '../../../../../hooks/DAO/proposal/usePrepareProposal';
 import { useFractal } from '../../../../../providers/App/AppProvider';
-import { useSafeAPI } from '../../../../../providers/App/hooks/useSafeAPI';
-import { NodeAction } from '../../../../../providers/App/node/action';
 import { ProposalBuilderMode } from '../../../../../types';
 
 export default function CreateProposalPage() {
   const {
-    action,
     node: { daoAddress, safe },
     governance: { type },
   } = useFractal();
-  const safeAPI = useSafeAPI();
   const { prepareProposal } = usePrepareProposal();
 
   const HEADER_HEIGHT = useHeaderHeight();
 
-  const isMounted = useRef(false);
-  useEffect(() => {
-    if (!safeAPI || !daoAddress || isMounted.current) {
-      return;
-    }
 
-    (async () => {
-      const safeInfo = await safeAPI.getSafeData(daoAddress);
-      action.dispatch({
-        type: NodeAction.SET_SAFE_INFO,
-        payload: safeInfo,
-      });
-    })();
-
-    isMounted.current = true;
-  }, [action, daoAddress, safeAPI]);
 
   if (!type || !daoAddress || !safe) {
     return (


### PR DESCRIPTION
Fixes #1568

Not sure if we should also cache and/or exclude routes. but move the implementation done in the New Proposals page to the `DAOController` and set it up to make the request whenever the url changes. 

The alternative to this, would be to refactor this hook back to the `isMounted` ref setup and add the hook to the particular pages/models/components that may create a proposal. But then we have to add it to any new pages/components that may need this features. Thoughts?