### PR TITLE
Don't refetch token balances every 20 seconds

### DIFF
--- a/src/hooks/DAO/loaders/useDecentTreasury.ts
+++ b/src/hooks/DAO/loaders/useDecentTreasury.ts
@@ -5,7 +5,6 @@ import useBalancesAPI from '../../../providers/App/hooks/useBalancesAPI';
 import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
 import { TreasuryAction } from '../../../providers/App/treasury/action';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
-import { useUpdateTimer } from '../../utils/useUpdateTimer';
 
 export const useDecentTreasury = () => {
   // tracks the current valid DAO address / chain; helps prevent unnecessary calls
@@ -18,8 +17,6 @@ export const useDecentTreasury = () => {
   const { getTokenBalances, getNFTBalances } = useBalancesAPI();
 
   const { chain } = useNetworkConfig();
-
-  const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
 
   const loadTreasury = useCallback(async () => {
     if (!daoAddress || !safeAPI) {
@@ -58,13 +55,12 @@ export const useDecentTreasury = () => {
   useEffect(() => {
     if (daoAddress && chain.id + daoAddress !== loadKey.current) {
       loadKey.current = chain.id + daoAddress;
-      setMethodOnInterval(loadTreasury);
+      loadTreasury();
     }
     if (!daoAddress) {
       loadKey.current = null;
-      clearIntervals();
     }
-  }, [chain, daoAddress, loadTreasury, setMethodOnInterval, clearIntervals]);
+  }, [chain, daoAddress, loadTreasury]);
 
   return;
 };


### PR DESCRIPTION
Closes #2185. 

We were using up our allotted Netlify Functions invocations much faster than anticipated (and are almost past our "free tier" usage), and a likely culprit was the fact that when a Safe is loaded, we re-fetch token/nft balances every 20 seconds.

This seems excessive.

This PR removes that timer and simply fetches balances at page load once, then no more.