### PR TITLE
Some renaming, cleanup on #1990

### DIFF
--- a/src/components/Proposals/AzoriusDetails/index.tsx
+++ b/src/components/Proposals/AzoriusDetails/index.tsx
@@ -4,7 +4,7 @@ import { AzoriusProposal } from '../../../types';
 import { ProposalDetailsGrid } from '../../ui/containers/ProposalDetailsGrid';
 import { useProposalCountdown } from '../../ui/proposal/useProposalCountdown';
 import { ProposalInfo } from '../ProposalInfo';
-import AzoriusProposalSummary from '../ProposalSummary';
+import { AzoriusProposalSummary } from '../ProposalSummary';
 import ProposalVotes from '../ProposalVotes';
 
 export function AzoriusProposalDetails({ proposal }: { proposal: AzoriusProposal }) {

--- a/src/components/Proposals/AzoriusDetails/index.tsx
+++ b/src/components/Proposals/AzoriusDetails/index.tsx
@@ -4,7 +4,7 @@ import { AzoriusProposal } from '../../../types';
 import { ProposalDetailsGrid } from '../../ui/containers/ProposalDetailsGrid';
 import { useProposalCountdown } from '../../ui/proposal/useProposalCountdown';
 import { ProposalInfo } from '../ProposalInfo';
-import ProposalSummary from '../ProposalSummary';
+import AzoriusProposalSummary from '../ProposalSummary';
 import ProposalVotes from '../ProposalVotes';
 
 export function AzoriusProposalDetails({ proposal }: { proposal: AzoriusProposal }) {
@@ -21,7 +21,7 @@ export function AzoriusProposalDetails({ proposal }: { proposal: AzoriusProposal
         <ProposalVotes proposal={proposal} />
       </GridItem>
       <GridItem maxW={CONTENT_MAXW}>
-        <ProposalSummary proposal={proposal} />
+        <AzoriusProposalSummary proposal={proposal} />
       </GridItem>
     </ProposalDetailsGrid>
   );

--- a/src/components/Proposals/ProposalActions/ProposalAction.tsx
+++ b/src/components/Proposals/ProposalActions/ProposalAction.tsx
@@ -3,7 +3,13 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSnapshotProposal from '../../../hooks/DAO/loaders/snapshot/useSnapshotProposal';
 import { useFractal } from '../../../providers/App/AppProvider';
-import { ExtendedSnapshotProposal, FractalProposal, FractalProposalState } from '../../../types';
+import {
+  AzoriusProposal,
+  ExtendedSnapshotProposal,
+  FractalProposal,
+  FractalProposalState,
+  SnapshotProposal,
+} from '../../../types';
 import { useVoteContext } from '../ProposalVotes/context/VoteContext';
 import CastVote from './CastVote';
 import { Execute } from './Execute';
@@ -35,15 +41,13 @@ function ProposalActions({
   }
 }
 
-// @todo: rename to AzoriusProposalAction
-export function ProposalAction({
+export function AzoriusOrSnapshotProposalAction({
   proposal,
   expandedView,
   extendedSnapshotProposal,
   onCastSnapshotVote,
 }: {
-  // @todo: this is actually either an AzoriusProposal or a SnapshotProposal, refactor
-  proposal: FractalProposal;
+  proposal: AzoriusProposal | SnapshotProposal;
   expandedView?: boolean;
   extendedSnapshotProposal?: ExtendedSnapshotProposal;
   onCastSnapshotVote?: () => Promise<void>;

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -18,11 +18,10 @@ import InfoRow from '../ui/proposal/InfoRow';
 import ProposalCreatedBy from '../ui/proposal/ProposalCreatedBy';
 import Divider from '../ui/utils/Divider';
 import { QuorumProgressBar } from '../ui/utils/ProgressBar';
-import { ProposalAction } from './ProposalActions/ProposalAction';
+import { AzoriusOrSnapshotProposalAction } from './ProposalActions/ProposalAction';
 import { VoteContextProvider } from './ProposalVotes/context/VoteContext';
 
-// @todo: rename to AzoriusProposalSummary
-export default function ProposalSummary({ proposal }: { proposal: AzoriusProposal }) {
+export default function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal }) {
   const {
     eventDate,
     startBlock,
@@ -275,7 +274,7 @@ export default function ProposalSummary({ proposal }: { proposal: AzoriusProposa
             mx="-2rem"
           />
           <VoteContextProvider proposal={proposal}>
-            <ProposalAction
+            <AzoriusOrSnapshotProposalAction
               proposal={proposal}
               expandedView
             />

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -21,7 +21,7 @@ import { QuorumProgressBar } from '../ui/utils/ProgressBar';
 import { AzoriusOrSnapshotProposalAction } from './ProposalActions/ProposalAction';
 import { VoteContextProvider } from './ProposalVotes/context/VoteContext';
 
-export default function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal }) {
+export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal }) {
   const {
     eventDate,
     startBlock,

--- a/src/components/Proposals/SnapshotProposalDetails/index.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/index.tsx
@@ -5,7 +5,7 @@ import { useFractal } from '../../../providers/App/AppProvider';
 import { SnapshotProposal } from '../../../types';
 import { ProposalDetailsGrid } from '../../ui/containers/ProposalDetailsGrid';
 import { useProposalCountdown } from '../../ui/proposal/useProposalCountdown';
-import { ProposalAction } from '../ProposalActions/ProposalAction';
+import { AzoriusOrSnapshotProposalAction } from '../ProposalActions/ProposalAction';
 import { ProposalInfo } from '../ProposalInfo';
 import { VoteContextProvider } from '../ProposalVotes/context/VoteContext';
 import SnapshotProposalSummary from './SnapshotProposalSummary';
@@ -42,7 +42,7 @@ export default function SnapshotProposalDetails({ proposal }: ISnapshotProposalD
             proposal={proposal}
             extendedSnapshotProposal={extendedSnapshotProposal}
           >
-            <ProposalAction
+            <AzoriusOrSnapshotProposalAction
               proposal={proposal}
               extendedSnapshotProposal={extendedSnapshotProposal}
               onCastSnapshotVote={loadProposal}


### PR DESCRIPTION
This is a follow up PR to #1990 to rename some generic proposal types to specific Azorious or Snapshot proposal types, where the context dictates that those are the only possible types involved.