### PR TITLE
Use the text link pattern in lieu of the pill button

### DIFF
--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -77,8 +77,15 @@ export default function ProposalSummary({ proposal }: { proposal: AzoriusProposa
 
   const isERC20 = type === GovernanceType.AZORIUS_ERC20;
   const isERC721 = type === GovernanceType.AZORIUS_ERC721;
+
+  // @todo @dev (see below):
+  // Caching has introduced a new "problem" edge case -- a proposal can be loaded before `votingStrategy` is loaded.
+  // I previously fixed this issue in `QuoromBadge` (see lines 36 and 45), but over here it's slightly more nuanced and
+  // will require a bit more thought. A quick patch instead is to add the `votingStrategy?` check in the `if` statement below,
+  // BUT this (and the implications of the previous fix) contradicts the non-null (but suddenly no longer true) typing of `votingStrategy`.
+  // We need to figure out a more type-safe way to handle all of this.
   if (
-    (isERC20 && (!votesToken || !votesToken.totalSupply)) ||
+    (isERC20 && (!votesToken || !votesToken.totalSupply || !votingStrategy?.quorumPercentage)) ||
     (isERC721 && (!erc721Tokens || !votingStrategy.quorumThreshold))
   ) {
     return (
@@ -176,6 +183,7 @@ export default function ProposalSummary({ proposal }: { proposal: AzoriusProposa
             type="block"
             value={startBlock.toString()}
             pl={0}
+            isTextLink
           >
             <Flex
               alignItems="center"

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -125,6 +125,7 @@ export default function ProposalSummary({ proposal }: { proposal: AzoriusProposa
       variant="text"
       textStyle="body-base"
       color="celery-0"
+      _active={{ color: 'celery--2' }}
       onClick={toggleShowVotingPower}
     >
       {showVotingPower

--- a/src/components/ui/links/DisplayAddress.tsx
+++ b/src/components/ui/links/DisplayAddress.tsx
@@ -8,16 +8,19 @@ export function DisplayAddress({
   address,
   truncate,
   children,
+  isTextLink,
   ...rest
 }: {
   address: string;
-  truncate?: boolean | undefined;
+  truncate?: boolean;
+  isTextLink?: boolean;
   children?: ReactNode;
 } & LinkProps) {
   const displayAddress = useDisplayName(address, truncate);
   return (
     <EtherscanLink
       {...rest}
+      isTextLink
       type="address"
       value={address}
     >
@@ -32,10 +35,13 @@ export function DisplayAddress({
         >
           {children || displayAddress.displayName}
         </Text>
-        <Icon
-          as={ArrowUpRight}
-          ml="0.5rem"
-        />
+        {!isTextLink && (
+          <Icon
+            as={ArrowUpRight}
+            mt="0.15rem"
+            ml="0.5rem"
+          />
+        )}
       </Flex>
     </EtherscanLink>
   );

--- a/src/components/ui/links/DisplayTransaction.tsx
+++ b/src/components/ui/links/DisplayTransaction.tsx
@@ -3,20 +3,29 @@ import { ArrowUpRight } from '@phosphor-icons/react';
 import { createAccountSubstring } from '../../../hooks/utils/useDisplayName';
 import EtherscanLink from './EtherscanLink';
 
-export default function DisplayTransaction({ txHash }: { txHash: string }) {
+export default function DisplayTransaction({
+  txHash,
+  isTextLink,
+}: {
+  txHash: string;
+  isTextLink?: boolean;
+}) {
   const displayName = createAccountSubstring(txHash);
   return (
     <EtherscanLink
       type="tx"
       value={txHash}
       pl={0}
+      isTextLink={isTextLink}
     >
       <Flex alignItems="center">
         <Text as="span">{displayName}</Text>
-        <Icon
-          as={ArrowUpRight}
-          ml="0.5rem"
-        />
+        {!isTextLink && (
+          <Icon
+            as={ArrowUpRight}
+            ml="0.5rem"
+          />
+        )}
       </Flex>
     </EtherscanLink>
   );

--- a/src/components/ui/links/EtherscanLink.tsx
+++ b/src/components/ui/links/EtherscanLink.tsx
@@ -9,6 +9,7 @@ export interface EtherscanLinkProps extends LinkProps {
   type: 'address' | 'block' | 'token' | 'tx';
   value: string | null;
   secondaryValue?: string;
+  isTextLink?: boolean;
 }
 
 export default function EtherscanLink({

--- a/src/components/ui/links/ExternalLink.tsx
+++ b/src/components/ui/links/ExternalLink.tsx
@@ -11,7 +11,9 @@ export default function ExternalLink({
     hover: {
       textDecoration: 'underline',
     },
-    active: {},
+    active: {
+      color: 'celery--2',
+    },
   };
 
   const pillLinkStyles = {

--- a/src/components/ui/links/ExternalLink.tsx
+++ b/src/components/ui/links/ExternalLink.tsx
@@ -4,8 +4,28 @@ import { Ref } from 'react';
 export default function ExternalLink({
   children,
   internalRef,
+  isTextLink,
   ...rest
-}: LinkProps & { internalRef?: Ref<any> }) {
+}: LinkProps & { isTextLink?: boolean; internalRef?: Ref<any> }) {
+  const textLinkStyles = {
+    hover: {
+      textDecoration: 'underline',
+    },
+    active: {},
+  };
+
+  const pillLinkStyles = {
+    hover: {
+      bg: 'celery--6',
+      borderColor: 'celery--6',
+    },
+    active: {
+      bg: 'celery--5',
+      borderColor: 'celery--5',
+      borderWidth: '1px',
+    },
+  };
+
   return (
     <Link
       color="celery-0"
@@ -14,8 +34,8 @@ export default function ExternalLink({
       borderRadius="625rem"
       borderColor="transparent"
       borderWidth="1px"
-      _hover={{ bg: 'celery--6', borderColor: 'celery--6' }}
-      _active={{ bg: 'celery--6', borderWidth: '1px', borderColor: 'celery--5' }}
+      _hover={isTextLink ? textLinkStyles.hover : pillLinkStyles.hover}
+      _active={isTextLink ? textLinkStyles.active : pillLinkStyles.active}
       target="_blank"
       rel="noreferrer"
       textDecoration="none"

--- a/src/components/ui/proposal/InfoRow.tsx
+++ b/src/components/ui/proposal/InfoRow.tsx
@@ -23,13 +23,23 @@ export default function InfoRow({
       </Text>
       {tooltip === undefined ? (
         txHash ? (
-          <DisplayTransaction txHash={txHash} />
+          <DisplayTransaction
+            isTextLink
+            txHash={txHash}
+          />
         ) : (
           <Text>{value}</Text>
         )
       ) : (
         <Tooltip label={tooltip}>
-          {txHash ? <DisplayTransaction txHash={txHash} /> : <Text color="white-0">{value}</Text>}
+          {txHash ? (
+            <DisplayTransaction
+              isTextLink
+              txHash={txHash}
+            />
+          ) : (
+            <Text color="white-0">{value}</Text>
+          )}
         </Tooltip>
       )}
     </Box>

--- a/src/components/ui/proposal/ProposalCreatedBy.tsx
+++ b/src/components/ui/proposal/ProposalCreatedBy.tsx
@@ -18,6 +18,7 @@ function ProposalCreatedBy({ proposer }: { proposer: string }) {
       <DisplayAddress
         address={proposer}
         pl={0}
+        isTextLink
       />
     </Box>
   );


### PR DESCRIPTION
closes #1971 

Testing: 

Confirm that links in proposal summary use text link pattern instead of pill design:
<img width="440" alt="Screenshot 2024-06-05 at 13 29 51" src="https://github.com/decentdao/decent-interface/assets/7101382/bb07a4be-be37-47f2-abee-206ca1463ce4">
<img width="408" alt="Screenshot 2024-06-05 at 13 30 07" src="https://github.com/decentdao/decent-interface/assets/7101382/f52bb89f-6e90-45fa-b5af-73d31b4c43c2">

Design:
<img width="775" alt="Screenshot 2024-06-05 at 13 31 06" src="https://github.com/decentdao/decent-interface/assets/7101382/e06e7d7c-63e2-46ee-b02c-f95d53406a3d">
