### PR TITLE
Fix execution button delay

### DIFF
--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -125,9 +125,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
         failedMessage: t('failedExecute', { ns: 'transaction' }),
         pendingMessage: t('pendingExecute', { ns: 'transaction' }),
         successMessage: t('successExecute', { ns: 'transaction' }),
-        successCallback: async () => {
-          await loadSafeMultisigProposals();
-        },
+        successCallback: loadSafeMultisigProposals,
       });
     } catch (e) {
       logError(e, 'Error occurred during transaction execution');
@@ -145,6 +143,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
         return;
       }
       const safeContract = GnosisSafeL2__factory.connect(safe.address, signerOrProvider);
+
       const safeTx = buildSafeTransaction({
         ...multisigTx,
         to: getAddress(multisigTx.to),
@@ -152,6 +151,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
         data: multisigTx.data as Hex | undefined,
         operation: multisigTx.operation as 0 | 1,
       });
+
       const signatures = buildSignatureBytes(
         multisigTx.confirmations.map(confirmation => {
           if (!isHex(confirmation.signature)) {
@@ -163,6 +163,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
           };
         }),
       );
+
       contractCall({
         contractFn: () =>
           safeContract.execTransaction(
@@ -206,7 +207,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
       action: () => Promise<any>;
       text: string;
       pageTitle: string;
-      icon: undefined | JSX.Element;
+      icon?: JSX.Element;
     };
   };
 
@@ -215,7 +216,6 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
       action: signTransaction,
       text: 'approve',
       pageTitle: 'signTitle',
-      icon: undefined,
     },
     [FractalProposalState.EXECUTABLE]: {
       action: executeTransaction,
@@ -227,13 +227,11 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
       action: timelockTransaction,
       text: 'timelock',
       pageTitle: 'timelockTitle',
-      icon: undefined,
     },
     [FractalProposalState.TIMELOCKED]: {
       action: async () => {},
       text: 'execute',
       pageTitle: 'executeTitle',
-      icon: undefined,
     },
   };
   const isActiveNonce = !!safe && multisigTx.nonce === safe.nonce;
