### PR TITLE
`1672` update animations

### DIFF
--- a/src/assets/theme/components/button/button.base.ts
+++ b/src/assets/theme/components/button/button.base.ts
@@ -8,6 +8,7 @@ const baseStyle = defineStyle({
   display: 'flex',
   justifyContent: 'center',
   gap: '4px',
+  transition: 'all ease-out 300ms',
   _disabled: {
     cursor: 'default',
   },

--- a/src/components/Proposals/ProposalCard/ProposalCard.tsx
+++ b/src/components/Proposals/ProposalCard/ProposalCard.tsx
@@ -47,9 +47,7 @@ function ProposalCard({ proposal }: { proposal: FractalProposal }) {
         bg="neutral-2"
         _hover={{ bg: 'neutral-3' }}
         _active={{ bg: 'neutral-2', border: '1px solid', borderColor: 'neutral-3' }}
-        transitionDuration="200ms"
-        transitionProperty="all"
-        transitionTimingFunction="ease-out"
+        transition="all ease-out 300ms"
         p="1.5rem"
         borderRadius="0.5rem"
       >

--- a/src/components/ui/menus/AccountDisplay/NetworkSelector.tsx
+++ b/src/components/ui/menus/AccountDisplay/NetworkSelector.tsx
@@ -52,6 +52,7 @@ export function NetworkSelector({
               w: 'full',
               borderRadius: '4px',
               _hover: { color: 'lilac--1', bg: 'white-alpha-04' },
+              transition: 'all ease-out 300ms',
             }}
             trigger={
               <Flex

--- a/src/components/ui/menus/OptionMenu/index.tsx
+++ b/src/components/ui/menus/OptionMenu/index.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuButton, MenuList, As, MenuProps, Tooltip, Portal, Box } from 
 import { MouseEvent, ReactNode, RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
+import { EaseOutComponent } from '../../utils/EaseOutComponent';
 import { OptionsList } from './OptionsList';
 import { IOption, IOptionsList } from './types';
 
@@ -48,15 +49,17 @@ export function OptionMenu({
         backdropFilter="auto"
         backdropBlur="10px"
       >
-        {children}
-        <OptionsList
-          options={options}
-          showOptionSelected={showOptionSelected}
-          closeOnSelect={closeOnSelect}
-          showOptionCount={showOptionCount}
-          namespace={namespace}
-          titleKey={titleKey}
-        />
+        <EaseOutComponent>
+          {children}
+          <OptionsList
+            options={options}
+            showOptionSelected={showOptionSelected}
+            closeOnSelect={closeOnSelect}
+            showOptionCount={showOptionCount}
+            namespace={namespace}
+            titleKey={titleKey}
+          />
+        </EaseOutComponent>
       </Box>
     </MenuList>
   );
@@ -82,7 +85,6 @@ export function OptionMenu({
           {trigger}
         </MenuButton>
       </Tooltip>
-
       {containerRef !== undefined ? (
         <Portal containerRef={containerRef}>{menuList}</Portal>
       ) : (

--- a/src/components/ui/menus/SafesMenu/index.tsx
+++ b/src/components/ui/menus/SafesMenu/index.tsx
@@ -15,6 +15,7 @@ import { CaretDown, Star } from '@phosphor-icons/react';
 import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AllSafesDrawer } from '../../../../pages/home/AllSafesDrawer';
+import { EaseOutComponent } from '../../utils/EaseOutComponent';
 import { SafesList } from './SafesList';
 
 export function SafesMenu() {
@@ -68,7 +69,11 @@ export function SafesMenu() {
                   />
                 </Flex>
               </MenuButton>
-              {isOpen && <SafesList />}
+              {isOpen && (
+                <EaseOutComponent>
+                  <SafesList />
+                </EaseOutComponent>
+              )}
             </Fragment>
           )}
         </Menu>

--- a/src/components/ui/page/Navigation/NavigationLink.tsx
+++ b/src/components/ui/page/Navigation/NavigationLink.tsx
@@ -24,6 +24,7 @@ function LinkContent({
         py="6px"
         px="6px"
         borderRadius={{ md: 4 }}
+        transition="all ease-out 300ms"
         _hover={{ bgColor: 'neutral-3' }}
         borderWidth={shouldApplyBorder ? '1px' : 0}
         borderColor={shouldApplyBorder ? 'neutral-4' : undefined}

--- a/src/components/ui/utils/EaseOutComponent.tsx
+++ b/src/components/ui/utils/EaseOutComponent.tsx
@@ -1,0 +1,18 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { ReactNode } from 'react';
+
+export function EaseOutComponent({ children }: { children: ReactNode }) {
+  const MotionDiv = motion.div;
+  return (
+    <AnimatePresence>
+      <MotionDiv
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.3, ease: 'easeOut' }}
+      >
+        {children}
+      </MotionDiv>
+    </AnimatePresence>
+  );
+}

--- a/src/components/ui/utils/Sort.tsx
+++ b/src/components/ui/utils/Sort.tsx
@@ -1,10 +1,11 @@
-import { Flex, Icon, Menu, MenuButton, MenuItem, MenuList, Text } from '@chakra-ui/react';
+import { Button, Flex, Icon, Menu, MenuButton, MenuItem, MenuList, Text } from '@chakra-ui/react';
 import { CaretDown } from '@phosphor-icons/react';
 import { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NEUTRAL_2_82_TRANSPARENT } from '../../../constants/common';
 import { SortBy } from '../../../types';
 import Divider from './Divider';
+import { EaseOutComponent } from './EaseOutComponent';
 
 function SortMenuItem({
   labelKey,
@@ -42,18 +43,11 @@ interface ISort {
 export function Sort({ sortBy, setSortBy, buttonProps }: ISort) {
   const { t } = useTranslation();
   return (
-    <Menu direction="ltr">
+    <Menu isLazy>
       <MenuButton
-        data-testid="sort-openMenu"
-        color="lilac-0"
+        as={Button}
+        variant="tertiary"
         p="0.25rem 0.5rem"
-        sx={{
-          '&:hover': {
-            color: 'lilac--1',
-            bg: 'white-alpha-04',
-            borderRadius: '0.25rem',
-          },
-        }}
         {...buttonProps}
       >
         <Flex alignItems="center">
@@ -65,7 +59,6 @@ export function Sort({ sortBy, setSortBy, buttonProps }: ISort) {
           />
         </Flex>
       </MenuButton>
-
       <MenuList
         borderWidth="1px"
         borderColor="neutral-3"
@@ -77,25 +70,27 @@ export function Sort({ sortBy, setSortBy, buttonProps }: ISort) {
         zIndex={5}
         p="0.25rem"
       >
-        <Text
-          px="0.5rem"
-          my="0.25rem"
-          textStyle="helper-text-small"
-          color="neutral-7"
-        >
-          {t('sortTitle')}
-        </Text>
-        <SortMenuItem
-          labelKey={SortBy.Newest}
-          testId="sort-newest"
-          onClick={() => setSortBy(SortBy.Newest)}
-        />
-        <Divider my="0.25rem" />
-        <SortMenuItem
-          labelKey={SortBy.Oldest}
-          testId="sort-oldest"
-          onClick={() => setSortBy(SortBy.Oldest)}
-        />
+        <EaseOutComponent>
+          <Text
+            px="0.5rem"
+            my="0.25rem"
+            textStyle="helper-text-small"
+            color="neutral-7"
+          >
+            {t('sortTitle')}
+          </Text>
+          <SortMenuItem
+            labelKey={SortBy.Newest}
+            testId="sort-newest"
+            onClick={() => setSortBy(SortBy.Newest)}
+          />
+          <Divider my="0.25rem" />
+          <SortMenuItem
+            labelKey={SortBy.Oldest}
+            testId="sort-oldest"
+            onClick={() => setSortBy(SortBy.Oldest)}
+          />
+        </EaseOutComponent>
       </MenuList>
     </Menu>
   );


### PR DESCRIPTION
Fixes #1672

Went a little beyond the original scope>
- All Menus across the app (Sort, Proposal Filter, Favorites)
- Buttons (Covers anything that is `as={Button}` as well as buttons themselves
- ProposalCard (just cleans up to single property)
- NetworkSelector 'Button'
- NavigationLink

It may be hard to noticed but I tested these change by increasing the duration so that I can see the animation happen. 

Only one I was unable to add the transition to (for some reason) is the `WalletMenu`, Neither wrapping with the new `EaseOutComponent` or adding the property directly anywhere, seems to work.