### PR TITLE
Remove typechain cleanup 2

### DIFF
--- a/src/helpers/crypto.ts
+++ b/src/helpers/crypto.ts
@@ -1,4 +1,3 @@
-import { Contract } from 'ethers';
 import {
   hashTypedData,
   Hash,
@@ -6,11 +5,9 @@ import {
   toHex,
   toBytes,
   encodePacked,
-  getAddress,
   Address,
   bytesToBigInt,
   Hex,
-  isHex,
   encodeFunctionData,
   Abi,
   WalletClient,
@@ -189,27 +186,6 @@ const finishBuildingConractCall = (
 };
 
 export const buildContractCall = (
-  contract: Contract,
-  method: string,
-  params: any[],
-  nonce: number,
-  delegateCall?: boolean,
-  overrides?: Partial<SafeTransaction>,
-): SafeTransaction => {
-  const data = contract.interface.encodeFunctionData(method, params);
-  if (!isHex(data)) {
-    throw new Error('encoded function data not hexadecimal');
-  }
-  return finishBuildingConractCall(
-    data,
-    nonce,
-    getAddress(contract.address),
-    delegateCall,
-    overrides,
-  );
-};
-
-export const buildContractCallViem = (
   contractAbi: Abi,
   contractAddress: Address,
   method: string,

--- a/src/hooks/DAO/loaders/useFractalFreeze.ts
+++ b/src/hooks/DAO/loaders/useFractalFreeze.ts
@@ -115,7 +115,6 @@ export const useFractalFreeze = ({
         account || zeroAddress,
         BigInt(freezeCreatedBlock),
       ]);
-      // const isFrozen = await freezeVotingContract.read.isFrozen();
 
       const freezeGuard = {
         freezeVotesThreshold,

--- a/src/models/AzoriusTxBuilder.ts
+++ b/src/models/AzoriusTxBuilder.ts
@@ -21,7 +21,7 @@ import ModuleProxyFactoryAbi from '../assets/abi/ModuleProxyFactory';
 import VotesERC20Abi from '../assets/abi/VotesERC20';
 import VotesERC20WrapperAbi from '../assets/abi/VotesERC20Wrapper';
 import { SENTINEL_ADDRESS } from '../constants/common';
-import { buildContractCallViem, getRandomBytes } from '../helpers';
+import { buildContractCall, getRandomBytes } from '../helpers';
 import {
   SafeTransaction,
   AzoriusGovernanceDAO,
@@ -138,7 +138,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
 
   public buildRemoveOwners(owners: string[]): SafeTransaction[] {
     const removeOwnerTxs = owners.map(owner =>
-      buildContractCallViem(
+      buildContractCall(
         GnosisSafeL2Abi,
         this.safeContractAddress,
         'removeOwner',
@@ -154,7 +154,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
     const daoData = this.daoData as AzoriusGovernanceDAO;
 
     if (daoData.votingStrategyType === VotingStrategyType.LINEAR_ERC20) {
-      return buildContractCallViem(
+      return buildContractCall(
         LinearERC20VotingAbi,
         this.linearERC20VotingAddress!,
         'setAzorius', // contract function name
@@ -163,7 +163,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
         false,
       );
     } else if (daoData.votingStrategyType === VotingStrategyType.LINEAR_ERC721) {
-      return buildContractCallViem(
+      return buildContractCall(
         LinearERC721VotingAbi,
         this.linearERC721VotingAddress!,
         'setAzorius', // contract function name
@@ -177,7 +177,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   }
 
   public buildEnableAzoriusModuleTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       GnosisSafeL2Abi,
       this.safeContractAddress,
       'enableModule',
@@ -188,7 +188,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   }
 
   public buildAddAzoriusContractAsOwnerTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       GnosisSafeL2Abi,
       this.safeContractAddress,
       'addOwnerWithThreshold',
@@ -199,7 +199,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   }
 
   public buildRemoveMultiSendOwnerTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       GnosisSafeL2Abi,
       this.safeContractAddress,
       'removeOwner',
@@ -210,7 +210,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   }
 
   public buildCreateTokenTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       ModuleProxyFactoryAbi,
       this.moduleProxyFactoryAddress,
       'deployModule',
@@ -223,7 +223,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   public buildDeployStrategyTx(): SafeTransaction {
     const daoData = this.daoData as AzoriusGovernanceDAO;
 
-    return buildContractCallViem(
+    return buildContractCall(
       ModuleProxyFactoryAbi,
       this.moduleProxyFactoryAddress,
       'deployModule',
@@ -240,7 +240,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   }
 
   public buildDeployAzoriusTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       ModuleProxyFactoryAbi,
       this.moduleProxyFactoryAddress,
       'deployModule',
@@ -251,7 +251,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   }
 
   public buildDeployTokenClaim() {
-    return buildContractCallViem(
+    return buildContractCall(
       ModuleProxyFactoryAbi,
       this.moduleProxyFactoryAddress,
       'deployModule',
@@ -267,7 +267,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
     }
 
     const azoriusGovernanceDaoData = this.daoData as AzoriusERC20DAO;
-    return buildContractCallViem(
+    return buildContractCall(
       VotesERC20Abi,
       this.votesTokenAddress,
       'approve',
@@ -278,7 +278,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   }
 
   public buildCreateTokenWrapperTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       ModuleProxyFactoryAbi,
       this.moduleProxyFactoryAddress,
       'deployModule',

--- a/src/models/DaoTxBuilder.ts
+++ b/src/models/DaoTxBuilder.ts
@@ -5,7 +5,7 @@ import FractalRegistryAbi from '../assets/abi/FractalRegistry';
 import GnosisSafeL2Abi from '../assets/abi/GnosisSafeL2';
 import KeyValuePairsAbi from '../assets/abi/KeyValuePairs';
 import MultiSendCallOnlyAbi from '../assets/abi/MultiSendCallOnly';
-import { buildContractCallViem, encodeMultiSend } from '../helpers';
+import { buildContractCall, encodeMultiSend } from '../helpers';
 import {
   SafeMultisigDAO,
   SafeTransaction,
@@ -230,7 +230,7 @@ export class DaoTxBuilder extends BaseTxBuilder {
   //
 
   private buildUpdateDAONameTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       FractalRegistryAbi,
       getAddress(this.fractalRegistryAddress),
       'updateDAOName',
@@ -241,7 +241,7 @@ export class DaoTxBuilder extends BaseTxBuilder {
   }
 
   private buildUpdateDAOSnapshotENSTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       KeyValuePairsAbi,
       getAddress(this.keyValuePairsAddress),
       'updateValues',
@@ -253,7 +253,7 @@ export class DaoTxBuilder extends BaseTxBuilder {
 
   private buildExecInternalSafeTx(signatures: string): SafeTransaction {
     const safeInternalTx = encodeMultiSend(this.internalTxs);
-    return buildContractCallViem(
+    return buildContractCall(
       GnosisSafeL2Abi,
       this.safeContractAddress,
       'execTransaction',

--- a/src/models/FreezeGuardTxBuilder.ts
+++ b/src/models/FreezeGuardTxBuilder.ts
@@ -18,7 +18,7 @@ import GnosisSafeL2Abi from '../assets/abi/GnosisSafeL2';
 import ModuleProxyFactoryAbi from '../assets/abi/ModuleProxyFactory';
 import MultisigFreezeGuardAbi from '../assets/abi/MultisigFreezeGuard';
 import MultisigFreezeVotingAbi from '../assets/abi/MultisigFreezeVoting';
-import { buildContractCallViem } from '../helpers';
+import { buildContractCall } from '../helpers';
 import { SafeTransaction, SubDAO, VotingStrategyType } from '../types';
 import { BaseTxBuilder } from './BaseTxBuilder';
 import { generateContractByteCodeLinear, generateSalt } from './helpers/utils';
@@ -98,7 +98,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
   }
 
   public buildDeployZodiacModuleTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       ModuleProxyFactoryAbi,
       this.moduleProxyFactoryAddress,
       'deployModule',
@@ -145,30 +145,22 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
     ];
 
     if (this.freezeVotingType === 'erc20') {
-      return buildContractCallViem(ERC20FreezeVotingAbi, this.freezeVotingAddress, ...functionArgs);
+      return buildContractCall(ERC20FreezeVotingAbi, this.freezeVotingAddress, ...functionArgs);
     } else if (this.freezeVotingType === 'erc721') {
-      return buildContractCallViem(
-        ERC721FreezeVotingAbi,
-        this.freezeVotingAddress,
-        ...functionArgs,
-      );
+      return buildContractCall(ERC721FreezeVotingAbi, this.freezeVotingAddress, ...functionArgs);
     } else if (this.freezeVotingType === 'multisig') {
-      return buildContractCallViem(
-        MultisigFreezeVotingAbi,
-        this.freezeVotingAddress,
-        ...functionArgs,
-      );
+      return buildContractCall(MultisigFreezeVotingAbi, this.freezeVotingAddress, ...functionArgs);
     } else {
       throw new Error('unsupported freeze voting type');
     }
   }
 
   public buildSetGuardTx(abi: Abi, address: Address): SafeTransaction {
-    return buildContractCallViem(abi, address, 'setGuard', [this.freezeGuardAddress], 0, false);
+    return buildContractCall(abi, address, 'setGuard', [this.freezeGuardAddress], 0, false);
   }
 
   public buildSetGuardTxSafe(safeAddress: Address): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       GnosisSafeL2Abi,
       safeAddress,
       'setGuard',
@@ -179,7 +171,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
   }
 
   public buildDeployFreezeGuardTx() {
-    return buildContractCallViem(
+    return buildContractCall(
       ModuleProxyFactoryAbi,
       this.moduleProxyFactoryAddress,
       'deployModule',

--- a/src/models/MultisigTxBuilder.ts
+++ b/src/models/MultisigTxBuilder.ts
@@ -1,6 +1,6 @@
 import { Address } from 'viem';
 import GnosisSafeL2Abi from '../assets/abi/GnosisSafeL2';
-import { buildContractCallViem } from '../helpers';
+import { buildContractCall } from '../helpers';
 import { SafeMultisigDAO, SafeTransaction } from '../types';
 
 export class MultisigTxBuilder {
@@ -28,7 +28,7 @@ export class MultisigTxBuilder {
   };
 
   public buildRemoveMultiSendOwnerTx(): SafeTransaction {
-    return buildContractCallViem(
+    return buildContractCall(
       GnosisSafeL2Abi,
       this.safeContractAddress,
       'removeOwner',

--- a/src/models/helpers/fractalModuleData.ts
+++ b/src/models/helpers/fractalModuleData.ts
@@ -10,7 +10,7 @@ import {
 import FractalModuleAbi from '../../assets/abi/FractalModule';
 import GnosisSafeL2Abi from '../../assets/abi/GnosisSafeL2';
 import ModuleProxyFactoryAbi from '../../assets/abi/ModuleProxyFactory';
-import { buildContractCallViem } from '../../helpers/crypto';
+import { buildContractCall } from '../../helpers/crypto';
 import { SafeTransaction } from '../../types';
 import { generateContractByteCodeLinear, generateSalt } from './utils';
 
@@ -44,7 +44,7 @@ export const fractalModuleData = (
 
   const fractalSalt = generateSalt(fractalModuleCalldata, saltNum);
 
-  const deployFractalModuleTx = buildContractCallViem(
+  const deployFractalModuleTx = buildContractCall(
     ModuleProxyFactoryAbi,
     moduleProxyFactoryAddress,
     'deployModule',
@@ -59,7 +59,7 @@ export const fractalModuleData = (
     bytecodeHash: keccak256(encodePacked(['bytes'], [fractalByteCodeLinear])),
   });
 
-  const enableFractalModuleTx = buildContractCallViem(
+  const enableFractalModuleTx = buildContractCall(
     GnosisSafeL2Abi,
     safeAddress,
     'enableModule',

--- a/src/models/helpers/safeData.ts
+++ b/src/models/helpers/safeData.ts
@@ -14,7 +14,7 @@ import {
 } from 'viem';
 import GnosisSafeL2Abi from '../../assets/abi/GnosisSafeL2';
 import GnosisSafeProxyFactoryAbi from '../../assets/abi/GnosisSafeProxyFactory';
-import { buildContractCallViem } from '../../helpers/crypto';
+import { buildContractCall } from '../../helpers/crypto';
 import { SafeMultisigDAO } from '../../types';
 
 export const safeData = async (
@@ -66,7 +66,7 @@ export const safeData = async (
     ),
   });
 
-  const createSafeTx = buildContractCallViem(
+  const createSafeTx = buildContractCall(
     GnosisSafeProxyFactoryAbi,
     safeFactoryContract.address,
     'createProxyWithNonce',


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-interface/pull/2002

- Remove unused `buildContractCall` and rename `buildContractCallViem` back to `buildContractCall`