### PR TITLE
Fix crosschain favorites names

### DIFF
--- a/src/hooks/DAO/useGetDAOName.ts
+++ b/src/hooks/DAO/useGetDAOName.ts
@@ -1,11 +1,10 @@
-import { FractalRegistry } from '@fractal-framework/fractal-contracts';
 import { useCallback, useEffect, useState } from 'react';
-import { Address, PublicClient } from 'viem';
+import { Address, PublicClient, getContract, parseAbi, getAddress } from 'viem';
 import { usePublicClient } from 'wagmi';
-import { getEventRPC } from '../../helpers';
 import { useFractal } from '../../providers/App/AppProvider';
 import { FractalContracts } from '../../types';
 import { createAccountSubstring } from '../utils/useDisplayName';
+import { getNetworkConfig } from './../../providers/NetworkConfig/NetworkConfigProvider';
 import { demoData } from './loaders/loadDemoData';
 
 const getDAOName = async ({
@@ -19,7 +18,7 @@ const getDAOName = async ({
   publicClient: PublicClient | undefined;
   baseContracts: FractalContracts | undefined;
 }) => {
-  if (!publicClient) {
+  if (!publicClient || !publicClient.chain) {
     throw new Error('Public client not available');
   }
 
@@ -43,15 +42,28 @@ const getDAOName = async ({
     throw new Error('Base contracts not set');
   }
 
-  const rpc = getEventRPC<FractalRegistry>(baseContracts.fractalRegistryContract);
-  const events = await rpc.queryFilter(rpc.filters.FractalNameUpdated(address));
+  const {
+    contracts: { fractalRegistry },
+  } = getNetworkConfig(publicClient.chain.id);
+
+  const fractalRegistryContract = getContract({
+    abi: parseAbi(['event FractalNameUpdated(address indexed daoAddress, string daoName)']),
+    address: getAddress(fractalRegistry),
+    client: publicClient,
+  });
+
+  const events = await fractalRegistryContract.getEvents.FractalNameUpdated(
+    { daoAddress: address },
+    { fromBlock: 0n },
+  );
+
   const latestEvent = events.pop();
 
   if (latestEvent) {
     return latestEvent.args.daoName;
   }
 
-  if (publicClient.chain) {
+  if (publicClient.chain && demoData[publicClient.chain.id] !== undefined) {
     const demo = demoData[publicClient.chain.id][address];
     if (demo && demo.name) {
       return demo.name;

--- a/src/hooks/DAO/useGetDAOName.ts
+++ b/src/hooks/DAO/useGetDAOName.ts
@@ -59,7 +59,7 @@ const getDAOName = async ({
 
   const latestEvent = events.pop();
 
-  if (latestEvent) {
+  if (latestEvent?.args.daoName) {
     return latestEvent.args.daoName;
   }
 

--- a/src/providers/NetworkConfig/NetworkConfigProvider.tsx
+++ b/src/providers/NetworkConfig/NetworkConfigProvider.tsx
@@ -11,7 +11,7 @@ export const useNetworkConfig = (): NetworkConfig =>
 
 export const supportedNetworks = Object.values(networks).sort((a, b) => a.order - b.order);
 
-const getNetworkConfig = (chainId: number) => {
+export const getNetworkConfig = (chainId: number) => {
   const foundChain = supportedNetworks.find(network => network.chain.id === chainId);
   if (foundChain) {
     return foundChain;


### PR DESCRIPTION
Fixes #2043 

Now, all Favorited Safe names will load regardless of the currently connected network.