### PR TITLE
Remove typechain cleanup 4

### DIFF
--- a/src/hooks/DAO/useBuildDAOTx.ts
+++ b/src/hooks/DAO/useBuildDAOTx.ts
@@ -11,10 +11,8 @@ import {
   AzoriusGovernance,
   VotingStrategyType,
 } from '../../types';
-import useSignerOrProvider from '../utils/useSignerOrProvider';
 
 const useBuildDAOTx = () => {
-  const signerOrProvider = useSignerOrProvider();
   const {
     contracts: {
       fallbackHandler,
@@ -54,7 +52,7 @@ const useBuildDAOTx = () => {
     ) => {
       let isAzorius = false;
 
-      if (!user.address || !signerOrProvider || !publicClient) {
+      if (!user.address || !publicClient) {
         return;
       }
 
@@ -66,7 +64,6 @@ const useBuildDAOTx = () => {
       }
 
       const txBuilderFactory = new TxBuilderFactory(
-        signerOrProvider,
         publicClient,
         isAzorius,
         daoData,
@@ -128,7 +125,6 @@ const useBuildDAOTx = () => {
     },
     [
       user.address,
-      signerOrProvider,
       publicClient,
       fallbackHandler,
       votesERC20WrapperMasterCopy,

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -11,11 +11,9 @@ import { useFractal } from '../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { ProposalExecuteData, AzoriusERC20DAO, AzoriusERC721DAO } from '../../types';
 import { useCanUserCreateProposal } from '../utils/useCanUserSubmitProposal';
-import useSignerOrProvider from '../utils/useSignerOrProvider';
 import useSubmitProposal from './proposal/useSubmitProposal';
 
 const useDeployAzorius = () => {
-  const signerOrProvider = useSignerOrProvider();
   const navigate = useNavigate();
   const {
     contracts: {
@@ -62,7 +60,6 @@ const useDeployAzorius = () => {
       }
 
       const txBuilderFactory = new TxBuilderFactory(
-        signerOrProvider,
         publicClient,
         true,
         daoData,
@@ -137,7 +134,6 @@ const useDeployAzorius = () => {
       canUserCreateProposal,
       safe,
       publicClient,
-      signerOrProvider,
       fallbackHandler,
       votesERC20WrapperMasterCopy,
       votesERC20MasterCopy,

--- a/src/models/AzoriusTxBuilder.ts
+++ b/src/models/AzoriusTxBuilder.ts
@@ -66,7 +66,6 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
   private claimNonce: bigint;
 
   constructor(
-    signerOrProvider: any,
     publicClient: PublicClient,
     daoData: AzoriusERC20DAO | AzoriusERC721DAO,
     safeContractAddress: Address,
@@ -81,7 +80,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
     parentAddress?: Address,
     parentTokenAddress?: Address,
   ) {
-    super(signerOrProvider, publicClient, true, daoData, parentAddress, parentTokenAddress);
+    super(publicClient, true, daoData, parentAddress, parentTokenAddress);
 
     this.safeContractAddress = safeContractAddress;
 

--- a/src/models/BaseTxBuilder.ts
+++ b/src/models/BaseTxBuilder.ts
@@ -1,9 +1,7 @@
-import { ethers } from 'ethers';
 import { PublicClient } from 'viem';
 import { SafeMultisigDAO, SubDAO, AzoriusERC20DAO, AzoriusERC721DAO } from '../types';
 
 export class BaseTxBuilder {
-  protected readonly signerOrProvider: ethers.Signer | any;
   protected readonly publicClient: PublicClient;
   protected readonly isAzorius: boolean;
   protected readonly daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO;
@@ -11,14 +9,12 @@ export class BaseTxBuilder {
   protected readonly parentTokenAddress?: string;
 
   constructor(
-    signerOrProvider: ethers.Signer | any,
     publicClient: PublicClient,
     isAzorius: boolean,
     daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO,
     parentAddress?: string,
     parentTokenAddress?: string,
   ) {
-    this.signerOrProvider = signerOrProvider;
     this.publicClient = publicClient;
     this.daoData = daoData;
     this.isAzorius = isAzorius;

--- a/src/models/DaoTxBuilder.ts
+++ b/src/models/DaoTxBuilder.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'ethers';
 import { Address, PublicClient, encodeFunctionData, getAddress, zeroAddress } from 'viem';
 import AzoriusAbi from '../assets/abi/Azorius';
 import FractalRegistryAbi from '../assets/abi/FractalRegistry';
@@ -41,7 +40,6 @@ export class DaoTxBuilder extends BaseTxBuilder {
   private readonly fractalModuleMasterCopyAddress: string;
 
   constructor(
-    signerOrProvider: ethers.Signer | any,
     publicClient: PublicClient,
     isAzorius: boolean,
     daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO,
@@ -59,7 +57,7 @@ export class DaoTxBuilder extends BaseTxBuilder {
     parentStrategyType?: VotingStrategyType,
     parentStrategyAddress?: string,
   ) {
-    super(signerOrProvider, publicClient, isAzorius, daoData, parentAddress, parentTokenAddress);
+    super(publicClient, isAzorius, daoData, parentAddress, parentTokenAddress);
 
     this.createSafeTx = createSafeTx;
     this.safeContractAddress = safeContractAddress;

--- a/src/models/FreezeGuardTxBuilder.ts
+++ b/src/models/FreezeGuardTxBuilder.ts
@@ -53,7 +53,6 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
   private multisigFreezeVotingMasterCopyAddress: Address;
 
   constructor(
-    signerOrProvider: any,
     publicClient: PublicClient,
     daoData: SubDAO,
     safeContractAddress: Address,
@@ -72,7 +71,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
     parentStrategyType?: VotingStrategyType,
     parentStrategyAddress?: Address,
   ) {
-    super(signerOrProvider, publicClient, isAzorius, daoData, parentAddress, parentTokenAddress);
+    super(publicClient, isAzorius, daoData, parentAddress, parentTokenAddress);
 
     this.safeContractAddress = safeContractAddress;
     this.saltNum = saltNum;

--- a/src/models/TxBuilderFactory.ts
+++ b/src/models/TxBuilderFactory.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'ethers';
 import { Address, PublicClient, getAddress, getContract } from 'viem';
 import GnosisSafeL2Abi from '../assets/abi/GnosisSafeL2';
 import GnosisSafeProxyFactoryAbi from '../assets/abi/GnosisSafeProxyFactory';
@@ -25,7 +24,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
   public predictedSafeAddress: string | undefined;
   public createSafeTx: SafeTransaction | undefined;
   private safeContractAddress: Address | undefined;
-  public fallbackHandler: string;
+  private fallbackHandler: string;
 
   private votesERC20WrapperMasterCopyAddress: string;
   private votesERC20MasterCopyAddress: string;
@@ -47,7 +46,6 @@ export class TxBuilderFactory extends BaseTxBuilder {
   private azoriusMasterCopyAddress: string;
 
   constructor(
-    signerOrProvider: ethers.Signer | any,
     publicClient: PublicClient,
     isAzorius: boolean,
     daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO,
@@ -73,7 +71,7 @@ export class TxBuilderFactory extends BaseTxBuilder {
     parentAddress?: string,
     parentTokenAddress?: string,
   ) {
-    super(signerOrProvider, publicClient, isAzorius, daoData, parentAddress, parentTokenAddress);
+    super(publicClient, isAzorius, daoData, parentAddress, parentTokenAddress);
 
     this.fallbackHandler = fallbackHandler;
     this.saltNum = getRandomBytes();
@@ -133,7 +131,6 @@ export class TxBuilderFactory extends BaseTxBuilder {
     parentStrategyAddress?: string,
   ): DaoTxBuilder {
     return new DaoTxBuilder(
-      this.signerOrProvider,
       this.publicClient,
       this.isAzorius,
       this.daoData,
@@ -160,7 +157,6 @@ export class TxBuilderFactory extends BaseTxBuilder {
     parentStrategyAddress?: string, // User only with ERC-721 parent
   ): FreezeGuardTxBuilder {
     return new FreezeGuardTxBuilder(
-      this.signerOrProvider,
       this.publicClient,
       this.daoData as SubDAO,
       this.safeContractAddress!,
@@ -191,7 +187,6 @@ export class TxBuilderFactory extends BaseTxBuilder {
 
   public async createAzoriusTxBuilder(): Promise<AzoriusTxBuilder> {
     const azoriusTxBuilder = new AzoriusTxBuilder(
-      this.signerOrProvider,
       this.publicClient,
       this.daoData as AzoriusERC20DAO,
       this.safeContractAddress!,


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-interface/pull/2004

- Don't need `signerOrProvider` in transaction builder classes any longer