### PR TITLE
`2046` roles index page components

### DIFF
--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -34,6 +34,7 @@ export interface RoleCardProps {
   };
 }
 
+// @todo update this component with Edit Page Badges
 export function RoleCard({ roleName, wearerAddress, payrollData, vestingData }: RoleCardProps) {
   const { addressPrefix } = useNetworkConfig();
   const { daoName: accountDisplayName } = useGetDAOName({
@@ -55,7 +56,7 @@ export function RoleCard({ roleName, wearerAddress, payrollData, vestingData }: 
           <Box
             boxSize="3rem"
             borderRadius="100%"
-            bg="rgba(255, 255, 255, 0.04)"
+            bg="white-alpha-04"
           ></Box>
         )}
         <Flex
@@ -86,7 +87,7 @@ export function RoleCard({ roleName, wearerAddress, payrollData, vestingData }: 
               textStyle="button-small"
               color="neutral-7"
             >
-              Payroll
+              {t('payroll')}
             </Text>
             <Flex
               textStyle="body-base"
@@ -130,7 +131,7 @@ export function RoleCard({ roleName, wearerAddress, payrollData, vestingData }: 
               textStyle="button-small"
               color="neutral-7"
             >
-              Vesting
+              {t('vesting')}
             </Text>
             <Flex
               textStyle="body-base"

--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -1,38 +1,63 @@
-import { Flex, Text } from '@chakra-ui/react';
-import { zeroAddress } from 'viem';
+import { Box, Flex, Image, Text } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+import { Address, zeroAddress } from 'viem';
 import { useGetDAOName } from '../../../hooks/DAO/useGetDAOName';
 import useAvatar from '../../../hooks/utils/useAvatar';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix } from '../../../utils/url';
 import { Card } from '../../ui/cards/Card';
+import EtherscanLink from '../../ui/links/EtherscanLink';
 import Avatar from '../../ui/page/Header/Avatar';
-// import { Hat } from '@hatsprotocol/sdk-v1-subgraph';
 
 export interface RoleCardProps {
-  // hat: Hat
+  roleName: string;
+  wearerAddress: Address | undefined;
+  vestingData?: {
+    vestingSchedule: string;
+    vestingAmount: string;
+    asset: {
+      address: string;
+      symbol: string;
+      name: string;
+      iconUri: string;
+    };
+  };
+  payrollData?: {
+    payrollSchedule: string;
+    payrollAmount: string;
+    asset: {
+      address: string;
+      symbol: string;
+      name: string;
+      iconUri: string;
+    };
+  };
 }
 
-export function RoleCard({}: RoleCardProps) {
-  // (mock) addresses of wearers
-  const wearers = [zeroAddress];
-  // (mock) role name of hat
-  const roleName = 'Role Name';
-
+export function RoleCard({ roleName, wearerAddress, payrollData, vestingData }: RoleCardProps) {
   const { addressPrefix } = useNetworkConfig();
   const { daoName: accountDisplayName } = useGetDAOName({
-    address: wearers[0],
+    address: wearerAddress || zeroAddress,
     chainId: getChainIdFromPrefix(addressPrefix),
   });
-
-  const avatarURL = useAvatar(wearers[0]);
+  const avatarURL = useAvatar(wearerAddress || zeroAddress);
+  const { t } = useTranslation(['roles']);
   return (
     <Card mb="0.5rem">
-      <Flex>
-        <Avatar
-          size="lg"
-          address={wearers[0]}
-          url={avatarURL}
-        />
+      <Flex alignItems="center">
+        {wearerAddress ? (
+          <Avatar
+            size="xl"
+            address={wearerAddress}
+            url={avatarURL}
+          />
+        ) : (
+          <Box
+            boxSize="3rem"
+            borderRadius="100%"
+            bg="rgba(255, 255, 255, 0.04)"
+          ></Box>
+        )}
         <Flex
           direction="column"
           ml="1rem"
@@ -43,14 +68,101 @@ export function RoleCard({}: RoleCardProps) {
           >
             {roleName}
           </Text>
-
           <Text
             textStyle="button-small"
             color="neutral-7"
           >
-            {accountDisplayName}
+            {wearerAddress ? accountDisplayName : t('unassigned')}
           </Text>
         </Flex>
+      </Flex>
+      <Flex flexDir="column">
+        {payrollData && (
+          <Box
+            mt="1rem"
+            ml="4rem"
+          >
+            <Text
+              textStyle="button-small"
+              color="neutral-7"
+            >
+              Payroll
+            </Text>
+            <Flex
+              textStyle="body-base"
+              color="white-0"
+              gap="0.25rem"
+              my="0.5rem"
+            >
+              <Image
+                src={payrollData.asset.iconUri}
+                fallbackSrc="/images/coin-icon-default.svg"
+                alt={payrollData.asset.symbol}
+                w="1.25rem"
+                h="1.25rem"
+              />
+              {payrollData.payrollAmount}
+              <EtherscanLink
+                color="white-0"
+                _hover={{ bg: 'transparent' }}
+                textStyle="body-base"
+                padding={0}
+                borderWidth={0}
+                value={payrollData.asset.address}
+                type="token"
+                wordBreak="break-word"
+              >
+                {payrollData.asset.symbol}
+              </EtherscanLink>
+              <Text>
+                {'/'} {payrollData.payrollSchedule}
+              </Text>
+            </Flex>
+          </Box>
+        )}
+        {vestingData && (
+          <Box
+            mt="0.25rem"
+            ml="4rem"
+          >
+            <Text
+              textStyle="button-small"
+              color="neutral-7"
+            >
+              Vesting
+            </Text>
+            <Flex
+              textStyle="body-base"
+              color="white-0"
+              gap="0.25rem"
+              my="0.5rem"
+            >
+              <Image
+                src={vestingData.asset.iconUri}
+                fallbackSrc="/images/coin-icon-default.svg"
+                alt={vestingData.asset.symbol}
+                w="1.25rem"
+                h="1.25rem"
+              />
+              {vestingData.vestingAmount}
+              <EtherscanLink
+                color="white-0"
+                _hover={{ bg: 'transparent' }}
+                textStyle="body-base"
+                padding={0}
+                borderWidth={0}
+                value={vestingData.asset.address}
+                type="token"
+                wordBreak="break-word"
+              >
+                {vestingData.asset.symbol}
+              </EtherscanLink>
+              <Text>
+                {t('after')} {vestingData.vestingSchedule}
+              </Text>
+            </Flex>
+          </Box>
+        )}
       </Flex>
     </Card>
   );

--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -57,7 +57,7 @@ export function RoleCard({ roleName, wearerAddress, payrollData, vestingData }: 
             boxSize="3rem"
             borderRadius="100%"
             bg="white-alpha-04"
-          ></Box>
+          />
         )}
         <Flex
           direction="column"

--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -92,6 +92,7 @@ export function RoleCard({ roleName, wearerAddress, payrollData, vestingData }: 
               textStyle="body-base"
               color="white-0"
               gap="0.25rem"
+              alignItems="center"
               my="0.5rem"
             >
               <Image
@@ -135,6 +136,7 @@ export function RoleCard({ roleName, wearerAddress, payrollData, vestingData }: 
               textStyle="body-base"
               color="white-0"
               gap="0.25rem"
+              alignItems="center"
               my="0.5rem"
             >
               <Image

--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -1,0 +1,57 @@
+import { Flex, Text } from '@chakra-ui/react';
+import { zeroAddress } from 'viem';
+import { useGetDAOName } from '../../../hooks/DAO/useGetDAOName';
+import useAvatar from '../../../hooks/utils/useAvatar';
+import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
+import { getChainIdFromPrefix } from '../../../utils/url';
+import { Card } from '../../ui/cards/Card';
+import Avatar from '../../ui/page/Header/Avatar';
+// import { Hat } from '@hatsprotocol/sdk-v1-subgraph';
+
+export interface RoleCardProps {
+  // hat: Hat
+}
+
+export function RoleCard({}: RoleCardProps) {
+  // (mock) addresses of wearers
+  const wearers = [zeroAddress];
+  // (mock) role name of hat
+  const roleName = 'Role Name';
+
+  const { addressPrefix } = useNetworkConfig();
+  const { daoName: accountDisplayName } = useGetDAOName({
+    address: wearers[0],
+    chainId: getChainIdFromPrefix(addressPrefix),
+  });
+
+  const avatarURL = useAvatar(wearers[0]);
+  return (
+    <Card mb="0.5rem">
+      <Flex>
+        <Avatar
+          size="lg"
+          address={wearers[0]}
+          url={avatarURL}
+        />
+        <Flex
+          direction="column"
+          ml="1rem"
+        >
+          <Text
+            textStyle="display-lg"
+            color="white-0"
+          >
+            {roleName}
+          </Text>
+
+          <Text
+            textStyle="button-small"
+            color="neutral-7"
+          >
+            {accountDisplayName}
+          </Text>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/components/pages/Roles/RolesTable.tsx
+++ b/src/components/pages/Roles/RolesTable.tsx
@@ -35,6 +35,7 @@ export interface RoleRowProps {
 }
 
 export function RolesHeader() {
+  const { t } = useTranslation(['roles']);
   return (
     <Thead
       sx={{
@@ -48,11 +49,11 @@ export function RolesHeader() {
         textStyle="label-base"
         color="neutral-7"
       >
-        <Th>Role</Th>
-        <Th>Member</Th>
-        {/* @todo These values are viewed only by admin */}
-        <Th>Payroll</Th>
-        <Th>Vesting</Th>
+        <Th>{t('role')}</Th>
+        <Th>{t('member')}</Th>
+        {/* @todo These values are viewed only by admin? */}
+        <Th>{t('payroll')}</Th>
+        <Th>{t('vesting')}</Th>
       </Tr>
     </Thead>
   );
@@ -239,9 +240,7 @@ export function RolesTable() {
             wearerAddress={zeroAddress}
             payrollData={{
               payrollAmount: '1000',
-              // ? How is this formatted when received
               payrollSchedule: 'mo',
-              // ? What asset data is available from Sablier
               asset: {
                 symbol: 'USDC',
                 name: 'USDC Stablecoin',
@@ -252,9 +251,7 @@ export function RolesTable() {
             }}
             vestingData={{
               vestingAmount: '1000',
-              // ? How is this formatted when received
               vestingSchedule: '1yr',
-              // ? What asset data is available from Sablier
               asset: {
                 symbol: 'USDC',
                 name: 'USDC Stablecoin',

--- a/src/components/pages/Roles/RolesTable.tsx
+++ b/src/components/pages/Roles/RolesTable.tsx
@@ -1,0 +1,271 @@
+import { Box, Flex, Image, Table, Tbody, Td, Text, Th, Thead, Tr } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+import { Address, zeroAddress } from 'viem';
+import { useGetDAOName } from '../../../hooks/DAO/useGetDAOName';
+import useAvatar from '../../../hooks/utils/useAvatar';
+import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
+import { getChainIdFromPrefix } from '../../../utils/url';
+import EtherscanLink from '../../ui/links/EtherscanLink';
+import Avatar from '../../ui/page/Header/Avatar';
+
+// @todo I imagine this interface can eventually be shared between the RoleCard and this component, for now keeping seperated
+export interface RoleRowProps {
+  roleName: string;
+  wearerAddress: Address | undefined;
+  vestingData?: {
+    vestingSchedule: string;
+    vestingAmount: string;
+    asset: {
+      address: string;
+      symbol: string;
+      name: string;
+      iconUri: string;
+    };
+  };
+  payrollData?: {
+    payrollSchedule: string;
+    payrollAmount: string;
+    asset: {
+      address: string;
+      symbol: string;
+      name: string;
+      iconUri: string;
+    };
+  };
+}
+
+export function RolesHeader() {
+  return (
+    <Thead
+      sx={{
+        th: {
+          padding: '0.75rem',
+        },
+      }}
+      bg="white-alpha-04"
+    >
+      <Tr
+        textStyle="label-base"
+        color="neutral-7"
+      >
+        <Th>Role</Th>
+        <Th>Member</Th>
+        {/* @todo These values are viewed only by admin */}
+        <Th>Payroll</Th>
+        <Th>Vesting</Th>
+      </Tr>
+    </Thead>
+  );
+}
+
+export function RolesRow({ roleName, wearerAddress, payrollData, vestingData }: RoleRowProps) {
+  const { addressPrefix } = useNetworkConfig();
+  const { daoName: accountDisplayName } = useGetDAOName({
+    address: wearerAddress || zeroAddress,
+    chainId: getChainIdFromPrefix(addressPrefix),
+  });
+  const avatarURL = useAvatar(wearerAddress || zeroAddress);
+  const { t } = useTranslation(['roles']);
+  return (
+    <Tr
+      minHeight="10rem"
+      sx={{
+        td: { padding: '0.75rem', height: '4rem' },
+      }}
+      _hover={{ bg: 'neutral-3' }}
+      _active={{ bg: 'neutral-2', border: '1px solid', borderColor: 'neutral-3' }}
+      transition="all ease-out 300ms"
+    >
+      <Td>
+        <Text
+          textStyle="body-base"
+          color="lilac-0"
+        >
+          {roleName}
+        </Text>
+      </Td>
+      <Td>
+        <Flex alignItems="center">
+          {wearerAddress ? (
+            <Avatar
+              size="icon"
+              address={wearerAddress}
+              url={avatarURL}
+            />
+          ) : (
+            <Box
+              boxSize="3rem"
+              borderRadius="100%"
+              bg="rgba(255, 255, 255, 0.04)"
+            ></Box>
+          )}
+          <Flex
+            direction="column"
+            ml="0.5rem"
+          >
+            <Text
+              textStyle="body-base"
+              color="white-0"
+            >
+              {wearerAddress ? accountDisplayName : t('unassigned')}
+            </Text>
+          </Flex>
+        </Flex>
+      </Td>
+      <Td>
+        <Flex flexDir="column">
+          {payrollData ? (
+            <Box>
+              <Flex
+                textStyle="body-base"
+                alignItems="center"
+                color="white-0"
+                gap="0.25rem"
+                my="0.5rem"
+              >
+                <Image
+                  src={payrollData.asset.iconUri}
+                  fallbackSrc="/images/coin-icon-default.svg"
+                  alt={payrollData.asset.symbol}
+                  w="1.25rem"
+                  h="1.25rem"
+                />
+                {payrollData.payrollAmount}
+                <EtherscanLink
+                  color="white-0"
+                  _hover={{ bg: 'transparent' }}
+                  textStyle="body-base"
+                  padding={0}
+                  borderWidth={0}
+                  value={payrollData.asset.address}
+                  type="token"
+                  wordBreak="break-word"
+                >
+                  {payrollData.asset.symbol}
+                </EtherscanLink>
+                <Text>
+                  {'/'} {payrollData.payrollSchedule}
+                </Text>
+              </Flex>
+            </Box>
+          ) : (
+            <Text
+              textStyle="body-base"
+              color="neutral-6"
+            >
+              n/a
+            </Text>
+          )}
+        </Flex>
+      </Td>
+      <Td>
+        {' '}
+        {vestingData ? (
+          <Box>
+            <Flex
+              textStyle="body-base"
+              color="white-0"
+              gap="0.25rem"
+              alignItems="center"
+              my="0.5rem"
+            >
+              <Image
+                src={vestingData.asset.iconUri}
+                fallbackSrc="/images/coin-icon-default.svg"
+                alt={vestingData.asset.symbol}
+                w="1.25rem"
+                h="1.25rem"
+              />
+              {vestingData.vestingAmount}
+              <EtherscanLink
+                color="white-0"
+                _hover={{ bg: 'transparent' }}
+                textStyle="body-base"
+                padding={0}
+                borderWidth={0}
+                value={vestingData.asset.address}
+                type="token"
+                wordBreak="break-word"
+              >
+                {vestingData.asset.symbol}
+              </EtherscanLink>
+              <Text>
+                {t('after')} {vestingData.vestingSchedule}
+              </Text>
+            </Flex>
+          </Box>
+        ) : (
+          <Text
+            textStyle="body-base"
+            color="neutral-6"
+          >
+            n/a
+          </Text>
+        )}
+      </Td>
+    </Tr>
+  );
+}
+
+export function RolesTable() {
+  return (
+    <Box
+      overflow="hidden"
+      borderRadius="0.75rem"
+      border="1px solid"
+      borderColor="white-alpha-08"
+    >
+      <Table variant="unstyled">
+        <RolesHeader />
+        {/* Map Rows */}
+        <Tbody
+          sx={{
+            tr: {
+              transition: 'all ease-out 300ms',
+              borderBottom: '1px solid',
+              borderColor: 'white-alpha-08',
+            },
+            'tr:last-child': {
+              borderBottom: 'none',
+            },
+          }}
+        >
+          <RolesRow
+            roleName="Admin"
+            wearerAddress={zeroAddress}
+          />
+          <RolesRow
+            roleName="CEO"
+            wearerAddress={zeroAddress}
+            payrollData={{
+              payrollAmount: '1000',
+              // ? How is this formatted when received
+              payrollSchedule: 'mo',
+              // ? What asset data is available from Sablier
+              asset: {
+                symbol: 'USDC',
+                name: 'USDC Stablecoin',
+                iconUri:
+                  'https://assets.coingecko.com/coins/images/279/small/usd-coin.png?1594842487',
+                address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              },
+            }}
+            vestingData={{
+              vestingAmount: '1000',
+              // ? How is this formatted when received
+              vestingSchedule: '1yr',
+              // ? What asset data is available from Sablier
+              asset: {
+                symbol: 'USDC',
+                name: 'USDC Stablecoin',
+                iconUri:
+                  'https://assets.coingecko.com/coins/images/279/small/usd-coin.png?1594842487',
+                address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              },
+            }}
+          />
+        </Tbody>
+      </Table>
+    </Box>
+  );
+}

--- a/src/components/pages/Roles/RolesTable.tsx
+++ b/src/components/pages/Roles/RolesTable.tsx
@@ -66,7 +66,7 @@ export function RolesRow({ roleName, wearerAddress, payrollData, vestingData }: 
     chainId: getChainIdFromPrefix(addressPrefix),
   });
   const avatarURL = useAvatar(wearerAddress || zeroAddress);
-  const { t } = useTranslation(['roles']);
+  const { t } = useTranslation(['roles', 'daoCreate']);
   return (
     <Tr
       minHeight="10rem"
@@ -97,8 +97,8 @@ export function RolesRow({ roleName, wearerAddress, payrollData, vestingData }: 
             <Box
               boxSize="3rem"
               borderRadius="100%"
-              bg="rgba(255, 255, 255, 0.04)"
-            ></Box>
+              bg="white-alpha-04"
+            />
           )}
           <Flex
             direction="column"
@@ -118,9 +118,7 @@ export function RolesRow({ roleName, wearerAddress, payrollData, vestingData }: 
           {payrollData ? (
             <Box>
               <Flex
-                textStyle="body-base"
                 alignItems="center"
-                color="white-0"
                 gap="0.25rem"
                 my="0.5rem"
               >
@@ -144,7 +142,10 @@ export function RolesRow({ roleName, wearerAddress, payrollData, vestingData }: 
                 >
                   {payrollData.asset.symbol}
                 </EtherscanLink>
-                <Text>
+                <Text
+                  color="white-0"
+                  textStyle="body-base"
+                >
                   {'/'} {payrollData.payrollSchedule}
                 </Text>
               </Flex>
@@ -154,13 +155,12 @@ export function RolesRow({ roleName, wearerAddress, payrollData, vestingData }: 
               textStyle="body-base"
               color="neutral-6"
             >
-              n/a
+              {t('n/a')}
             </Text>
           )}
         </Flex>
       </Td>
       <Td>
-        {' '}
         {vestingData ? (
           <Box>
             <Flex
@@ -200,7 +200,7 @@ export function RolesRow({ roleName, wearerAddress, payrollData, vestingData }: 
             textStyle="body-base"
             color="neutral-6"
           >
-            n/a
+            {t('n/a')}
           </Text>
         )}
       </Td>

--- a/src/components/ui/cards/Card.tsx
+++ b/src/components/ui/cards/Card.tsx
@@ -10,6 +10,8 @@ export function Card({ children, ...rest }: BoxProps) {
       transition="all ease-out 300ms"
       p="1.5rem"
       borderRadius="0.5rem"
+      border="1px solid"
+      borderColor="neutral-3"
       {...rest}
     >
       {children}

--- a/src/components/ui/cards/Card.tsx
+++ b/src/components/ui/cards/Card.tsx
@@ -1,0 +1,18 @@
+import { Box, BoxProps } from '@chakra-ui/react';
+
+export function Card({ children, ...rest }: BoxProps) {
+  return (
+    <Box
+      minHeight="6.25rem"
+      bg="neutral-2"
+      _hover={{ bg: 'neutral-3' }}
+      _active={{ bg: 'neutral-2', border: '1px solid', borderColor: 'neutral-3' }}
+      transition="all ease-out 300ms"
+      p="1.5rem"
+      borderRadius="0.5rem"
+      {...rest}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/src/components/ui/cards/Card.tsx
+++ b/src/components/ui/cards/Card.tsx
@@ -3,7 +3,6 @@ import { Box, BoxProps } from '@chakra-ui/react';
 export function Card({ children, ...rest }: BoxProps) {
   return (
     <Box
-      minHeight="6.25rem"
       bg="neutral-2"
       _hover={{ bg: 'neutral-3' }}
       _active={{ bg: 'neutral-2', border: '1px solid', borderColor: 'neutral-3' }}

--- a/src/components/ui/page/Header/Avatar.tsx
+++ b/src/components/ui/page/Header/Avatar.tsx
@@ -4,11 +4,12 @@ import { Suspense } from 'react';
 import { useImage } from 'react-image';
 import { getAddress } from 'viem';
 
-export type AvatarSize = 'icon' | 'lg' | 'sm';
+export type AvatarSize = 'icon' | 'lg' | 'sm' | 'xl';
 const avatarSizes: { [size: string]: string } = {
   sm: '1rem',
   icon: '1.5rem',
   lg: '2rem',
+  xl: '3rem',
 };
 
 function BlockieAvatar({ address, size }: { size: AvatarSize; address: string }) {

--- a/src/components/ui/page/Header/PageHeader.tsx
+++ b/src/components/ui/page/Header/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Icon, IconButton, Spacer, Text } from '@chakra-ui/react';
+import { Box, Button, ButtonProps, Flex, Icon, IconButton, Spacer, Text } from '@chakra-ui/react';
 import { Icon as PhosphorIcon } from '@phosphor-icons/react';
 import { ReactNode, useEffect, useState } from 'react';
 import { CONTENT_MAXW } from '../../../../constants/common';
@@ -14,11 +14,15 @@ interface PageHeaderProps {
   address?: string;
   breadcrumbs: Crumb[];
   hasDAOLink?: boolean;
+  // @todo remove buttonVariant in favor of using buttonProps
   buttonVariant?: 'text' | 'secondary';
   ButtonIcon?: PhosphorIcon;
   buttonText?: string;
+  // @todo remove buttonClick in favor of using buttonProps
   buttonClick?: () => void;
   buttonTestId?: string;
+  buttonProps?: ButtonProps;
+  // @todo remove isButtonDisabled in favor of using buttonProps
   isButtonDisabled?: boolean;
   children?: ReactNode;
 }
@@ -37,6 +41,7 @@ function PageHeader({
   buttonClick,
   buttonTestId,
   isButtonDisabled,
+  buttonProps,
   children,
 }: PageHeaderProps) {
   const {
@@ -84,6 +89,7 @@ function PageHeader({
                 data-testid={buttonTestId}
                 variant={buttonVariant}
                 isDisabled={isButtonDisabled}
+                {...buttonProps}
               >
                 {buttonText}
               </Button>
@@ -102,6 +108,7 @@ function PageHeader({
                 size="icon-sm"
                 data-testid={buttonTestId}
                 isDisabled={isButtonDisabled}
+                {...buttonProps}
                 as={Button}
               >
                 {buttonText}

--- a/src/hooks/DAO/useGetDAOName.ts
+++ b/src/hooks/DAO/useGetDAOName.ts
@@ -51,14 +51,10 @@ const getDAOName = async ({
     return latestEvent.args.daoName;
   }
 
-  if (publicClient.chain) {
-    try {
-      const demo = demoData[publicClient.chain.id][address];
-      if (demo && demo.name) {
-        return demo.name;
-      }
-    } catch (e) {
-      // Ignore
+  if (publicClient.chain && demoData[publicClient.chain.id]) {
+    const demo = demoData[publicClient.chain.id][address];
+    if (demo && demo.name) {
+      return demo.name;
     }
   }
 

--- a/src/hooks/DAO/useGetDAOName.ts
+++ b/src/hooks/DAO/useGetDAOName.ts
@@ -52,9 +52,13 @@ const getDAOName = async ({
   }
 
   if (publicClient.chain) {
-    const demo = demoData[publicClient.chain.id][address];
-    if (demo && demo.name) {
-      return demo.name;
+    try {
+      const demo = demoData[publicClient.chain.id][address];
+      if (demo && demo.name) {
+        return demo.name;
+      }
+    } catch (e) {
+      // Ignore
     }
   }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -15,6 +15,7 @@ import NAVIGATION_EN from './locales/en/navigation.json';
 import PROPOSAL_EN from './locales/en/proposal.json';
 import PROPOSAL_METADATA_EN from './locales/en/proposalMetadata.json';
 import PROPOSAL_TEMPLATE_EN from './locales/en/proposalTemplate.json';
+import ROLES_EN from './locales/en/roles.json';
 import SETTINGS_EN from './locales/en/settings.json';
 import STAKE_EN from './locales/en/stake.json';
 import TRANSACTION_EN from './locales/en/transaction.json';
@@ -60,6 +61,7 @@ export const supportedLanguages = {
     settings: SETTINGS_EN,
     stake: STAKE_EN,
     home: HOME_EN,
+    roles: ROLES_EN,
   },
 };
 

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -2,7 +2,6 @@
   "roles": "Roles",
   "role": "Role",
   "member": "Member",
-  
   "noRoles": "You haven’t added any Roles yet. Create one above.",
   "unassigned": "Unassigned",
   "after": "after",

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -6,5 +6,6 @@
   "unassigned": "Unassigned",
   "after": "after",
   "payroll": "Payroll",
-  "vesting": "Vesting"
+  "vesting": "Vesting",
+  "editRoles": "Edit Roles"
 }

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -1,0 +1,4 @@
+{
+  "roles": "Roles",
+  "noRoles": "You haven’t added any Roles yet. Create one above."
+}

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -1,4 +1,6 @@
 {
   "roles": "Roles",
-  "noRoles": "You haven’t added any Roles yet. Create one above."
+  "noRoles": "You haven’t added any Roles yet. Create one above.",
+  "unassigned": "Unassigned",
+  "after": "after"
 }

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -1,6 +1,11 @@
 {
   "roles": "Roles",
+  "role": "Role",
+  "member": "Member",
+  
   "noRoles": "You haven’t added any Roles yet. Create one above.",
   "unassigned": "Unassigned",
-  "after": "after"
+  "after": "after",
+  "payroll": "Payroll",
+  "vesting": "Vesting"
 }

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Show, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
+import { RoleCard } from '../../../../components/pages/Roles/RoleCard';
 import { Card } from '../../../../components/ui/cards/Card';
 import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
 import PageHeader from '../../../../components/ui/page/Header/PageHeader';
@@ -42,6 +43,17 @@ function Roles() {
           </Text>
         </Card>
       )}
+      {/* {hatsTree && ( */}
+      <Show above="md">{/* Table */}</Show>
+      <Show below="md">
+        {/* Role admin not set */}
+        <RoleCard />
+        {/* Role admin set */}
+        <RoleCard />
+        {/* Role admin set with steams */}
+        <RoleCard />
+      </Show>
+      {/* )} */}
     </Box>
   );
 }

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -25,7 +25,7 @@ function Roles() {
           },
         ]}
         buttonVariant="secondary"
-        buttonText="Edit Roles"
+        buttonText={t('editRoles')}
         buttonProps={{
           leftIcon: <Pencil />,
         }}

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -3,6 +3,7 @@ import { Pencil } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { zeroAddress } from 'viem';
 import { RoleCard } from '../../../../components/pages/Roles/RoleCard';
+import { RolesTable } from '../../../../components/pages/Roles/RolesTable';
 import { Card } from '../../../../components/ui/cards/Card';
 import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
 import PageHeader from '../../../../components/ui/page/Header/PageHeader';
@@ -52,7 +53,9 @@ function Roles() {
         </Card>
       )}
       {/* {hatsTree && ( */}
-      <Show above="md">{/* Table */}</Show>
+      <Show above="md">
+        <RolesTable />
+      </Show>
       <Show below="md">
         {/* Role admin not set */}
         <RoleCard

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Show, Text } from '@chakra-ui/react';
+import { Pencil } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { zeroAddress } from 'viem';
 import { RoleCard } from '../../../../components/pages/Roles/RoleCard';
@@ -6,7 +7,6 @@ import { Card } from '../../../../components/ui/cards/Card';
 import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
 import PageHeader from '../../../../components/ui/page/Header/PageHeader';
 import { useRolesState } from '../../../../state/useRolesState';
-
 function Roles() {
   const { hatsTree } = useRolesState();
   const { t } = useTranslation(['roles', 'navigation', 'breadcrumbs', 'dashboard']);
@@ -23,6 +23,13 @@ function Roles() {
             path: '',
           },
         ]}
+        buttonVariant="secondary"
+        buttonText="Edit Roles"
+        buttonProps={{
+          leftIcon: <Pencil />,
+        }}
+        // @todo navigate to edit roles page
+        buttonClick={() => {}}
       />
       {hatsTree === undefined && (
         <Card

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -1,19 +1,46 @@
-import { Box } from '@chakra-ui/react';
+import { Box, Show, Text } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+import { Card } from '../../../../components/ui/cards/Card';
+import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
+import PageHeader from '../../../../components/ui/page/Header/PageHeader';
 import { useRolesState } from '../../../../state/useRolesState';
 
 function Roles() {
   const { hatsTree } = useRolesState();
+  const { t } = useTranslation(['roles', 'navigation', 'breadcrumbs', 'dashboard']);
 
   return (
-    <Box my="1rem">
-      <Box fontSize={'larger'}>Hat Tree</Box>
-      {hatsTree === undefined && <Box>Searching for Hats Tree...</Box>}
-      {hatsTree === null && <Box>No Hats Tree exists for this Safe yet :(</Box>}
-      {hatsTree && (
-        <Box>
-          <Box>We have a Hats Tree! {hatsTree.id}</Box>
-          <Box>It has {hatsTree.hats ? hatsTree.hats.length : 0} Hats</Box>
-        </Box>
+    <Box>
+      <PageHeader
+        title={t('roles')}
+        breadcrumbs={[
+          {
+            terminus: t('roles', {
+              ns: 'roles',
+            }),
+            path: '',
+          },
+        ]}
+      />
+      {hatsTree === undefined && (
+        <Card
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <BarLoader />
+        </Card>
+      )}
+      {hatsTree === null && (
+        <Card>
+          <Text
+            textStyle="body-base"
+            textAlign="center"
+            color="white-alpha-16"
+          >
+            {t('noRoles')}
+          </Text>
+        </Card>
       )}
     </Box>
   );

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -57,20 +57,18 @@ function Roles() {
         <RolesTable />
       </Show>
       <Show below="md">
-        {/* Role admin not set */}
+        {/* (Mocked) Role admin not set */}
         <RoleCard
           roleName="Admin"
           wearerAddress={undefined}
         />
-        {/* Role admin set with steams */}
+        {/* (Mocked) Role set with streams */}
         <RoleCard
           roleName="CEO"
           wearerAddress={zeroAddress}
           payrollData={{
             payrollAmount: '1000',
-            // ? How is this formatted when received
             payrollSchedule: 'mo',
-            // ? What asset data is available from Sablier
             asset: {
               symbol: 'USDC',
               name: 'USDC Stablecoin',
@@ -81,9 +79,22 @@ function Roles() {
           }}
           vestingData={{
             vestingAmount: '1000',
-            // ? How is this formatted when received
             vestingSchedule: '1yr',
-            // ? What asset data is available from Sablier
+            asset: {
+              symbol: 'USDC',
+              name: 'USDC Stablecoin',
+              iconUri:
+                'https://assets.coingecko.com/coins/images/279/small/usd-coin.png?1594842487',
+              address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            },
+          }}
+        />
+        <RoleCard
+          roleName="Code Reviewer"
+          wearerAddress={zeroAddress}
+          payrollData={{
+            payrollAmount: '1',
+            payrollSchedule: 'mo',
             asset: {
               symbol: 'USDC',
               name: 'USDC Stablecoin',

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Show, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
+import { zeroAddress } from 'viem';
 import { RoleCard } from '../../../../components/pages/Roles/RoleCard';
 import { Card } from '../../../../components/ui/cards/Card';
 import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
@@ -33,7 +34,7 @@ function Roles() {
         </Card>
       )}
       {hatsTree === null && (
-        <Card>
+        <Card my="0.5rem">
           <Text
             textStyle="body-base"
             textAlign="center"
@@ -47,11 +48,41 @@ function Roles() {
       <Show above="md">{/* Table */}</Show>
       <Show below="md">
         {/* Role admin not set */}
-        <RoleCard />
-        {/* Role admin set */}
-        <RoleCard />
+        <RoleCard
+          roleName="Admin"
+          wearerAddress={undefined}
+        />
         {/* Role admin set with steams */}
-        <RoleCard />
+        <RoleCard
+          roleName="CEO"
+          wearerAddress={zeroAddress}
+          payrollData={{
+            payrollAmount: '1000',
+            // ? How is this formatted when received
+            payrollSchedule: 'mo',
+            // ? What asset data is available from Sablier
+            asset: {
+              symbol: 'USDC',
+              name: 'USDC Stablecoin',
+              iconUri:
+                'https://assets.coingecko.com/coins/images/279/small/usd-coin.png?1594842487',
+              address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            },
+          }}
+          vestingData={{
+            vestingAmount: '1000',
+            // ? How is this formatted when received
+            vestingSchedule: '1yr',
+            // ? What asset data is available from Sablier
+            asset: {
+              symbol: 'USDC',
+              name: 'USDC Stablecoin',
+              iconUri:
+                'https://assets.coingecko.com/coins/images/279/small/usd-coin.png?1594842487',
+              address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            },
+          }}
+        />
       </Show>
       {/* )} */}
     </Box>


### PR DESCRIPTION
Closes #2046

Adds the first pass at the main components of the Roles index page. 

This includes:
- `RoleCard`: For Mobile, Will also be used for 'Edit' page. Where a few updates will be made in that PR for the badges
- `RolesTable`: For Desktop, Same as above.
- `roles.json`: translation file added

@decentdao/engineering I added a try/catch to `getDAOName` where it hits the `demoData` as it was causing a uncaught error which would prevent this returning. 

@~Reviewers. This doesn't use live data. I mocked setup by passing in props, I expect this to change as it gets integrated with live data. I also did not add a conditional preventing the 'No Hats exists' UI and the Mocked Cards and Table to show together.

Currently there are no click/navigating interactions and will be added in future PRs.