@@ -243,7 +241,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
   return (
     <ContentBox containerBoxProps={{ bg: BACKGROUND_SEMI_TRANSPARENT }}>
       <Flex justifyContent="space-between">
-        <Text textStyle="text-lg-mono-medium">{t(buttonProps[proposal.state!].pageTitle)}</Text>
+        <Text>{t(buttonProps[proposal.state!].pageTitle)}</Text>
         <ProposalCountdown proposal={proposal} />
       </Flex>
       <Box marginTop={4}>

--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -33,7 +33,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
 
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(false);
 
-  let wasTimelocked = useRef(
+  const wasTimelocked = useRef(
     proposal.state === FractalProposalState.TIMELOCKABLE ||
       proposal.state === FractalProposalState.TIMELOCKED,
   );
@@ -139,9 +139,9 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
         failedMessage: t('failedExecute', { ns: 'transaction' }),
         pendingMessage: t('pendingExecute', { ns: 'transaction' }),
         successMessage: t('successExecute', { ns: 'transaction' }),
-        successCallback: () => {
+        successCallback: async () => {
           setIsSubmitDisabled(true);
-          loadSafeMultisigProposals();
+          await loadSafeMultisigProposals();
         },
       });
     } catch (e) {

--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -23,8 +23,6 @@ import ContentBox from '../../ui/containers/ContentBox';
 import { ProposalCountdown } from '../../ui/proposal/ProposalCountdown';
 
 export function TxActions({ proposal }: { proposal: MultisigProposal }) {
-  console.log('This proposal: ', proposal);
-
   const {
     node: { safe },
     guardContracts: { freezeGuardContractAddress },

--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -35,12 +35,23 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
 
   const [isSubmitDisabled, setIsSubmitDisabled] = useState(false);
 
+  let wasTimelocked = useRef(
+    proposal.state === FractalProposalState.TIMELOCKABLE ||
+      proposal.state === FractalProposalState.TIMELOCKED,
+  );
+
+  useEffect(() => {
+    if (wasTimelocked.current && proposal.state === FractalProposalState.EXECUTABLE) {
+      setIsSubmitDisabled(false);
+    }
+  }, [proposal.state]);
+
   const { chain } = useNetworkConfig();
   const { t } = useTranslation(['proposal', 'common', 'transaction']);
 
   const [asyncRequest, asyncRequestPending] = useAsyncRequest();
   const [contractCall, contractCallPending] = useTransaction();
-  const { loadSafeMultisigProposals, refreshSafeMultisigProposal } = useSafeMultisigProposals();
+  const { loadSafeMultisigProposals } = useSafeMultisigProposals();
   const baseContracts = useSafeContracts();
   if (user.votingWeight === 0n) return <></>;
 

--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -22,6 +22,8 @@ import ContentBox from '../../ui/containers/ContentBox';
 import { ProposalCountdown } from '../../ui/proposal/ProposalCountdown';
 
 export function TxActions({ proposal }: { proposal: MultisigProposal }) {
+  console.log('This proposal: ', proposal);
+
   const {
     node: { safe },
     guardContracts: { freezeGuardContractAddress },
@@ -35,7 +37,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
 
   const [asyncRequest, asyncRequestPending] = useAsyncRequest();
   const [contractCall, contractCallPending] = useTransaction();
-  const loadSafeMultisigProposals = useSafeMultisigProposals();
+  const { loadSafeMultisigProposals, refreshSafeMultisigProposal } = useSafeMultisigProposals();
   const baseContracts = useSafeContracts();
   if (user.votingWeight === 0n) return <></>;
 
@@ -182,7 +184,9 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
         pendingMessage: t('pendingExecute', { ns: 'transaction' }),
         successMessage: t('successExecute', { ns: 'transaction' }),
         successCallback: async () => {
-          await loadSafeMultisigProposals();
+          // @todo: Indicate to UI that the transaction is executed
+          // await loadSafeMultisigProposals();
+          await refreshSafeMultisigProposal(proposal);
         },
       });
     } catch (e) {

--- a/src/components/Proposals/ProposalActions/ProposalAction.tsx
+++ b/src/components/Proposals/ProposalActions/ProposalAction.tsx
@@ -35,12 +35,14 @@ function ProposalActions({
   }
 }
 
+// @todo: rename to AzoriusProposalAction
 export function ProposalAction({
   proposal,
   expandedView,
   extendedSnapshotProposal,
   onCastSnapshotVote,
 }: {
+  // @todo: this is actually either an AzoriusProposal or a SnapshotProposal, refactor
   proposal: FractalProposal;
   expandedView?: boolean;
   extendedSnapshotProposal?: ExtendedSnapshotProposal;

--- a/src/components/Proposals/ProposalActions/ProposalAction.tsx
+++ b/src/components/Proposals/ProposalActions/ProposalAction.tsx
@@ -9,7 +9,7 @@ import CastVote from './CastVote';
 import { Execute } from './Execute';
 
 // TODO: Refactor extendedSnapshotProposal and onCastSnapshotVote to the context
-export function ProposalActions({
+function ProposalActions({
   proposal,
   extendedSnapshotProposal,
   onCastSnapshotVote,

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -21,6 +21,7 @@ import { QuorumProgressBar } from '../ui/utils/ProgressBar';
 import { ProposalAction } from './ProposalActions/ProposalAction';
 import { VoteContextProvider } from './ProposalVotes/context/VoteContext';
 
+// @todo: rename to AzoriusProposalSummary
 export default function ProposalSummary({ proposal }: { proposal: AzoriusProposal }) {
   const {
     eventDate,

--- a/src/hooks/DAO/loaders/governance/useAzoriusListeners.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusListeners.ts
@@ -38,16 +38,16 @@ const proposalCreatedEventListener = (
   dispatch: Dispatch<FractalActions>,
 ): TypedListener<ProposalCreatedEvent> => {
   return async (_strategyAddress, proposalId, proposer, transactions, metadata) => {
+    if (!metadata) {
+      return;
+    }
+
     // Wait for a block before processing.
     // We've seen that calling smart contract functions in `mapProposalCreatedEventToProposal`
     // which include the `proposalId` error out because the RPC node (rather, the block it's on)
     // doesn't see this proposal yet (despite the event being caught in the app...).
     const averageBlockTime = await getAverageBlockTime(provider);
     await new Promise(resolve => setTimeout(resolve, averageBlockTime * 1000));
-
-    if (!metadata) {
-      return;
-    }
 
     const typedTransactions = transactions.map(t => ({
       ...t,

--- a/src/hooks/DAO/loaders/governance/useSafeMultisigProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useSafeMultisigProposals.ts
@@ -3,10 +3,7 @@ import { logError } from '../../../../helpers/errorLogging';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { FractalGovernanceAction } from '../../../../providers/App/governance/action';
 import { useSafeAPI } from '../../../../providers/App/hooks/useSafeAPI';
-import {
-  ActivityEventType,
-  MultisigProposal,
-} from '../../../../types';
+import { ActivityEventType, MultisigProposal } from '../../../../types';
 import { useSafeTransactions } from '../../../utils/useSafeTransactions';
 
 export const useSafeMultisigProposals = () => {

--- a/src/hooks/DAO/loaders/useLoadDAOProposals.ts
+++ b/src/hooks/DAO/loaders/useLoadDAOProposals.ts
@@ -30,7 +30,7 @@ export const useLoadDAOProposals = () => {
     } else if (type === GovernanceType.MULTISIG) {
       // load mulisig proposals
       // @dev what is the point of setMethodOnInterval here?
-      setMethodOnInterval(loadSafeMultisigProposals);
+      return setMethodOnInterval(loadSafeMultisigProposals);
     }
   }, [
     clearIntervals,

--- a/src/hooks/DAO/loaders/useLoadDAOProposals.ts
+++ b/src/hooks/DAO/loaders/useLoadDAOProposals.ts
@@ -15,13 +15,13 @@ export const useLoadDAOProposals = () => {
 
   const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
   const loadAzoriusProposals = useAzoriusProposals();
-  const loadSafeMultisigProposals = useSafeMultisigProposals();
+  const { loadSafeMultisigProposals } = useSafeMultisigProposals();
 
   const loadDAOProposals = useCallback(async () => {
     clearIntervals();
     if (type === GovernanceType.AZORIUS_ERC20 || type === GovernanceType.AZORIUS_ERC721) {
       // load Azorius proposals and strategies
-      loadAzoriusProposals(proposal => {
+      return loadAzoriusProposals(proposal => {
         action.dispatch({
           type: FractalGovernanceAction.SET_AZORIUS_PROPOSAL,
           payload: proposal,
@@ -29,6 +29,7 @@ export const useLoadDAOProposals = () => {
       });
     } else if (type === GovernanceType.MULTISIG) {
       // load mulisig proposals
+      // @dev what is the point of setMethodOnInterval here?
       setMethodOnInterval(loadSafeMultisigProposals);
     }
   }, [

--- a/src/hooks/utils/useUpdateTimer.tsx
+++ b/src/hooks/utils/useUpdateTimer.tsx
@@ -17,7 +17,7 @@ export const useUpdateTimer = (safeAddress?: string | null) => {
   // Set a method to be executed at a set interval, considering the user's idle state
   const setMethodOnInterval = useCallback(
     async (getMethod: () => Promise<any | undefined>, milliseconds: number = twentySeconds) => {
-      let returnValue: any | undefined;
+      let returnValue: any;
       returnValue = await Promise.resolve(getMethod());
 
       // Clear the interval if the method is already in the timers list

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -111,7 +111,7 @@
   "customNonce": "Custom Nonce (advanced)",
   "customNonceTrimmed": "Custom Nonce",
   "customNonceTooltip": "Optionally set a custom proposal nonce to avoid collisions.",
-  "notActiveNonceTooltip": "There is proposal with a lower nonce that must be executed first.",
+  "notActiveNonceTooltip": "There is a proposal with a lower nonce that must be executed first.",
   "nonce": "Nonce",
   "votingTooltip": "Time remaining to cast your vote.",
   "timeLockedTooltip": "This proposal can be executed once its timelock period has passed.",


### PR DESCRIPTION
Closes #1558

This PR patches up the time delay between when the app indicates a proposal timelock and/or execute transaction has been successfully ran and when the data actually indicates as much.

We have achieved this by simply keeping the execute button disabled after the success toast. If the user chooses to stay on the screen, eventually the node data will be updated, and the button will disappear.

In the case of timelock, the button will re-enable itself after timelock when the proposal becomes executable.

I expect, if the user refreshes the page in that small window where the node hasn't reflected the updated proposal state, the button will then be clickable -- not much we can do in that case beyond localstorage caching, which we _have_ discussed. Problem is multisig safe proposals are currently not cached as they're loaded all at once every time, and choosing to selectively cache them will take a bit more thought. 

There's a separate task for this caching [here](https://github.com/orgs/decentdao/projects/32/views/3?pane=issue&itemId=65769569), if we end up deciding it's something worth doing.