### PR TITLE
Fix proposal count

### DIFF
--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -25,6 +25,7 @@ const nonSnapshotProposals = (proposals: FractalProposal[]) => {
 
 const totalProposalsCount = (
   proposals: FractalProposal[] | null,
+  skippedProposalCount: number,
   type: GovernanceType | undefined,
 ) => {
   if (!proposals) {
@@ -53,8 +54,11 @@ const totalProposalsCount = (
       }, 0);
 
       // Then, return the highest Azorius proposal ID
-      // plus the number of Snapshot proposals.
-      return highestNonSnapshotProposalId + proposals.length - nonSnapshot.length;
+      // plus the number of Snapshot proposals
+      // minus the number of skipped proposals.
+      return (
+        highestNonSnapshotProposalId + proposals.length - nonSnapshot.length - skippedProposalCount
+      );
     }
     default: {
       return 0;
@@ -79,6 +83,7 @@ const nonActiveProposals = (proposals: FractalProposal[]) => {
 
 const allActiveProposalsCount = (
   proposals: FractalProposal[] | null,
+  skippedProposalCount: number,
   type: GovernanceType | undefined,
 ) => {
   if (!proposals) {
@@ -103,7 +108,11 @@ const allActiveProposalsCount = (
       } else {
         // Getting here means that all of the loaded proposals so far are active
         // or there are no non-Snapshot proposals.
-        const totalNonSnapshotProposalsCount = totalProposalsCount(allNonSnapshotProposals, type);
+        const totalNonSnapshotProposalsCount = totalProposalsCount(
+          allNonSnapshotProposals,
+          skippedProposalCount,
+          type,
+        );
         if (totalNonSnapshotProposalsCount === activeNonSnapshotProposals.length) {
           // If we're here, then all of the proposals on this Safe are active, or there are zero of them!
           return activeNonSnapshotProposals.length + activeSnapshotProposals.length;
@@ -123,7 +132,7 @@ export function InfoProposals() {
   const { t } = useTranslation('dashboard');
   const {
     node: { daoAddress },
-    governance: { proposals, type },
+    governance: { proposals, type, skippedProposalCount },
   } = useFractal();
 
   if (!daoAddress || !type) {
@@ -139,11 +148,11 @@ export function InfoProposals() {
     );
   }
 
-  const totalProposalsValue = totalProposalsCount(proposals, type);
+  const totalProposalsValue = totalProposalsCount(proposals, skippedProposalCount, type);
   const totalProposalsDisplay =
     totalProposalsValue === undefined ? '...' : totalProposalsValue.toString();
 
-  const activeProposalsValue = allActiveProposalsCount(proposals, type);
+  const activeProposalsValue = allActiveProposalsCount(proposals, skippedProposalCount, type);
   const activeProposalsDisplay =
     activeProposalsValue === undefined ? '...' : activeProposalsValue.toString();
 

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -187,6 +187,10 @@ export const useAzoriusProposals = () => {
           proposalCreatedEvent.args[1].eq(0) // proposal id 0
         ) {
           // skip
+          action.dispatch({
+            type: FractalGovernanceAction.SKIPPED_A_PROPOSAL,
+            payload: null,
+          });
           continue;
         }
 

--- a/src/providers/App/governance/action.ts
+++ b/src/providers/App/governance/action.ts
@@ -18,6 +18,7 @@ export enum FractalGovernanceAction {
   SET_GOVERNANCE_TYPE = 'SET_GOVERNANCE_TYPE',
   SET_PROPOSALS = 'SET_PROPOSALS',
   SET_AZORIUS_PROPOSAL = 'SET_AZORIUS_PROPOSAL',
+  SKIPPED_A_PROPOSAL = 'SKIPPED_A_PROPOSAL',
   SET_SNAPSHOT_PROPOSALS = 'SET_SNAPSHOT_PROPOSALS',
   SET_PROPOSAL_TEMPLATES = 'SET_PROPOSAL_TEMPLATES',
   SET_STRATEGY = 'SET_STRATEGY',
@@ -68,6 +69,10 @@ export type FractalGovernanceActions =
   | {
       type: FractalGovernanceAction.SET_AZORIUS_PROPOSAL;
       payload: FractalProposal;
+    }
+  | {
+      type: FractalGovernanceAction.SKIPPED_A_PROPOSAL;
+      payload: null;
     }
   | {
       type: FractalGovernanceAction.SET_SNAPSHOT_PROPOSALS;

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -17,6 +17,7 @@ export const initialGovernanceState: FractalGovernance = {
   loadingProposals: true,
   allProposalsLoaded: false,
   proposals: null,
+  skippedProposalCount: 0,
   pendingProposals: null,
   proposalTemplates: null,
   type: undefined,
@@ -79,6 +80,12 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
         pendingProposals: createPendingProposals(state.pendingProposals, [
           action.payload.transactionHash,
         ]),
+      };
+    }
+    case FractalGovernanceAction.SKIPPED_A_PROPOSAL: {
+      return {
+        ...state,
+        skippedProposalCount: state.skippedProposalCount + 1,
       };
     }
     case FractalGovernanceAction.SET_PROPOSAL_TEMPLATES: {

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -302,6 +302,7 @@ export interface Governance {
   allProposalsLoaded: boolean;
   proposals: FractalProposal[] | null;
   pendingProposals: string[] | null;
+  skippedProposalCount: number;
   proposalTemplates?: ProposalTemplate[] | null;
   tokenClaimContract?: ERC20Claim;
 }


### PR DESCRIPTION
Add a property to state to track the number of proposals that are being "skipped", to adjust total proposal count.

This is only relevant for our Decent DAO, which has that broken proposal due to malformed Metadata JSON.

We skip that malformed proposal during processing and don't add it to state at all, but a side effect is that our "proposal count" components on the dashboard rely on the Azorius proposal IDs to determine how many have been created (proposal count equals highest ID + 1).

Since we don't want to acknowledge this malformed proposal in our UI, we need to adjust our total proposal count to account for it.