### PR TITLE
Dictate whether mainnets are supported in-app or not based on environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -48,5 +48,8 @@ VITE_APP_SHUTTER_EON_PUBKEY=0x0e6493bbb4ee8b19aa9b70367685049ff01dc9382c46aed83f
 # index.html and WalletConnect metadata
 VITE_APP_SITE_URL="https://app.dev.decentdao.org"
 
+# Disable mainnets
+VITE_APP_TESTNETS_ONLY=""
+
 # WalletConnect Cloud Project ID
 VITE_APP_WALLET_CONNECT_PROJECT_ID=""

--- a/src/providers/NetworkConfig/NetworkConfigProvider.tsx
+++ b/src/providers/NetworkConfig/NetworkConfigProvider.tsx
@@ -9,7 +9,10 @@ export const NetworkConfigContext = createContext({} as NetworkConfig);
 export const useNetworkConfig = (): NetworkConfig =>
   useContext(NetworkConfigContext as Context<NetworkConfig>);
 
-export const supportedNetworks = Object.values(networks).sort((a, b) => a.order - b.order);
+export const supportedNetworks = Object.values(networks)
+  .filter(n => (import.meta.env.VITE_APP_TESTNETS_ONLY ? !n.isMainnet : true))
+  .sort((a, b) => a.order - b.order);
+
 export const moralisSupportedChainIds = supportedNetworks
   .filter(network => network.moralisSupported)
   .map(network => network.chain.id);

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -29,6 +29,7 @@ const SAFE_VERSION = '1.3.0';
 const baseConfig: NetworkConfig = {
   order: 10,
   chain: base,
+  isMainnet: true,
   moralisSupported: true,
   rpcEndpoint: `https://base-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_BASE_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-base.safe.global',

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -29,6 +29,7 @@ const SAFE_VERSION = '1.3.0';
 const mainnetConfig: NetworkConfig = {
   order: 0,
   chain: mainnet,
+  isMainnet: true,
   moralisSupported: true,
   rpcEndpoint: `https://eth-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_MAINNET_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-mainnet.safe.global',

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -29,6 +29,7 @@ const SAFE_VERSION = '1.3.0';
 const optimismConfig: NetworkConfig = {
   order: 15,
   chain: optimism,
+  isMainnet: true,
   moralisSupported: true,
   rpcEndpoint: `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_OPTIMISM_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-optimism.safe.global',

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -29,6 +29,7 @@ const SAFE_VERSION = '1.3.0';
 const polygonConfig: NetworkConfig = {
   order: 20,
   chain: polygon,
+  isMainnet: true,
   moralisSupported: true,
   rpcEndpoint: `https://polygon-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_POLYGON_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-polygon.safe.global',

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -29,6 +29,7 @@ const SAFE_VERSION = '1.3.0';
 const sepoliaConfig: NetworkConfig = {
   order: 30,
   chain: sepolia,
+  isMainnet: false,
   moralisSupported: true,
   rpcEndpoint: `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_SEPOLIA_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-sepolia.safe.global',

--- a/src/providers/NetworkConfig/web3-modal.config.ts
+++ b/src/providers/NetworkConfig/web3-modal.config.ts
@@ -7,8 +7,6 @@ import { Chain } from 'wagmi/chains';
 import { NetworkConfig } from '../../types/network';
 import { supportedNetworks } from './NetworkConfigProvider';
 
-const supportedWagmiChains = supportedNetworks.map(network => network.chain);
-
 export const walletConnectProjectId = import.meta.env.VITE_APP_WALLET_CONNECT_PROJECT_ID;
 export const queryClient = new QueryClient();
 
@@ -28,7 +26,7 @@ const transportsReducer = (accumulator: Record<string, HttpTransport>, network: 
 };
 
 export const wagmiConfig = defaultWagmiConfig({
-  chains: supportedWagmiChains as [Chain, ...Chain[]],
+  chains: supportedNetworks.map(network => network.chain) as [Chain, ...Chain[]],
   projectId: walletConnectProjectId,
   metadata: wagmiMetadata,
   transports: supportedNetworks.reduce(transportsReducer, {}),

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -10,6 +10,7 @@ export type Providers =
 export type NetworkConfig = {
   order: number; // any arbitrary integer, used to "order" the networks in the dropdown
   chain: Chain;
+  isMainnet: boolean;
   moralisSupported: boolean;
   rpcEndpoint: string;
   safeBaseURL: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -27,6 +27,8 @@ interface ImportMetaEnv {
 
   readonly VITE_APP_SITE_URL: string;
 
+  readonly VITE_APP_TESTNETS_ONLY: boolean;
+
   readonly VITE_APP_WALLET_CONNECT_PROJECT_ID: string;
 }
 


### PR DESCRIPTION
After speaking with @SpookyAction-BTC, (and probably should be speaking with @decentdao/product and @decentdao/engineering about it too), it seemed most appropriate to disable all "non-testnet" networks on the dev site.

In practice this means that _only_ Sepolia is supported on dev.

Reasoning:
- we have half-baked functionality on dev (specifically, things that will break for users if they attempt to use them)
- Therefore we shouldn't let people using DAOs on networks with Real Economic Value to do things that are potentially breaking.

Developer note: I've added the env var to dev site on Netlify already.