### PR TITLE
`1931` Part 2: `1710` Cross network favorites

### DIFF
--- a/src/components/ui/icons/FavoriteIcon.tsx
+++ b/src/components/ui/icons/FavoriteIcon.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getAddress } from 'viem';
 import { useAccountFavorites } from '../../../hooks/DAO/loaders/useFavorites';
+import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 
 interface Props extends BoxProps {
   safeAddress: string;
@@ -11,9 +12,11 @@ interface Props extends BoxProps {
 
 export function FavoriteIcon({ safeAddress, ...rest }: Props) {
   const { favoritesList, toggleFavorite } = useAccountFavorites();
+  const { addressPrefix } = useNetworkConfig();
   const isFavorite = useMemo(
-    () => (!!safeAddress ? favoritesList.includes(getAddress(safeAddress)) : false),
-    [favoritesList, safeAddress],
+    () =>
+      !!safeAddress ? favoritesList.includes(addressPrefix + ':' + getAddress(safeAddress)) : false,
+    [favoritesList, safeAddress, addressPrefix],
   );
   const { t } = useTranslation();
   return (

--- a/src/components/ui/icons/FavoriteIcon.tsx
+++ b/src/components/ui/icons/FavoriteIcon.tsx
@@ -15,7 +15,7 @@ export function FavoriteIcon({ safeAddress, ...rest }: Props) {
   const { addressPrefix } = useNetworkConfig();
   const isFavorite = useMemo(
     () =>
-      !!safeAddress ? favoritesList.includes(addressPrefix + ':' + getAddress(safeAddress)) : false,
+      !!safeAddress ? favoritesList.includes(`${addressPrefix}:${getAddress(safeAddress)}`) : false,
     [favoritesList, safeAddress, addressPrefix],
   );
   const { t } = useTranslation();

--- a/src/components/ui/menus/DAOSearch/SearchDisplay.tsx
+++ b/src/components/ui/menus/DAOSearch/SearchDisplay.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SafeDisplayRow } from '../../../../pages/home/SafeDisplayRow';
 import { useFractal } from '../../../../providers/App/AppProvider';
+import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 
 interface ISearchDisplay {
   loading: boolean;
@@ -22,6 +23,7 @@ export function SearchDisplay({
 }: ISearchDisplay) {
   const { t } = useTranslation(['common', 'dashboard']);
   const { node } = useFractal();
+  const { addressPrefix } = useNetworkConfig();
 
   const isCurrentSafe = useMemo(
     () => !!node && !!node.daoAddress && node.daoAddress === address,
@@ -86,6 +88,7 @@ export function SearchDisplay({
 
         <SafeDisplayRow
           address={address}
+          network={addressPrefix}
           onClick={() => {
             onClickView();
             if (closeDrawer) closeDrawer();

--- a/src/components/ui/menus/DAOSearch/SearchDisplay.tsx
+++ b/src/components/ui/menus/DAOSearch/SearchDisplay.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { SafeDisplayRow } from '../../../../pages/home/SafeDisplayRow';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
+import { ErrorBoundary } from '../../utils/ErrorBoundary';
+import { MySafesErrorFallback } from '../../utils/MySafesErrorFallback';
 
 interface ISearchDisplay {
   loading: boolean;
@@ -77,24 +79,25 @@ export function SearchDisplay({
         flexDir="column"
         px="0.5rem"
       >
-        <Text
-          textStyle="button-small"
-          color="neutral-7"
-          py="1rem"
-          px="0.5rem"
-        >
-          {t(isCurrentSafe ? 'labelCurrentDAO' : 'labelDAOFound')}
-        </Text>
-
-        <SafeDisplayRow
-          address={address}
-          network={addressPrefix}
-          onClick={() => {
-            onClickView();
-            if (closeDrawer) closeDrawer();
-          }}
-          showAddress={true}
-        />
+        <ErrorBoundary fallback={MySafesErrorFallback}>
+          <Text
+            textStyle="button-small"
+            color="neutral-7"
+            py="1rem"
+            px="0.5rem"
+          >
+            {t(isCurrentSafe ? 'labelCurrentDAO' : 'labelDAOFound')}
+          </Text>
+          <SafeDisplayRow
+            address={address}
+            network={addressPrefix}
+            onClick={() => {
+              onClickView();
+              if (closeDrawer) closeDrawer();
+            }}
+            showAddress={true}
+          />
+        </ErrorBoundary>
       </Flex>
     );
   }

--- a/src/components/ui/menus/DAOSearch/SearchDisplay.tsx
+++ b/src/components/ui/menus/DAOSearch/SearchDisplay.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SafeDisplayRow } from '../../../../pages/home/SafeDisplayRow';
 import { useFractal } from '../../../../providers/App/AppProvider';
-import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 
 interface ISearchDisplay {
   loading: boolean;
@@ -23,7 +22,6 @@ export function SearchDisplay({
 }: ISearchDisplay) {
   const { t } = useTranslation(['common', 'dashboard']);
   const { node } = useFractal();
-  const { addressPrefix } = useNetworkConfig();
 
   const isCurrentSafe = useMemo(
     () => !!node && !!node.daoAddress && node.daoAddress === address,
@@ -88,7 +86,6 @@ export function SearchDisplay({
 
         <SafeDisplayRow
           address={address}
-          network={addressPrefix}
           onClick={() => {
             onClickView();
             if (closeDrawer) closeDrawer();

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -7,20 +7,20 @@ import { DAO_ROUTES } from '../../../../constants/routes';
 import { useGetDAOName } from '../../../../hooks/DAO/useGetDAOName';
 
 export interface SafeMenuItemProps {
-  network: string;
   address: string;
   showAddress?: boolean;
   onClick?: () => void;
 }
 
-export function SafeMenuItem({ network, address }: SafeMenuItemProps) {
-  const { daoName } = useGetDAOName({ address: getAddress(address) });
+export function SafeMenuItem({ address }: SafeMenuItemProps) {
+  const [networkPrefix, daoAddress] = address.split(':');
+  const { daoName } = useGetDAOName({ address: getAddress(daoAddress) });
   const navigate = useNavigate();
 
   const { t } = useTranslation('dashboard');
 
   const onClickNav = () => {
-    navigate(DAO_ROUTES.dao.relative(network, address));
+    navigate(DAO_ROUTES.dao.relative(networkPrefix, daoAddress));
   };
 
   return (

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -8,19 +8,19 @@ import { useGetDAOName } from '../../../../hooks/DAO/useGetDAOName';
 
 export interface SafeMenuItemProps {
   address: string;
+  network: string;
   showAddress?: boolean;
   onClick?: () => void;
 }
 
-export function SafeMenuItem({ address }: SafeMenuItemProps) {
-  const [networkPrefix, daoAddress] = address.split(':');
-  const { daoName } = useGetDAOName({ address: getAddress(daoAddress) });
+export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
+  const { daoName } = useGetDAOName({ address: getAddress(address) });
   const navigate = useNavigate();
 
   const { t } = useTranslation('dashboard');
 
   const onClickNav = () => {
-    navigate(DAO_ROUTES.dao.relative(networkPrefix, daoAddress));
+    navigate(DAO_ROUTES.dao.relative(network, address));
   };
 
   return (

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -1,10 +1,13 @@
-import { Box, Button, MenuItem, Text } from '@chakra-ui/react';
-import { Star } from '@phosphor-icons/react';
+import { Box, Button, Flex, Image, MenuItem, Spacer, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getAddress } from 'viem';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { useGetDAOName } from '../../../../hooks/DAO/useGetDAOName';
+import useAvatar from '../../../../hooks/utils/useAvatar';
+import useDisplayName from '../../../../hooks/utils/useDisplayName';
+import { getNetworkIcon } from '../../../../utils/url';
+import Avatar from '../../page/Header/Avatar';
 
 export interface SafeMenuItemProps {
   address: string;
@@ -16,6 +19,8 @@ export interface SafeMenuItemProps {
 export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
   const { daoName } = useGetDAOName({ address: getAddress(address) });
   const navigate = useNavigate();
+  const { displayName: accountDisplayName } = useDisplayName(address);
+  const avatarURL = useAvatar(accountDisplayName);
 
   const { t } = useTranslation('dashboard');
 
@@ -37,12 +42,23 @@ export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
         justifyContent="flex-start"
         gap={2}
       >
-        <Star
-          size="1.5rem"
-          weight="fill"
+        <Avatar
+          address={address}
+          url={avatarURL}
         />
+        <Flex flexDir="column">
+          <Text
+            color="white-0"
+            textStyle="button-base"
+          >
+            {daoName ?? t('loadingFavorite')}
+          </Text>
+        </Flex>
 
-        <Text color={daoName ? 'white-0' : 'neutral-6'}>{daoName ?? t('loadingFavorite')}</Text>
+        <Spacer />
+
+        {/* Network Icon */}
+        <Image src={getNetworkIcon(network)} />
       </MenuItem>
     </Box>
   );

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -2,11 +2,13 @@ import { Box, Button, Flex, Image, MenuItem, Spacer, Text } from '@chakra-ui/rea
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getAddress } from 'viem';
+import { useSwitchChain } from 'wagmi';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { useGetDAOName } from '../../../../hooks/DAO/useGetDAOName';
 import useAvatar from '../../../../hooks/utils/useAvatar';
 import useDisplayName from '../../../../hooks/utils/useDisplayName';
-import { getNetworkIcon } from '../../../../utils/url';
+import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
+import { getChainIdFromPrefix, getNetworkIcon } from '../../../../utils/url';
 import Avatar from '../../page/Header/Avatar';
 
 export interface SafeMenuItemProps {
@@ -17,6 +19,9 @@ export interface SafeMenuItemProps {
 }
 
 export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
+  const { addressPrefix } = useNetworkConfig();
+  const { switchChain } = useSwitchChain();
+
   const { daoName } = useGetDAOName({ address: getAddress(address) });
   const navigate = useNavigate();
   const { displayName: accountDisplayName } = useDisplayName(address);
@@ -25,7 +30,16 @@ export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
   const { t } = useTranslation('dashboard');
 
   const onClickNav = () => {
-    navigate(DAO_ROUTES.dao.relative(network, address));
+    if (addressPrefix !== network) {
+      switchChain(
+        { chainId: getChainIdFromPrefix(network) },
+        {
+          onSuccess: () => navigate(DAO_ROUTES.dao.relative(network, address)),
+        },
+      );
+    } else {
+      navigate(DAO_ROUTES.dao.relative(network, address));
+    }
   };
 
   return (

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -30,7 +30,7 @@ export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
 
   const { displayName: accountDisplayName } = useDisplayName(
     address,
-    undefined,
+    false,
     getChainIdFromPrefix(network),
   );
   const avatarURL = useAvatar(accountDisplayName);

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -22,9 +22,17 @@ export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
   const { addressPrefix } = useNetworkConfig();
   const { switchChain } = useSwitchChain();
 
-  const { daoName } = useGetDAOName({ address: getAddress(address) });
+  const { daoName } = useGetDAOName({
+    address: getAddress(address),
+    chainId: getChainIdFromPrefix(network),
+  });
   const navigate = useNavigate();
-  const { displayName: accountDisplayName } = useDisplayName(address);
+
+  const { displayName: accountDisplayName } = useDisplayName(
+    address,
+    undefined,
+    getChainIdFromPrefix(network),
+  );
   const avatarURL = useAvatar(accountDisplayName);
 
   const { t } = useTranslation('dashboard');

--- a/src/components/ui/menus/SafesMenu/SafesList.tsx
+++ b/src/components/ui/menus/SafesMenu/SafesList.tsx
@@ -2,12 +2,10 @@ import { Box, MenuList } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { useAccountFavorites } from '../../../../hooks/DAO/loaders/useFavorites';
-import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { SafeMenuItem } from './SafeMenuItem';
 
 export function SafesList() {
   const { favoritesList } = useAccountFavorites();
-  const { addressPrefix } = useNetworkConfig();
 
   const { t } = useTranslation('dashboard');
   return (
@@ -31,7 +29,6 @@ export function SafesList() {
             {favoritesList.map(favorite => (
               <SafeMenuItem
                 key={favorite}
-                network={addressPrefix}
                 address={favorite}
               />
             ))}

--- a/src/components/ui/menus/SafesMenu/SafesList.tsx
+++ b/src/components/ui/menus/SafesMenu/SafesList.tsx
@@ -23,7 +23,6 @@ export function SafesList() {
         ) : (
           <Box
             maxHeight="20rem"
-            overflowY="scroll"
             className="scroll-dark"
           >
             {favoritesList.map(favorite => (

--- a/src/components/ui/menus/SafesMenu/SafesList.tsx
+++ b/src/components/ui/menus/SafesMenu/SafesList.tsx
@@ -2,6 +2,7 @@ import { Box, MenuList } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { useAccountFavorites } from '../../../../hooks/DAO/loaders/useFavorites';
+import { decodePrefixedAddress } from '../../../../utils/address';
 import { SafeMenuItem } from './SafeMenuItem';
 
 export function SafesList() {
@@ -28,8 +29,7 @@ export function SafesList() {
             {favoritesList.map(favorite => (
               <SafeMenuItem
                 key={favorite}
-                network={favorite.split(':')[0]}
-                address={favorite.split(':')[1]}
+                {...decodePrefixedAddress(favorite)}
               />
             ))}
           </Box>

--- a/src/components/ui/menus/SafesMenu/SafesList.tsx
+++ b/src/components/ui/menus/SafesMenu/SafesList.tsx
@@ -29,7 +29,8 @@ export function SafesList() {
             {favoritesList.map(favorite => (
               <SafeMenuItem
                 key={favorite}
-                address={favorite}
+                network={favorite.split(':')[0]}
+                address={favorite.split(':')[1]}
               />
             ))}
           </Box>

--- a/src/components/ui/menus/SafesMenu/SafesList.tsx
+++ b/src/components/ui/menus/SafesMenu/SafesList.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
 import { useAccountFavorites } from '../../../../hooks/DAO/loaders/useFavorites';
 import { decodePrefixedAddress } from '../../../../utils/address';
+import { ErrorBoundary } from '../../utils/ErrorBoundary';
+import { MySafesErrorFallback } from '../../utils/MySafesErrorFallback';
 import { SafeMenuItem } from './SafeMenuItem';
 
 export function SafesList() {
@@ -18,23 +20,25 @@ export function SafesList() {
       border="1px solid"
       borderColor="neutral-3"
     >
-      <Box>
-        {favoritesList.length === 0 ? (
-          <Box p="1rem 1rem">{t('emptyFavorites')}</Box>
-        ) : (
-          <Box
-            maxHeight="20rem"
-            className="scroll-dark"
-          >
-            {favoritesList.map(favorite => (
-              <SafeMenuItem
-                key={favorite}
-                {...decodePrefixedAddress(favorite)}
-              />
-            ))}
-          </Box>
-        )}
-      </Box>
+      <ErrorBoundary fallback={MySafesErrorFallback}>
+        <Box>
+          {favoritesList.length === 0 ? (
+            <Box p="1rem 1rem">{t('emptyFavorites')}</Box>
+          ) : (
+            <Box
+              maxHeight="20rem"
+              className="scroll-dark"
+            >
+              {favoritesList.map(favorite => (
+                <SafeMenuItem
+                  key={favorite}
+                  {...decodePrefixedAddress(favorite)}
+                />
+              ))}
+            </Box>
+          )}
+        </Box>
+      </ErrorBoundary>
     </MenuList>
   );
 }

--- a/src/components/ui/utils/MySafesErrorFallback.tsx
+++ b/src/components/ui/utils/MySafesErrorFallback.tsx
@@ -1,0 +1,20 @@
+import { Box, Text } from '@chakra-ui/react';
+import { t } from 'i18next';
+
+export function MySafesErrorFallback() {
+  return (
+    <Box
+      p="1rem"
+      maxW="100%"
+      bg="neutral-2"
+      borderRadius="0.5rem"
+    >
+      <Text
+        color="white-alpha-16"
+        align="center"
+      >
+        {t('errorMySafesNotLoaded', { ns: 'common' })}
+      </Text>
+    </Box>
+  );
+}

--- a/src/hooks/DAO/loaders/useFavorites.ts
+++ b/src/hooks/DAO/loaders/useFavorites.ts
@@ -13,8 +13,8 @@ export const useAccountFavorites = () => {
 
   const toggleFavorite = (address: string) => {
     const normalizedAddress = getAddress(address);
-    const addressWithPrefix = addressPrefix + ":" + normalizedAddress;
-    
+    const addressWithPrefix = addressPrefix + ':' + normalizedAddress;
+
     const favorites: string[] = getValue({ cacheName: CacheKeys.FAVORITES }) || [];
     let updatedFavorites: string[] = [];
     if (favorites.includes(addressWithPrefix)) {

--- a/src/hooks/DAO/loaders/useFavorites.ts
+++ b/src/hooks/DAO/loaders/useFavorites.ts
@@ -5,6 +5,7 @@ import { CacheKeys, CacheExpiry } from '../../utils/cache/cacheDefaults';
 import { getValue, setValue } from '../../utils/cache/useLocalStorage';
 
 export const useAccountFavorites = () => {
+  // @dev favorites are strings of the form networkPrefix:address
   const [favoritesList, setFavoritesList] = useState<string[]>(
     getValue({ cacheName: CacheKeys.FAVORITES }) || [],
   );
@@ -12,13 +13,14 @@ export const useAccountFavorites = () => {
 
   const toggleFavorite = (address: string) => {
     const normalizedAddress = getAddress(address);
+    const addressWithPrefix = addressPrefix + ":" + normalizedAddress;
+    
     const favorites: string[] = getValue({ cacheName: CacheKeys.FAVORITES }) || [];
     let updatedFavorites: string[] = [];
-
-    if (favorites.includes(normalizedAddress)) {
-      updatedFavorites = favorites.filter(favorite => favorite !== normalizedAddress);
+    if (favorites.includes(addressWithPrefix)) {
+      updatedFavorites = favorites.filter(favorite => favorite !== addressWithPrefix);
     } else {
-      updatedFavorites = favorites.concat([addressPrefix + normalizedAddress]);
+      updatedFavorites = favorites.concat([addressWithPrefix]);
     }
 
     setValue({ cacheName: CacheKeys.FAVORITES }, updatedFavorites, CacheExpiry.NEVER);

--- a/src/hooks/DAO/loaders/useFavorites.ts
+++ b/src/hooks/DAO/loaders/useFavorites.ts
@@ -6,13 +6,13 @@ import { getValue, setValue } from '../../utils/cache/useLocalStorage';
 
 export const useAccountFavorites = () => {
   const [favoritesList, setFavoritesList] = useState<string[]>(
-    getValue({ cacheName: CacheKeys.FAVORITES }),
+    getValue({ cacheName: CacheKeys.FAVORITES }) || [],
   );
   const { addressPrefix } = useNetworkConfig();
 
   const toggleFavorite = (address: string) => {
     const normalizedAddress = getAddress(address);
-    const favorites: string[] = getValue({ cacheName: CacheKeys.FAVORITES });
+    const favorites: string[] = getValue({ cacheName: CacheKeys.FAVORITES }) || [];
     let updatedFavorites: string[] = [];
 
     if (favorites.includes(normalizedAddress)) {

--- a/src/hooks/DAO/loaders/useFavorites.ts
+++ b/src/hooks/DAO/loaders/useFavorites.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { getAddress } from 'viem';
+import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { CacheKeys, CacheExpiry } from '../../utils/cache/cacheDefaults';
 import { getValue, setValue } from '../../utils/cache/useLocalStorage';
 
@@ -7,6 +8,7 @@ export const useAccountFavorites = () => {
   const [favoritesList, setFavoritesList] = useState<string[]>(
     getValue({ cacheName: CacheKeys.FAVORITES }),
   );
+  const { addressPrefix } = useNetworkConfig();
 
   const toggleFavorite = (address: string) => {
     const normalizedAddress = getAddress(address);
@@ -16,7 +18,7 @@ export const useAccountFavorites = () => {
     if (favorites.includes(normalizedAddress)) {
       updatedFavorites = favorites.filter(favorite => favorite !== normalizedAddress);
     } else {
-      updatedFavorites = favorites.concat([normalizedAddress]);
+      updatedFavorites = favorites.concat([addressPrefix + normalizedAddress]);
     }
 
     setValue({ cacheName: CacheKeys.FAVORITES }, updatedFavorites, CacheExpiry.NEVER);

--- a/src/hooks/DAO/loaders/useFavorites.ts
+++ b/src/hooks/DAO/loaders/useFavorites.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { getAddress } from 'viem';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
+import { encodePrefixedAddress } from '../../../utils/address';
 import { CacheKeys, CacheExpiry } from '../../utils/cache/cacheDefaults';
 import { getValue, setValue } from '../../utils/cache/useLocalStorage';
 
@@ -12,9 +13,7 @@ export const useAccountFavorites = () => {
   const { addressPrefix } = useNetworkConfig();
 
   const toggleFavorite = (address: string) => {
-    const normalizedAddress = getAddress(address);
-    const addressWithPrefix = addressPrefix + ':' + normalizedAddress;
-
+    const addressWithPrefix = encodePrefixedAddress(getAddress(address), addressPrefix);
     const favorites = getValue({ cacheName: CacheKeys.FAVORITES }) || [];
     let updatedFavorites: string[] = [];
     if (favorites.includes(addressWithPrefix)) {

--- a/src/hooks/DAO/useGetDAOName.ts
+++ b/src/hooks/DAO/useGetDAOName.ts
@@ -64,11 +64,15 @@ const getDAOName = async ({
 const useGetDAOName = ({
   address,
   registryName,
+  chainId,
 }: {
   address: Address;
   registryName?: string | null;
+  chainId?: number;
 }) => {
-  const publicClient = usePublicClient();
+  const publicClient = usePublicClient({
+    chainId,
+  });
   const { baseContracts } = useFractal();
 
   const [daoName, setDaoName] = useState<string>();

--- a/src/hooks/utils/useDisplayName.ts
+++ b/src/hooks/utils/useDisplayName.ts
@@ -14,13 +14,14 @@ export const createAccountSubstring = (account: string) => {
  *
  * This is intended to be used for NON DAO display names.  If you would like to get the
  * display name for a DAO, use the useDAOName hook instead.
+ * @todo Should switch to object for props
  */
-const useDisplayName = (account?: string | null, truncate?: boolean) => {
+const useDisplayName = (account?: string | null, truncate?: boolean, chainId?: number) => {
   if (truncate === undefined) truncate = true;
   const { chain } = useNetworkConfig();
   const { data: ensName } = useEnsName({
     address: !!account ? getAddress(account) : undefined,
-    chainId: chain.id,
+    chainId: chainId || chain.id,
   });
 
   const [accountSubstring, setAccountSubstring] = useState<string>();

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -49,6 +49,7 @@
   "errorNotProposer": "You do not have the necessary permissions to create a proposal for this Safe.",
   "errorSentryFallbackTitle": "Oops! Something went wrong",
   "errorSentryFallbackMessage": "We apologize for the inconvenience. Please try again later.",
+  "errorMySafesNotLoaded": "Safe(s) could not be loaded. Please try again later.",
   "errorGeneral": "An unexpected error occurred. Please try again later.",
   "errorCopyToClipboard": "Unable to copy text to clipboard!",
   "labelNowishAgo": "just now",

--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -12,7 +12,6 @@ import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../constants/common';
 import { CacheKeys } from '../../hooks/utils/cache/cacheDefaults';
 import { getValue } from '../../hooks/utils/cache/useLocalStorage';
-import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { SafeDisplayRow } from './SafeDisplayRow';
 
 interface AllSafesDrawerProps {
@@ -22,8 +21,6 @@ interface AllSafesDrawerProps {
 }
 
 export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
-  const { addressPrefix } = useNetworkConfig();
-
   const { t } = useTranslation('home');
   const [drawerHeight, setDrawerHeight] = useState('50%');
   const [isDragging, setIsDragging] = useState(false);
@@ -138,7 +135,6 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           {getValue({ cacheName: CacheKeys.FAVORITES }).map((favorite: string) => (
             <SafeDisplayRow
               key={favorite}
-              network={addressPrefix}
               address={favorite}
             />
           ))}

--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -132,8 +132,8 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           </Box>
         </DrawerHeader>
         <DrawerBody padding="0">
-          {getValue({ cacheName: CacheKeys.FAVORITES }) ||
-            [].map((favorite: string) => (
+          {(getValue({ cacheName: CacheKeys.FAVORITES }) ||
+            []).map((favorite: string) => (
               <SafeDisplayRow
                 key={favorite}
                 address={favorite.split(':')[1]}

--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../constants/common';
 import { CacheKeys } from '../../hooks/utils/cache/cacheDefaults';
 import { getValue } from '../../hooks/utils/cache/useLocalStorage';
+import { decodePrefixedAddress } from '../../utils/address';
 import { SafeDisplayRow } from './SafeDisplayRow';
 
 interface AllSafesDrawerProps {
@@ -135,8 +136,7 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           {(getValue({ cacheName: CacheKeys.FAVORITES }) || []).map((favorite: string) => (
             <SafeDisplayRow
               key={favorite}
-              address={favorite.split(':')[1]}
-              network={favorite.split(':')[0]}
+              {...decodePrefixedAddress(favorite)}
             />
           ))}
         </DrawerBody>

--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -9,6 +9,8 @@ import {
 } from '@chakra-ui/react';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ErrorBoundary } from '../../components/ui/utils/ErrorBoundary';
+import { MySafesErrorFallback } from '../../components/ui/utils/MySafesErrorFallback';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../constants/common';
 import { CacheKeys } from '../../hooks/utils/cache/cacheDefaults';
 import { getValue } from '../../hooks/utils/cache/useLocalStorage';
@@ -133,12 +135,14 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           </Box>
         </DrawerHeader>
         <DrawerBody padding="0">
-          {(getValue({ cacheName: CacheKeys.FAVORITES }) || []).map((favorite: string) => (
-            <SafeDisplayRow
-              key={favorite}
-              {...decodePrefixedAddress(favorite)}
-            />
-          ))}
+          <ErrorBoundary fallback={MySafesErrorFallback}>
+            {(getValue({ cacheName: CacheKeys.FAVORITES }) || []).map((favorite: string) => (
+              <SafeDisplayRow
+                key={favorite}
+                {...decodePrefixedAddress(favorite)}
+              />
+            ))}
+          </ErrorBoundary>
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -132,7 +132,7 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           </Box>
         </DrawerHeader>
         <DrawerBody padding="0">
-          {getValue({ cacheName: CacheKeys.FAVORITES }).map((favorite: string) => (
+          {getValue({ cacheName: CacheKeys.FAVORITES }) || [].map((favorite: string) => (
             <SafeDisplayRow
               key={favorite}
               address={favorite}

--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -132,13 +132,14 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           </Box>
         </DrawerHeader>
         <DrawerBody padding="0">
-          {getValue({ cacheName: CacheKeys.FAVORITES }) || [].map((favorite: string) => (
-            <SafeDisplayRow
-              key={favorite}
-              address={favorite.split(':')[1]}
-              network={favorite.split(':')[0]}
-            />
-          ))}
+          {getValue({ cacheName: CacheKeys.FAVORITES }) ||
+            [].map((favorite: string) => (
+              <SafeDisplayRow
+                key={favorite}
+                address={favorite.split(':')[1]}
+                network={favorite.split(':')[0]}
+              />
+            ))}
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -132,14 +132,13 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           </Box>
         </DrawerHeader>
         <DrawerBody padding="0">
-          {(getValue({ cacheName: CacheKeys.FAVORITES }) ||
-            []).map((favorite: string) => (
-              <SafeDisplayRow
-                key={favorite}
-                address={favorite.split(':')[1]}
-                network={favorite.split(':')[0]}
-              />
-            ))}
+          {(getValue({ cacheName: CacheKeys.FAVORITES }) || []).map((favorite: string) => (
+            <SafeDisplayRow
+              key={favorite}
+              address={favorite.split(':')[1]}
+              network={favorite.split(':')[0]}
+            />
+          ))}
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/pages/home/AllSafesDrawer.tsx
+++ b/src/pages/home/AllSafesDrawer.tsx
@@ -135,7 +135,8 @@ export function AllSafesDrawer({ isOpen, onClose }: AllSafesDrawerProps) {
           {getValue({ cacheName: CacheKeys.FAVORITES }) || [].map((favorite: string) => (
             <SafeDisplayRow
               key={favorite}
-              address={favorite}
+              address={favorite.split(':')[1]}
+              network={favorite.split(':')[0]}
             />
           ))}
         </DrawerBody>

--- a/src/pages/home/MySafes.tsx
+++ b/src/pages/home/MySafes.tsx
@@ -2,14 +2,12 @@ import { Box, Button, Flex, Show, Text, useBreakpointValue, useDisclosure } from
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAccountFavorites } from '../../hooks/DAO/loaders/useFavorites';
-import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { AllSafesDrawer } from './AllSafesDrawer';
 import { SafeDisplayRow } from './SafeDisplayRow';
 
 export function MySafes() {
   const { t } = useTranslation('home');
   const { favoritesList } = useAccountFavorites();
-  const { addressPrefix } = useNetworkConfig();
   const [showAll, setShowAll] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -52,7 +50,6 @@ export function MySafes() {
             {favoritesToShow.map(favorite => (
               <SafeDisplayRow
                 key={favorite}
-                network={addressPrefix}
                 address={favorite}
               />
             ))}

--- a/src/pages/home/MySafes.tsx
+++ b/src/pages/home/MySafes.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Flex, Show, Text, useBreakpointValue, useDisclosure } from
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAccountFavorites } from '../../hooks/DAO/loaders/useFavorites';
+import { decodePrefixedAddress } from '../../utils/address';
 import { AllSafesDrawer } from './AllSafesDrawer';
 import { SafeDisplayRow } from './SafeDisplayRow';
 
@@ -50,8 +51,7 @@ export function MySafes() {
             {favoritesToShow.map(favorite => (
               <SafeDisplayRow
                 key={favorite}
-                address={favorite.split(':')[1]}
-                network={favorite.split(':')[0]}
+                {...decodePrefixedAddress(favorite)}
               />
             ))}
           </Box>

--- a/src/pages/home/MySafes.tsx
+++ b/src/pages/home/MySafes.tsx
@@ -1,6 +1,8 @@
 import { Box, Button, Flex, Show, Text, useBreakpointValue, useDisclosure } from '@chakra-ui/react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ErrorBoundary } from '../../components/ui/utils/ErrorBoundary';
+import { MySafesErrorFallback } from '../../components/ui/utils/MySafesErrorFallback';
 import { useAccountFavorites } from '../../hooks/DAO/loaders/useFavorites';
 import { decodePrefixedAddress } from '../../utils/address';
 import { AllSafesDrawer } from './AllSafesDrawer';
@@ -21,41 +23,43 @@ export function MySafes() {
   return (
     <Box>
       <Box w="full">
-        {/* SAFES CONTENT */}
-        {favoritesList.length === 0 ? (
-          <Flex
-            direction={{ base: 'column', md: 'row' }}
-            columnGap="0.5rem"
-            justifyContent="center"
-            p="1rem"
-            maxW="100%"
-            my="0.5rem"
-            bg="neutral-2"
-            borderRadius="0.5rem"
-          >
-            <Text
-              color="white-alpha-16"
-              align="center"
+        <ErrorBoundary fallback={MySafesErrorFallback}>
+          {/* SAFES CONTENT */}
+          {favoritesList.length === 0 ? (
+            <Flex
+              direction={{ base: 'column', md: 'row' }}
+              columnGap="0.5rem"
+              justifyContent="center"
+              p="1rem"
+              maxW="100%"
+              my="0.5rem"
+              bg="neutral-2"
+              borderRadius="0.5rem"
             >
-              {t('emptyFavorites', { ns: 'dashboard' })}
-            </Text>
-            <Text
-              color="white-alpha-16"
-              align="center"
-            >
-              {t('emptyFavoritesSubtext', { ns: 'dashboard' })}
-            </Text>
-          </Flex>
-        ) : (
-          <Box>
-            {favoritesToShow.map(favorite => (
-              <SafeDisplayRow
-                key={favorite}
-                {...decodePrefixedAddress(favorite)}
-              />
-            ))}
-          </Box>
-        )}
+              <Text
+                color="white-alpha-16"
+                align="center"
+              >
+                {t('emptyFavorites', { ns: 'dashboard' })}
+              </Text>
+              <Text
+                color="white-alpha-16"
+                align="center"
+              >
+                {t('emptyFavoritesSubtext', { ns: 'dashboard' })}
+              </Text>
+            </Flex>
+          ) : (
+            <Box>
+              {favoritesToShow.map(favorite => (
+                <SafeDisplayRow
+                  key={favorite}
+                  {...decodePrefixedAddress(favorite)}
+                />
+              ))}
+            </Box>
+          )}
+        </ErrorBoundary>
       </Box>
 
       {/* VIEW ALL BUTTON */}

--- a/src/pages/home/MySafes.tsx
+++ b/src/pages/home/MySafes.tsx
@@ -50,7 +50,8 @@ export function MySafes() {
             {favoritesToShow.map(favorite => (
               <SafeDisplayRow
                 key={favorite}
-                address={favorite}
+                address={favorite.split(':')[1]}
+                network={favorite.split(':')[0]}
               />
             ))}
           </Box>

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -8,8 +8,7 @@ import { DAO_ROUTES } from '../../constants/routes';
 import { useGetDAOName } from '../../hooks/DAO/useGetDAOName';
 import useAvatar from '../../hooks/utils/useAvatar';
 import useDisplayName, { createAccountSubstring } from '../../hooks/utils/useDisplayName';
-import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
-import { getNetworkIcon } from '../../utils/url';
+import { getChainName, getNetworkIcon } from '../../utils/url';
 
 export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeMenuItemProps) {
   const { daoName } = useGetDAOName({ address: getAddress(address) });
@@ -27,7 +26,6 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
 
   const nameColor = showAddress ? 'neutral-7' : 'white-0';
 
-  const networkConfig = useNetworkConfig();
 
   return (
     <Flex
@@ -70,7 +68,7 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
       <Flex gap="0.5rem">
         <Image src={getNetworkIcon(network)} />
         <Show above="md">
-          <Text>{networkConfig.chain.name}</Text>
+          <Text>{getChainName(network)}</Text>
         </Show>
       </Flex>
     </Flex>

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -9,8 +9,10 @@ import { useGetDAOName } from '../../hooks/DAO/useGetDAOName';
 import useAvatar from '../../hooks/utils/useAvatar';
 import useDisplayName, { createAccountSubstring } from '../../hooks/utils/useDisplayName';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
+import { getNetworkIcon } from '../../utils/url';
 
-export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeMenuItemProps) {
+export function SafeDisplayRow({ address, onClick, showAddress }: SafeMenuItemProps) {
+  const [networkPrefix, daoAddress] = address.split(':');
   const { daoName } = useGetDAOName({ address: getAddress(address) });
   const navigate = useNavigate();
 
@@ -21,7 +23,7 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
 
   const onClickNav = () => {
     if (onClick) onClick();
-    navigate(DAO_ROUTES.dao.relative(network, address));
+    navigate(DAO_ROUTES.dao.relative(networkPrefix, daoAddress));
   };
 
   const nameColor = showAddress ? 'neutral-7' : 'white-0';
@@ -50,7 +52,7 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
     >
       <Avatar
         size="lg"
-        address={address}
+        address={daoAddress}
         url={avatarURL}
       />
       <Flex flexDir="column">
@@ -60,14 +62,14 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
         >
           {daoName ?? t('loadingFavorite')}
         </Text>
-        {showAddress && <Text textStyle="button-base">{createAccountSubstring(address)}</Text>}
+        {showAddress && <Text textStyle="button-base">{createAccountSubstring(daoAddress)}</Text>}
       </Flex>
 
       <Spacer />
 
       {/* Network Icon */}
       <Flex gap="0.5rem">
-        <Image src={networkConfig.nativeTokenIcon} />
+        <Image src={getNetworkIcon(networkPrefix)} />
         <Show above="md">
           <Text>{networkConfig.chain.name}</Text>
         </Show>

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -2,15 +2,20 @@ import { Flex, Image, Show, Spacer, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getAddress } from 'viem';
+import { useSwitchChain } from 'wagmi';
 import { SafeMenuItemProps } from '../../components/ui/menus/SafesMenu/SafeMenuItem';
 import Avatar from '../../components/ui/page/Header/Avatar';
 import { DAO_ROUTES } from '../../constants/routes';
 import { useGetDAOName } from '../../hooks/DAO/useGetDAOName';
 import useAvatar from '../../hooks/utils/useAvatar';
 import useDisplayName, { createAccountSubstring } from '../../hooks/utils/useDisplayName';
-import { getChainName, getNetworkIcon } from '../../utils/url';
+import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
+import { getChainIdFromPrefix, getChainName, getNetworkIcon } from '../../utils/url';
 
 export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeMenuItemProps) {
+  const { addressPrefix } = useNetworkConfig();
+  const { switchChain } = useSwitchChain();
+
   const { daoName } = useGetDAOName({ address: getAddress(address) });
   const navigate = useNavigate();
 
@@ -21,11 +26,19 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
 
   const onClickNav = () => {
     if (onClick) onClick();
-    navigate(DAO_ROUTES.dao.relative(network, address));
+    if (addressPrefix !== network) {
+      switchChain(
+        { chainId: getChainIdFromPrefix(network) },
+        {
+          onSuccess: () => navigate(DAO_ROUTES.dao.relative(network, address)),
+        },
+      );
+    } else {
+      navigate(DAO_ROUTES.dao.relative(network, address));
+    }
   };
 
   const nameColor = showAddress ? 'neutral-7' : 'white-0';
-
 
   return (
     <Flex

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -27,7 +27,7 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
 
   const { displayName: accountDisplayName } = useDisplayName(
     address,
-    undefined,
+    false,
     getChainIdFromPrefix(network),
   );
   const avatarURL = useAvatar(accountDisplayName);

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -11,8 +11,7 @@ import useDisplayName, { createAccountSubstring } from '../../hooks/utils/useDis
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { getNetworkIcon } from '../../utils/url';
 
-export function SafeDisplayRow({ address, onClick, showAddress }: SafeMenuItemProps) {
-  const [networkPrefix, daoAddress] = address.split(':');
+export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeMenuItemProps) {
   const { daoName } = useGetDAOName({ address: getAddress(address) });
   const navigate = useNavigate();
 
@@ -23,7 +22,7 @@ export function SafeDisplayRow({ address, onClick, showAddress }: SafeMenuItemPr
 
   const onClickNav = () => {
     if (onClick) onClick();
-    navigate(DAO_ROUTES.dao.relative(networkPrefix, daoAddress));
+    navigate(DAO_ROUTES.dao.relative(network, address));
   };
 
   const nameColor = showAddress ? 'neutral-7' : 'white-0';
@@ -52,7 +51,7 @@ export function SafeDisplayRow({ address, onClick, showAddress }: SafeMenuItemPr
     >
       <Avatar
         size="lg"
-        address={daoAddress}
+        address={address}
         url={avatarURL}
       />
       <Flex flexDir="column">
@@ -62,14 +61,14 @@ export function SafeDisplayRow({ address, onClick, showAddress }: SafeMenuItemPr
         >
           {daoName ?? t('loadingFavorite')}
         </Text>
-        {showAddress && <Text textStyle="button-base">{createAccountSubstring(daoAddress)}</Text>}
+        {showAddress && <Text textStyle="button-base">{createAccountSubstring(address)}</Text>}
       </Flex>
 
       <Spacer />
 
       {/* Network Icon */}
       <Flex gap="0.5rem">
-        <Image src={getNetworkIcon(networkPrefix)} />
+        <Image src={getNetworkIcon(network)} />
         <Show above="md">
           <Text>{networkConfig.chain.name}</Text>
         </Show>

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -16,12 +16,20 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
   const { addressPrefix } = useNetworkConfig();
   const { switchChain } = useSwitchChain();
 
-  const { daoName } = useGetDAOName({ address: getAddress(address) });
+  const { daoName } = useGetDAOName({
+    address: getAddress(address),
+    chainId: getChainIdFromPrefix(network),
+  });
+
   const navigate = useNavigate();
 
   const { t } = useTranslation('dashboard');
 
-  const { displayName: accountDisplayName } = useDisplayName(address);
+  const { displayName: accountDisplayName } = useDisplayName(
+    address,
+    undefined,
+    getChainIdFromPrefix(network),
+  );
   const avatarURL = useAvatar(accountDisplayName);
 
   const onClickNav = () => {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,0 +1,13 @@
+import { Address } from 'viem';
+
+export const decodePrefixedAddress = (address: string) => {
+  const [prefix, addressWithoutPrefix] = address.split(':');
+  return {
+    network: prefix,
+    address: addressWithoutPrefix,
+  };
+};
+
+export const encodePrefixedAddress = (address: Address, network: string) => {
+  return `${network}:${address}`;
+};

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -2,6 +2,9 @@ import { Address } from 'viem';
 
 export const decodePrefixedAddress = (address: string) => {
   const [prefix, addressWithoutPrefix] = address.split(':');
+  if (!prefix || !addressWithoutPrefix) {
+    throw new Error('Invalid address format');
+  }
   return {
     network: prefix,
     address: addressWithoutPrefix,

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -28,3 +28,36 @@ export const validateENSName = (ensAddress?: string): boolean => {
     return false;
   }
 };
+
+export const networkPrefix: { [key: number]: string } = {
+  1: 'eth',
+  1115511: 'sep',
+  10: 'oeth',
+  8453: 'base',
+  137: 'matic',
+  84532: 'basesep',
+};
+
+export const addNetworkPrefix = (address: string, chainId: number): string => {
+  return `${networkPrefix[chainId]}:${address}`;
+};
+
+export const networkIcons: { [key: number]: string } = {
+  1: '/images/coin-icon-eth.svg',
+  1115511: '/images/coin-icon-sep.svg',
+  10: '/images/coin-icon-op.svg',
+  8453: '/images/coin-icon-base.svg',
+  137: '/images/coin-icon-pol.svg',
+  84532: '/images/coin-icon-base-sep.svg',
+};
+
+export const getChainIdFromNetworkPrefix = (_networkPrefix: string): number => {
+  return Number(
+    Object.keys(networkPrefix).find(key => networkPrefix[parseInt(key)] === _networkPrefix),
+  );
+};
+
+export const getNetworkIcon = (_networkPrefix: string): string => {
+  const chainId = getChainIdFromNetworkPrefix(_networkPrefix);
+  return networkIcons[chainId];
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -56,3 +56,13 @@ export const getChainName = (_networkPrefix: string): string => {
   }
   return network.chain.name;
 };
+
+export const getChainIdFromPrefix = (_networkPrefix: string): number => {
+  const network = Object.values(networks).find(
+    _network => _network.addressPrefix === _networkPrefix,
+  );
+  if (!network) {
+    throw new Error(`No network found for chainId ${_networkPrefix}`);
+  }
+  return network.chain.id;
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -34,7 +34,7 @@ export const addNetworkPrefix = (address: string, chainId: number): string => {
   if (!network) {
     throw new Error(`No network found for chainId ${chainId}`);
   }
-  return `${network?.addressPrefix}:${address}`;
+  return `${network.addressPrefix}:${address}`;
 };
 
 export const getNetworkIcon = (_networkPrefix: string): string => {
@@ -42,9 +42,9 @@ export const getNetworkIcon = (_networkPrefix: string): string => {
     _network => _network.addressPrefix === _networkPrefix,
   );
   if (!network) {
-    throw new Error(`No network found for networkPrefix ${_networkPrefix}`);
+    throw new Error(`No chain found for network prefix ${_networkPrefix}`);
   }
-  return network?.nativeTokenIcon;
+  return network.nativeTokenIcon;
 };
 
 export const getChainName = (_networkPrefix: string): string => {
@@ -52,7 +52,7 @@ export const getChainName = (_networkPrefix: string): string => {
     _network => _network.addressPrefix === _networkPrefix,
   );
   if (!network) {
-    throw new Error(`No network found for chainId ${_networkPrefix}`);
+    throw new Error(`No chain found for network prefix ${_networkPrefix}`);
   }
   return network.chain.name;
 };
@@ -62,7 +62,7 @@ export const getChainIdFromPrefix = (_networkPrefix: string): number => {
     _network => _network.addressPrefix === _networkPrefix,
   );
   if (!network) {
-    throw new Error(`No network found for chainId ${_networkPrefix}`);
+    throw new Error(`No chain found for network prefix ${_networkPrefix}`);
   }
   return network.chain.id;
 };

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,5 @@
 import { normalize } from 'viem/ens';
-
+import * as networks from '../providers/NetworkConfig/networks';
 export const isValidUrl = (urlString: string) => {
   try {
     const url = new URL(urlString);
@@ -29,35 +29,20 @@ export const validateENSName = (ensAddress?: string): boolean => {
   }
 };
 
-export const networkPrefix: { [key: number]: string } = {
-  1: 'eth',
-  1115511: 'sep',
-  10: 'oeth',
-  8453: 'base',
-  137: 'matic',
-  84532: 'basesep',
-};
-
 export const addNetworkPrefix = (address: string, chainId: number): string => {
-  return `${networkPrefix[chainId]}:${address}`;
-};
-
-export const networkIcons: { [key: number]: string } = {
-  1: '/images/coin-icon-eth.svg',
-  1115511: '/images/coin-icon-sep.svg',
-  10: '/images/coin-icon-op.svg',
-  8453: '/images/coin-icon-base.svg',
-  137: '/images/coin-icon-pol.svg',
-  84532: '/images/coin-icon-base-sep.svg',
-};
-
-export const getChainIdFromNetworkPrefix = (_networkPrefix: string): number => {
-  return Number(
-    Object.keys(networkPrefix).find(key => networkPrefix[parseInt(key)] === _networkPrefix),
-  );
+  const network = Object.values(networks).find(_network => _network.chain.id === chainId);
+  if (!network) {
+    throw new Error(`No network found for chainId ${chainId}`);
+  }
+  return `${network?.addressPrefix}:${address}`;
 };
 
 export const getNetworkIcon = (_networkPrefix: string): string => {
-  const chainId = getChainIdFromNetworkPrefix(_networkPrefix);
-  return networkIcons[chainId];
+  const network = Object.values(networks).find(
+    _network => _network.addressPrefix === _networkPrefix,
+  );
+  if (!network) {
+    throw new Error(`No network found for networkPrefix ${_networkPrefix}`);
+  }
+  return network?.nativeTokenIcon;
 };

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -46,3 +46,13 @@ export const getNetworkIcon = (_networkPrefix: string): string => {
   }
   return network?.nativeTokenIcon;
 };
+
+export const getChainName = (_networkPrefix: string): string => {
+  const network = Object.values(networks).find(
+    _network => _network.addressPrefix === _networkPrefix,
+  );
+  if (!network) {
+    throw new Error(`No network found for chainId ${_networkPrefix}`);
+  }
+  return network.chain.name;
+};


### PR DESCRIPTION
Fixes #1710

Kinda a weird one to fit in the middle but wanted this work to be done prior to the Local Storage migration actually is done so that the typing is setup.

This PR handles adding the network prefix to the cached favorite string. It also adds some helper functions to get the network prefix and chain id via the network prefix to allow for the UI around the favorites. 