### PR TITLE
`Roles` | Various role create form bugs

### DIFF
--- a/src/components/pages/Roles/forms/RoleFormCreateProposal.tsx
+++ b/src/components/pages/Roles/forms/RoleFormCreateProposal.tsx
@@ -19,7 +19,7 @@ import { RoleFormValues, RoleValue } from '../types';
 export default function RoleFormCreateProposal({ close }: { close: () => void }) {
   const [drawerViewingRole, setDrawerViewingRole] = useState<RoleValue>();
   const { t } = useTranslation(['modals', 'common', 'proposal']);
-  const { values, handleSubmit, isSubmitting } = useFormikContext<RoleFormValues>();
+  const { values, isSubmitting, submitForm } = useFormikContext<RoleFormValues>();
   const editedRoles = useMemo(() => {
     return values.hats.filter(hat => !!hat.editedRole);
   }, [values.hats]);
@@ -142,7 +142,7 @@ export default function RoleFormCreateProposal({ close }: { close: () => void })
           {t('cancel', { ns: 'common' })}
         </Button>
         <Button
-          onClick={() => handleSubmit()}
+          onClick={submitForm}
           isDisabled={isSubmitting}
         >
           {t('sendAssetsSubmit')}

--- a/src/components/pages/Roles/forms/RoleFormInfo.tsx
+++ b/src/components/pages/Roles/forms/RoleFormInfo.tsx
@@ -20,15 +20,22 @@ export default function RoleFormInfo() {
     >
       <FormControl>
         <Field name={`roleEditing.name`}>
-          {({ field, form: { setFieldValue }, meta }: FieldProps<string, RoleFormValues>) => (
+          {({
+            field,
+            form: { setFieldValue, setFieldTouched },
+            meta,
+          }: FieldProps<string, RoleFormValues>) => (
             <LabelWrapper
               label="Role Name"
-              errorMessage={meta.error}
+              errorMessage={meta.touched && meta.error ? meta.error : undefined}
             >
               <InputComponent
                 value={field.value}
                 onChange={e => {
                   setFieldValue(field.name, e.target.value);
+                }}
+                onBlur={() => {
+                  setFieldTouched(field.name, true);
                 }}
                 testId="role-name"
                 placeholder="Role Name"
@@ -46,10 +53,14 @@ export default function RoleFormInfo() {
       </FormControl>
       <FormControl>
         <Field name={`roleEditing.description`}>
-          {({ field, form: { setFieldValue }, meta }: FieldProps<string, RoleFormValues>) => (
+          {({
+            field,
+            form: { setFieldValue, setFieldTouched },
+            meta,
+          }: FieldProps<string, RoleFormValues>) => (
             <LabelWrapper
               label="Description"
-              errorMessage={meta.error}
+              errorMessage={meta.touched && meta.error ? meta.error : undefined}
             >
               <TextareaComponent
                 value={field.value}
@@ -65,6 +76,9 @@ export default function RoleFormInfo() {
                 }}
                 textAreaProps={{
                   h: '12rem',
+                  onBlur: () => {
+                    setFieldTouched(field.name, true);
+                  },
                 }}
               />
             </LabelWrapper>
@@ -73,13 +87,20 @@ export default function RoleFormInfo() {
       </FormControl>
       <FormControl>
         <Field name={`roleEditing.wearer`}>
-          {({ field, form: { setFieldValue }, meta }: FieldProps<string, RoleFormValues>) => (
+          {({
+            field,
+            form: { setFieldValue, setFieldTouched },
+            meta,
+          }: FieldProps<string, RoleFormValues>) => (
             <LabelWrapper
               label="Member"
               errorMessage={meta.error}
             >
               <AddressInput
                 value={field.value}
+                onBlur={() => {
+                  setFieldTouched(field.name, true);
+                }}
                 onChange={e => {
                   setFieldValue(field.name, e.target.value);
                 }}

--- a/src/components/pages/Roles/forms/RoleFormInfo.tsx
+++ b/src/components/pages/Roles/forms/RoleFormInfo.tsx
@@ -94,7 +94,7 @@ export default function RoleFormInfo() {
           }: FieldProps<string, RoleFormValues>) => (
             <LabelWrapper
               label="Member"
-              errorMessage={meta.error}
+              errorMessage={meta.touched && meta.error ? meta.error : undefined}
             >
               <AddressInput
                 value={field.value}

--- a/src/hooks/schemas/common/useValidationAddress.tsx
+++ b/src/hooks/schemas/common/useValidationAddress.tsx
@@ -84,12 +84,17 @@ export const useValidationAddress = () => {
       test: async function (address: string | undefined) {
         if (!address) return false;
         setIsValidating(true);
-        const { validation } = await validateAddress({ signerOrProvider, address });
-        if (validation.isValidAddress) {
-          addressValidationMap.current.set(address, validation);
+        try {
+          const { validation } = await validateAddress({ signerOrProvider, address });
+          if (validation.isValidAddress) {
+            addressValidationMap.current.set(address, validation);
+          }
+          return validation.isValidAddress;
+        } catch (error) {
+          return false;
+        } finally {
+          setIsValidating(false);
         }
-        setIsValidating(false);
-        return validation.isValidAddress;
       },
     };
   }, [signerOrProvider, addressValidationMap, t]);

--- a/src/hooks/schemas/roles/useRolesSchema.ts
+++ b/src/hooks/schemas/roles/useRolesSchema.ts
@@ -1,10 +1,13 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 import { RoleValue } from '../../../components/pages/Roles/types';
 import { useValidationAddress } from '../common/useValidationAddress';
 
 export const useRolesSchema = () => {
   const { addressValidationTest } = useValidationAddress();
+  const { t } = useTranslation(['roles']);
+
   const rolesSchema = useMemo(
     () =>
       Yup.object().shape({
@@ -15,13 +18,13 @@ export const useRolesSchema = () => {
             is: (roleEditing: RoleValue) => roleEditing !== undefined,
             then: _schema =>
               _schema.shape({
-                name: Yup.string().required('Role name is required'),
-                description: Yup.string().required('Role description is required'),
-                wearer: Yup.string().required('Member is required').test(addressValidationTest),
+                name: Yup.string().required(t('roleNameRequired')),
+                description: Yup.string().required(t('roleDescriptionRequired')),
+                wearer: Yup.string().required(t('roleMemberRequired')).test(addressValidationTest),
               }),
           }),
       }),
-    [addressValidationTest],
+    [addressValidationTest, t],
   );
   return { rolesSchema };
 };

--- a/src/hooks/schemas/roles/useRolesSchema.ts
+++ b/src/hooks/schemas/roles/useRolesSchema.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import * as Yup from 'yup';
+import { EditedRole } from '../../../components/pages/Roles/types';
 import { useValidationAddress } from '../common/useValidationAddress';
 
 export const useRolesSchema = () => {
@@ -7,11 +8,23 @@ export const useRolesSchema = () => {
   const rolesSchema = useMemo(
     () =>
       Yup.object().shape({
-        roleEditing: Yup.object().shape({
-          name: Yup.string().required('Role name is required'),
-          description: Yup.string().required('Role description is required'),
-          wearer: Yup.string().required('Member is required').test(addressValidationTest),
-        }),
+        roleEditing: Yup.object()
+          .shape({
+            name: Yup.string(),
+            description: Yup.string(),
+            wearer: Yup.string(),
+          })
+          .when({
+            is: (roleEditing: EditedRole) => {
+              return !!roleEditing;
+            },
+            then: _schema =>
+              _schema.shape({
+                name: Yup.string().required('Role name is required'),
+                description: Yup.string().required('Role description is required'),
+                wearer: Yup.string().required('Member is required').test(addressValidationTest),
+              }),
+          }),
       }),
     [addressValidationTest],
   );

--- a/src/hooks/schemas/roles/useRolesSchema.ts
+++ b/src/hooks/schemas/roles/useRolesSchema.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import * as Yup from 'yup';
-import { EditedRole } from '../../../components/pages/Roles/types';
+import { RoleValue } from '../../../components/pages/Roles/types';
 import { useValidationAddress } from '../common/useValidationAddress';
 
 export const useRolesSchema = () => {
@@ -9,15 +9,9 @@ export const useRolesSchema = () => {
     () =>
       Yup.object().shape({
         roleEditing: Yup.object()
-          .shape({
-            name: Yup.string(),
-            description: Yup.string(),
-            wearer: Yup.string(),
-          })
+          .default(undefined)
           .when({
-            is: (roleEditing: EditedRole) => {
-              return !!roleEditing;
-            },
+            is: (roleEditing: RoleValue) => roleEditing !== undefined,
             then: _schema =>
               _schema.shape({
                 name: Yup.string().required('Role name is required'),

--- a/src/hooks/schemas/roles/useRolesSchema.ts
+++ b/src/hooks/schemas/roles/useRolesSchema.ts
@@ -10,6 +10,7 @@ export const useRolesSchema = () => {
       Yup.object().shape({
         roleEditing: Yup.object()
           .default(undefined)
+          .nullable()
           .when({
             is: (roleEditing: RoleValue) => roleEditing !== undefined,
             then: _schema =>

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -27,5 +27,8 @@
   "updatedHats": "Update {{count}} role",
   "updatedHats_other": "Update {{count}} roles",
   "removedHats": "Remove {{count}} role",
-  "removedHats_other": "Remove {{count}} roles"
+  "removedHats_other": "Remove {{count}} roles",
+  "roleNameRequired": "Role name is required",
+  "roleDescriptionRequired": "Role description is required",
+  "roleMemberRequired": "Member is required"
 }

--- a/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
@@ -125,17 +125,15 @@ export default function RoleEditDetails() {
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
   const navigate = useNavigate();
-  const { values } = useFormikContext<RoleFormValues>();
   const [searchParams] = useSearchParams();
   const hatEditingId = searchParams.get('hatId');
-  const hatIndex = values.hats.findIndex(h => h.id === hatEditingId);
   if (!isHex(hatEditingId)) return null;
   if (!daoAddress) return null;
   if (hatEditingId === undefined) return null;
 
   return (
     <FieldArray name="hats">
-      {({ remove, push }) => (
+      {({ push }) => (
         <>
           <Show below="md">
             <Portal>
@@ -159,9 +157,6 @@ export default function RoleEditDetails() {
                     alignItems="center"
                     aria-label={t('editRoles')}
                     onClick={() => {
-                      if (hatIndex === -1) {
-                        remove(hatIndex);
-                      }
                       navigate(DAO_ROUTES.rolesEdit.relative(addressPrefix, daoAddress));
                     }}
                   >
@@ -194,9 +189,6 @@ export default function RoleEditDetails() {
               isOpen
               placement="right"
               onClose={() => {
-                if (hatIndex === -1) {
-                  remove(hatIndex);
-                }
                 navigate(DAO_ROUTES.rolesEdit.relative(addressPrefix, daoAddress));
               }}
             >

--- a/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
@@ -125,15 +125,17 @@ export default function RoleEditDetails() {
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
   const navigate = useNavigate();
+  const { values } = useFormikContext<RoleFormValues>();
   const [searchParams] = useSearchParams();
   const hatEditingId = searchParams.get('hatId');
+  const hatIndex = values.hats.findIndex(h => h.id === hatEditingId);
   if (!isHex(hatEditingId)) return null;
   if (!daoAddress) return null;
   if (hatEditingId === undefined) return null;
 
   return (
     <FieldArray name="hats">
-      {({ push }) => (
+      {({ remove, push }) => (
         <>
           <Show below="md">
             <Portal>
@@ -157,6 +159,9 @@ export default function RoleEditDetails() {
                     alignItems="center"
                     aria-label={t('editRoles')}
                     onClick={() => {
+                      if (hatIndex === -1) {
+                        remove(hatIndex);
+                      }
                       navigate(DAO_ROUTES.rolesEdit.relative(addressPrefix, daoAddress));
                     }}
                   >


### PR DESCRIPTION
Fixes #2143
- This is fixed by fixing the schema to work properly preventing clicking Save button when its a invalid address

---
Fixes #2144 
- There was a problem with the structure of the schema. 
  - `.default(undefined)`: Adding this stopped Yup from changing the initial value from `undefined` to `{}` which was causing the `is` conditional to be true when it should be undefined
  - `.nullable()`: allows for the `setFieldValue(undefined)` that we are using to actually clear the field.

---
## Other Fixes
- I also noticed that there was some left over 'remove' code that no longer is needed and causing a bug.
- I also re-added the `meta.touched` and got that working properly by using the `onBlur` prop