### PR TITLE
Improve token/nft balance caching

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,9 @@
 # Minutes to cache token balances for address
 BALANCES_CACHE_INTERVAL_MINUTES=""
 
+# Minutes to give Moralis to index new addresses
+BALANCES_MORALIS_INDEX_DELAY_MINUTES=""
+
 # Moralis API key
 MORALIS_API_KEY=""
 

--- a/netlify/functions/balances.mts
+++ b/netlify/functions/balances.mts
@@ -1,0 +1,108 @@
+import { getStore } from '@netlify/blobs';
+import type { Store } from '@netlify/blobs';
+import Moralis from 'moralis';
+import { isAddress } from 'viem';
+import type { Address } from 'viem';
+import { moralisSupportedChainIds } from '../../src/providers/NetworkConfig/NetworkConfigProvider';
+
+export interface BalanceDataWithMetadata<T> {
+  data: T[];
+  metadata: {
+    fetched: number;
+    firstFetched: number;
+  };
+}
+
+export async function getBalances<T>(
+  request: Request,
+  fetchFromStore: (store: Store, storeKey: string) => Promise<BalanceDataWithMetadata<T> | null>,
+  fetchFromMoralis: (scope: { chain: string; address: Address }) => Promise<T[]>,
+) {
+  if (!process.env.MORALIS_API_KEY) {
+    console.error('Moralis API key is missing');
+    return Response.json({ error: 'Internal server error' }, { status: 503 });
+  }
+
+  if (!process.env.BALANCES_CACHE_INTERVAL_MINUTES) {
+    console.error('BALANCES_CACHE_INTERVAL_MINUTES is not set');
+    return Response.json({ error: 'Internal server error' }, { status: 503 });
+  }
+
+  if (!process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) {
+    console.error('BALANCES_MORALIS_INDEX_DELAY_MINUTES is not set');
+    return Response.json({ error: 'Internal server error' }, { status: 503 });
+  }
+
+  const requestSearchParams = new URL(request.url).searchParams;
+  const addressParam = requestSearchParams.get('address');
+
+  if (!addressParam) {
+    return Response.json({ error: 'Address missing from request' }, { status: 400 });
+  }
+
+  if (!isAddress(addressParam)) {
+    return Response.json({ error: 'Provided address is not a valid address' }, { status: 400 });
+  }
+
+  const networkParam = requestSearchParams.get('network');
+  if (!networkParam) {
+    return Response.json({ error: 'Network missing from request' }, { status: 400 });
+  }
+
+  const chainId = parseInt(networkParam);
+  if (!moralisSupportedChainIds.includes(chainId)) {
+    return Response.json({ error: 'Requested network is not supported' }, { status: 400 });
+  }
+
+  const tokensStore = getStore(`moralis-balances-tokens-${networkParam}`);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const cacheTimeSeconds = parseInt(process.env.BALANCES_CACHE_INTERVAL_MINUTES) * 60;
+  const moralisIndexDelaySeconds = parseInt(process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) * 60;
+  const storeKey = addressParam;
+  try {
+    const balances = await fetchFromStore(tokensStore, storeKey);
+
+    // Determine whether to return cached token balances or fetch new data from Moralis API:
+    // 1. Check if the cached data is still valid:
+    //    - The cache is considered valid if the 'fetched' timestamp plus the cache interval is greater than the current time ('nowSeconds').
+    // 2. Validate the data:
+    //    - Data is considered valid if:
+    //      a. The 'firstFetched' timestamp plus the Moralis index delay is less than the current time, meaning the delay period has passed.
+    //      b. The data array is not empty, indicating that valid data was previously fetched.
+    //      c. If the data array is empty, but the 'firstFetched' timestamp is within the Moralis index delay period, the cache is not yet considered valid.
+    // If the cached data is valid according to these checks, return the cached data. Otherwise, proceed to fetch new data from the Moralis API.
+    if (
+      balances &&
+      balances.metadata.fetched + cacheTimeSeconds > nowSeconds &&
+      (balances.metadata.firstFetched + moralisIndexDelaySeconds < nowSeconds ||
+        (balances.data.length > 0 &&
+          balances.metadata.firstFetched + moralisIndexDelaySeconds > nowSeconds))
+    ) {
+      return Response.json({ data: balances.data });
+    }
+
+    if (!Moralis.Core.isStarted) {
+      await Moralis.start({
+        apiKey: process.env.MORALIS_API_KEY,
+      });
+    }
+
+    let mappedData: T[] = [];
+
+    try {
+      mappedData = await fetchFromMoralis({ chain: chainId.toString(), address: addressParam });
+
+      const firstFetched = balances?.metadata.firstFetched ?? nowSeconds;
+      await tokensStore.setJSON(storeKey, mappedData, {
+        metadata: { fetched: nowSeconds, firstFetched },
+      });
+    } catch (e) {
+      console.error('Unexpected error while fetching balances', e);
+    }
+
+    return Response.json({ data: mappedData });
+  } catch (e) {
+    console.error(e);
+    return Response.json({ error: 'Unexpected error while fetching balances' }, { status: 503 });
+  }
+}

--- a/netlify/functions/nftBalances.mts
+++ b/netlify/functions/nftBalances.mts
@@ -22,7 +22,6 @@ export default async function getNftBalances(request: Request) {
         ) as unknown as NFTBalance,
     );
 
-    console.log({ mappedNftsData });
     return mappedNftsData;
   };
 

--- a/netlify/functions/nftBalances.mts
+++ b/netlify/functions/nftBalances.mts
@@ -9,6 +9,7 @@ type NFTBalancesWithMetadata = {
   data: NFTBalance[];
   metadata: {
     fetched: number;
+    firstFetched: number;
   };
 };
 
@@ -20,6 +21,11 @@ export default async function getNftBalances(request: Request) {
 
   if (!process.env.BALANCES_CACHE_INTERVAL_MINUTES) {
     console.error('BALANCES_CACHE_INTERVAL_MINUTES is not set');
+    return Response.json({ error: 'Error while fetching prices' }, { status: 503 });
+  }
+
+  if (!process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) {
+    console.error('BALANCES_MORALIS_INDEX_DELAY_MINUTES is not set');
     return Response.json({ error: 'Error while fetching prices' }, { status: 503 });
   }
 
@@ -47,49 +53,60 @@ export default async function getNftBalances(request: Request) {
   const nftsStore = getStore(`moralis-balances-nfts-${networkParam}`);
   const nowSeconds = Math.floor(Date.now() / 1000);
   const cacheTimeSeconds = parseInt(process.env.BALANCES_CACHE_INTERVAL_MINUTES) * 60;
-  const config = { nowSeconds, cacheTimeSeconds };
-  const storeKey = `${networkParam}/${addressParam}`;
+  const moralisIndexDelaySeconds = parseInt(process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) * 60;
+  const config = { nowSeconds, cacheTimeSeconds, moralisIndexDelaySeconds };
+  const storeKey = addressParam;
   try {
     const balances = await (nftsStore.getWithMetadata(storeKey, {
       type: 'json',
     }) as Promise<NFTBalancesWithMetadata> | null);
 
+    // Determine whether to return cached token balances or fetch new data from Moralis API:
+    // 1. Check if the cached data is still valid:
+    //    - The cache is considered valid if the 'fetched' timestamp plus the cache interval is greater than the current time ('nowSeconds').
+    // 2. Validate the data:
+    //    - Data is considered valid if:
+    //      a. The 'firstFetched' timestamp plus the Moralis index delay is less than the current time, meaning the delay period has passed.
+    //      b. The data array is not empty, indicating that valid data was previously fetched.
+    //      c. If the data array is empty, but the 'firstFetched' timestamp is within the Moralis index delay period, the cache is not yet considered valid.
+    // If the cached data is valid according to these checks, return the cached data. Otherwise, proceed to fetch new data from the Moralis API.
     if (
-      balances?.metadata.fetched &&
-      balances.metadata.fetched + config.cacheTimeSeconds > config.nowSeconds
+      balances &&
+      balances.metadata.fetched + config.cacheTimeSeconds > config.nowSeconds &&
+      (balances.metadata.firstFetched + config.moralisIndexDelaySeconds < config.nowSeconds ||
+        (balances.data.length > 0 &&
+          balances.metadata.firstFetched + config.moralisIndexDelaySeconds > config.nowSeconds))
     ) {
       return Response.json({ data: balances.data });
-    } else {
-      if (!Moralis.Core.isStarted) {
-        await Moralis.start({
-          apiKey: process.env.MORALIS_API_KEY,
-        });
-      }
-      let mappedNftsData: NFTBalance[] = [];
-
-      let nftsFetched = false;
-      try {
-        const nftsResponse = await Moralis.EvmApi.nft.getWalletNFTs({
-          chain: chainId.toString(),
-          address: addressParam,
-        });
-        mappedNftsData = nftsResponse.result.map(nftBalance =>
-          camelCaseKeys<ReturnType<typeof nftBalance.toJSON>>(nftBalance.toJSON()),
-        );
-        nftsFetched = true;
-      } catch (e) {
-        console.error('Error while fetching address NFTs', e);
-        nftsFetched = false;
-      }
-
-      if (nftsFetched) {
-        await nftsStore.setJSON(storeKey, mappedNftsData, {
-          metadata: { fetched: config.nowSeconds },
-        });
-      }
-
-      return Response.json({ data: mappedNftsData });
     }
+
+    if (!Moralis.Core.isStarted) {
+      await Moralis.start({
+        apiKey: process.env.MORALIS_API_KEY,
+      });
+    }
+
+    let mappedNftsData: NFTBalance[] = [];
+
+    try {
+      const nftsResponse = await Moralis.EvmApi.nft.getWalletNFTs({
+        chain: chainId.toString(),
+        address: addressParam,
+      });
+
+      mappedNftsData = nftsResponse.result.map(nftBalance =>
+        camelCaseKeys<ReturnType<typeof nftBalance.toJSON>>(nftBalance.toJSON()),
+      );
+
+      const firstFetched = balances?.metadata.firstFetched ?? config.nowSeconds;
+      await nftsStore.setJSON(storeKey, mappedNftsData, {
+        metadata: { fetched: config.nowSeconds, firstFetched },
+      });
+    } catch (e) {
+      console.error('Error while fetching address NFTs', e);
+    }
+
+    return Response.json({ data: mappedNftsData });
   } catch (e) {
     console.error(e);
     return Response.json(

--- a/netlify/functions/nftBalances.mts
+++ b/netlify/functions/nftBalances.mts
@@ -3,7 +3,7 @@ import Moralis from 'moralis';
 import type { Address } from 'viem';
 import type { NFTBalance } from '../../src/types';
 import { camelCaseKeys } from '../../src/utils/dataFormatter';
-import { BalanceDataWithMetadata, getBalances } from './balances.mts';
+import { BalanceDataWithMetadata, getBalances } from '../shared/moralisBalances.mts';
 
 export default async function getNftBalances(request: Request) {
   const fetchFromStore = async (store: Store, storeKey: string) => {
@@ -22,8 +22,9 @@ export default async function getNftBalances(request: Request) {
         ) as unknown as NFTBalance,
     );
 
+    console.log({ mappedNftsData });
     return mappedNftsData;
   };
 
-  return getBalances(request, fetchFromStore, fetchFromMoralis);
+  return getBalances(request, 'nfts', fetchFromStore, fetchFromMoralis);
 }

--- a/netlify/functions/nftBalances.mts
+++ b/netlify/functions/nftBalances.mts
@@ -1,117 +1,29 @@
-import { getStore } from '@netlify/blobs';
+import type { Store } from '@netlify/blobs';
 import Moralis from 'moralis';
-import { isAddress } from 'viem';
-import { moralisSupportedChainIds } from '../../src/providers/NetworkConfig/NetworkConfigProvider';
+import type { Address } from 'viem';
 import type { NFTBalance } from '../../src/types';
 import { camelCaseKeys } from '../../src/utils/dataFormatter';
-
-type NFTBalancesWithMetadata = {
-  data: NFTBalance[];
-  metadata: {
-    fetched: number;
-    firstFetched: number;
-  };
-};
+import { BalanceDataWithMetadata, getBalances } from './balances.mts';
 
 export default async function getNftBalances(request: Request) {
-  if (!process.env.MORALIS_API_KEY) {
-    console.error('Moralis API key is missing');
-    return Response.json({ error: 'Error while fetching token balances' }, { status: 503 });
-  }
-
-  if (!process.env.BALANCES_CACHE_INTERVAL_MINUTES) {
-    console.error('BALANCES_CACHE_INTERVAL_MINUTES is not set');
-    return Response.json({ error: 'Error while fetching prices' }, { status: 503 });
-  }
-
-  if (!process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) {
-    console.error('BALANCES_MORALIS_INDEX_DELAY_MINUTES is not set');
-    return Response.json({ error: 'Error while fetching prices' }, { status: 503 });
-  }
-
-  const requestSearchParams = new URL(request.url).searchParams;
-  const addressParam = requestSearchParams.get('address');
-
-  if (!addressParam) {
-    return Response.json({ error: 'Address missing from request' }, { status: 400 });
-  }
-
-  if (!isAddress(addressParam)) {
-    return Response.json({ error: 'Provided address is not a valid address' }, { status: 400 });
-  }
-
-  const networkParam = requestSearchParams.get('network');
-  if (!networkParam) {
-    return Response.json({ error: 'Network missing from request' }, { status: 400 });
-  }
-
-  const chainId = parseInt(networkParam);
-  if (!moralisSupportedChainIds.includes(chainId)) {
-    return Response.json({ error: 'Requested network is not supported' }, { status: 400 });
-  }
-
-  const nftsStore = getStore(`moralis-balances-nfts-${networkParam}`);
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const cacheTimeSeconds = parseInt(process.env.BALANCES_CACHE_INTERVAL_MINUTES) * 60;
-  const moralisIndexDelaySeconds = parseInt(process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) * 60;
-  const config = { nowSeconds, cacheTimeSeconds, moralisIndexDelaySeconds };
-  const storeKey = addressParam;
-  try {
-    const balances = await (nftsStore.getWithMetadata(storeKey, {
+  const fetchFromStore = async (store: Store, storeKey: string) => {
+    return store.getWithMetadata(storeKey, {
       type: 'json',
-    }) as Promise<NFTBalancesWithMetadata> | null);
+    }) as Promise<BalanceDataWithMetadata<NFTBalance>> | null;
+  };
 
-    // Determine whether to return cached token balances or fetch new data from Moralis API:
-    // 1. Check if the cached data is still valid:
-    //    - The cache is considered valid if the 'fetched' timestamp plus the cache interval is greater than the current time ('nowSeconds').
-    // 2. Validate the data:
-    //    - Data is considered valid if:
-    //      a. The 'firstFetched' timestamp plus the Moralis index delay is less than the current time, meaning the delay period has passed.
-    //      b. The data array is not empty, indicating that valid data was previously fetched.
-    //      c. If the data array is empty, but the 'firstFetched' timestamp is within the Moralis index delay period, the cache is not yet considered valid.
-    // If the cached data is valid according to these checks, return the cached data. Otherwise, proceed to fetch new data from the Moralis API.
-    if (
-      balances &&
-      balances.metadata.fetched + config.cacheTimeSeconds > config.nowSeconds &&
-      (balances.metadata.firstFetched + config.moralisIndexDelaySeconds < config.nowSeconds ||
-        (balances.data.length > 0 &&
-          balances.metadata.firstFetched + config.moralisIndexDelaySeconds > config.nowSeconds))
-    ) {
-      return Response.json({ data: balances.data });
-    }
+  const fetchFromMoralis = async (scope: { chain: string; address: Address }) => {
+    const nftsResponse = await Moralis.EvmApi.nft.getWalletNFTs(scope);
 
-    if (!Moralis.Core.isStarted) {
-      await Moralis.start({
-        apiKey: process.env.MORALIS_API_KEY,
-      });
-    }
-
-    let mappedNftsData: NFTBalance[] = [];
-
-    try {
-      const nftsResponse = await Moralis.EvmApi.nft.getWalletNFTs({
-        chain: chainId.toString(),
-        address: addressParam,
-      });
-
-      mappedNftsData = nftsResponse.result.map(nftBalance =>
-        camelCaseKeys<ReturnType<typeof nftBalance.toJSON>>(nftBalance.toJSON()),
-      );
-
-      const firstFetched = balances?.metadata.firstFetched ?? config.nowSeconds;
-      await nftsStore.setJSON(storeKey, mappedNftsData, {
-        metadata: { fetched: config.nowSeconds, firstFetched },
-      });
-    } catch (e) {
-      console.error('Error while fetching address NFTs', e);
-    }
-
-    return Response.json({ data: mappedNftsData });
-  } catch (e) {
-    console.error(e);
-    return Response.json(
-      { error: 'Unexpected error while fetching NFTs balances' },
-      { status: 503 },
+    const mappedNftsData = nftsResponse.result.map(
+      nftBalance =>
+        camelCaseKeys<ReturnType<typeof nftBalance.toJSON>>(
+          nftBalance.toJSON(),
+        ) as unknown as NFTBalance,
     );
-  }
+
+    return mappedNftsData;
+  };
+
+  return getBalances(request, fetchFromStore, fetchFromMoralis);
 }

--- a/netlify/functions/tokenBalances.mts
+++ b/netlify/functions/tokenBalances.mts
@@ -3,7 +3,7 @@ import Moralis from 'moralis';
 import type { Address } from 'viem';
 import type { TokenBalance } from '../../src/types';
 import { camelCaseKeys } from '../../src/utils/dataFormatter';
-import { BalanceDataWithMetadata, getBalances } from './balances.mts';
+import { BalanceDataWithMetadata, getBalances } from '../shared/moralisBalances.mts';
 
 export default async function getTokenBalancesWithPrices(request: Request) {
   const fetchFromStore = async (store: Store, storeKey: string) => {
@@ -28,5 +28,5 @@ export default async function getTokenBalancesWithPrices(request: Request) {
     return mappedTokensData;
   };
 
-  return getBalances(request, fetchFromStore, fetchFromMoralis);
+  return getBalances(request, 'tokens', fetchFromStore, fetchFromMoralis);
 }

--- a/netlify/functions/tokenBalances.mts
+++ b/netlify/functions/tokenBalances.mts
@@ -1,123 +1,32 @@
-import { getStore } from '@netlify/blobs';
+import type { Store } from '@netlify/blobs';
 import Moralis from 'moralis';
-import { isAddress } from 'viem';
-import { moralisSupportedChainIds } from '../../src/providers/NetworkConfig/NetworkConfigProvider';
+import type { Address } from 'viem';
 import type { TokenBalance } from '../../src/types';
 import { camelCaseKeys } from '../../src/utils/dataFormatter';
-
-type TokenBalancesWithMetadata = {
-  data: TokenBalance[];
-  metadata: {
-    fetched: number;
-    firstFetched: number;
-  };
-};
+import { BalanceDataWithMetadata, getBalances } from './balances.mts';
 
 export default async function getTokenBalancesWithPrices(request: Request) {
-  if (!process.env.MORALIS_API_KEY) {
-    console.error('Moralis API key is missing');
-    return Response.json({ error: 'Error while fetching token balances' }, { status: 503 });
-  }
-
-  if (!process.env.BALANCES_CACHE_INTERVAL_MINUTES) {
-    console.error('BALANCES_CACHE_INTERVAL_MINUTES is not set');
-    return Response.json({ error: 'Error while fetching prices' }, { status: 503 });
-  }
-
-  if (!process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) {
-    console.error('BALANCES_MORALIS_INDEX_DELAY_MINUTES is not set');
-    return Response.json({ error: 'Error while fetching prices' }, { status: 503 });
-  }
-
-  const requestSearchParams = new URL(request.url).searchParams;
-  const addressParam = requestSearchParams.get('address');
-
-  if (!addressParam) {
-    return Response.json({ error: 'Address missing from request' }, { status: 400 });
-  }
-
-  if (!isAddress(addressParam)) {
-    return Response.json({ error: 'Provided address is not a valid address' }, { status: 400 });
-  }
-
-  const networkParam = requestSearchParams.get('network');
-  if (!networkParam) {
-    return Response.json({ error: 'Network missing from request' }, { status: 400 });
-  }
-
-  const chainId = parseInt(networkParam);
-  if (!moralisSupportedChainIds.includes(chainId)) {
-    return Response.json({ error: 'Requested network is not supported' }, { status: 400 });
-  }
-
-  const tokensStore = getStore(`moralis-balances-tokens-${networkParam}`);
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const cacheTimeSeconds = parseInt(process.env.BALANCES_CACHE_INTERVAL_MINUTES) * 60;
-  const moralisIndexDelaySeconds = parseInt(process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) * 60;
-  const config = { nowSeconds, cacheTimeSeconds, moralisIndexDelaySeconds };
-  const storeKey = addressParam;
-  try {
-    const balances = await (tokensStore.getWithMetadata(storeKey, {
+  const fetchFromStore = async (store: Store, storeKey: string) => {
+    return store.getWithMetadata(storeKey, {
       type: 'json',
-    }) as Promise<TokenBalancesWithMetadata> | null);
+    }) as Promise<BalanceDataWithMetadata<TokenBalance>> | null;
+  };
 
-    // Determine whether to return cached token balances or fetch new data from Moralis API:
-    // 1. Check if the cached data is still valid:
-    //    - The cache is considered valid if the 'fetched' timestamp plus the cache interval is greater than the current time ('nowSeconds').
-    // 2. Validate the data:
-    //    - Data is considered valid if:
-    //      a. The 'firstFetched' timestamp plus the Moralis index delay is less than the current time, meaning the delay period has passed.
-    //      b. The data array is not empty, indicating that valid data was previously fetched.
-    //      c. If the data array is empty, but the 'firstFetched' timestamp is within the Moralis index delay period, the cache is not yet considered valid.
-    // If the cached data is valid according to these checks, return the cached data. Otherwise, proceed to fetch new data from the Moralis API.
-    if (
-      balances &&
-      balances.metadata.fetched + config.cacheTimeSeconds > config.nowSeconds &&
-      (balances.metadata.firstFetched + config.moralisIndexDelaySeconds < config.nowSeconds ||
-        (balances.data.length > 0 &&
-          balances.metadata.firstFetched + config.moralisIndexDelaySeconds > config.nowSeconds))
-    ) {
-      return Response.json({ data: balances.data });
-    }
+  const fetchFromMoralis = async (scope: { chain: string; address: Address }) => {
+    const tokensResponse = await Moralis.EvmApi.wallets.getWalletTokenBalancesPrice(scope);
 
-    if (!Moralis.Core.isStarted) {
-      await Moralis.start({
-        apiKey: process.env.MORALIS_API_KEY,
-      });
-    }
+    const mappedTokensData = tokensResponse.result
+      .filter(tokenBalance => tokenBalance.balance.value.toBigInt() > 0n)
+      .map(
+        tokenBalance =>
+          ({
+            ...camelCaseKeys(tokenBalance.toJSON()),
+            decimals: Number(tokenBalance.decimals),
+          }) as unknown as TokenBalance,
+      );
 
-    let mappedTokensData: TokenBalance[] = [];
+    return mappedTokensData;
+  };
 
-    try {
-      const tokensResponse = await Moralis.EvmApi.wallets.getWalletTokenBalancesPrice({
-        chain: chainId.toString(),
-        address: addressParam,
-      });
-
-      mappedTokensData = tokensResponse.result
-        .filter(tokenBalance => tokenBalance.balance.value.toBigInt() > 0n)
-        .map(
-          tokenBalance =>
-            ({
-              ...camelCaseKeys(tokenBalance.toJSON()),
-              decimals: Number(tokenBalance.decimals),
-            }) as unknown as TokenBalance,
-        );
-
-      const firstFetched = balances?.metadata.firstFetched ?? config.nowSeconds;
-      await tokensStore.setJSON(storeKey, mappedTokensData, {
-        metadata: { fetched: config.nowSeconds, firstFetched },
-      });
-    } catch (e) {
-      console.error('Unexpected error while fetching address token balances', e);
-    }
-
-    return Response.json({ data: mappedTokensData });
-  } catch (e) {
-    console.error(e);
-    return Response.json(
-      { error: 'Unexpected error while fetching token balances' },
-      { status: 503 },
-    );
-  }
+  return getBalances(request, fetchFromStore, fetchFromMoralis);
 }

--- a/netlify/shared/moralisBalances.mts
+++ b/netlify/shared/moralisBalances.mts
@@ -79,7 +79,6 @@ export async function getBalances<T>(
         (balances.data.length > 0 &&
           balances.metadata.firstFetched + moralisIndexDelaySeconds > nowSeconds))
     ) {
-      console.log('in here');
       return Response.json({ data: balances.data });
     }
 

--- a/netlify/shared/moralisBalances.mts
+++ b/netlify/shared/moralisBalances.mts
@@ -13,6 +13,35 @@ export interface BalanceDataWithMetadata<T> {
   };
 }
 
+const returnCache = <T,>(data: T[]) => {
+  return Response.json({ data });
+};
+
+const refetch = async <T,>(refetchParams: {
+  fetchFromMoralis: (scope: { chain: string; address: Address }) => Promise<T[]>;
+  chain: string;
+  address: Address;
+  balances: BalanceDataWithMetadata<T> | null;
+  nowSeconds: number;
+  store: Store;
+}) => {
+  const { fetchFromMoralis, chain, address, balances, nowSeconds, store } = refetchParams;
+
+  if (!Moralis.Core.isStarted) {
+    await Moralis.start({
+      apiKey: process.env.MORALIS_API_KEY,
+    });
+  }
+
+  const mappedData = await fetchFromMoralis({ chain, address });
+  const firstFetched = balances?.metadata.firstFetched ?? nowSeconds;
+  await store.setJSON(address, mappedData, {
+    metadata: { fetched: nowSeconds, firstFetched },
+  });
+
+  return Response.json({ data: mappedData });
+};
+
 export async function getBalances<T>(
   request: Request,
   storeName: string,
@@ -55,53 +84,84 @@ export async function getBalances<T>(
     return Response.json({ error: 'Requested network is not supported' }, { status: 400 });
   }
 
-  const store = getStore(`moralis-balances-${storeName}-${networkParam}`);
   const nowSeconds = Math.floor(Date.now() / 1000);
   const cacheTimeSeconds = parseInt(process.env.BALANCES_CACHE_INTERVAL_MINUTES) * 60;
   const moralisIndexDelaySeconds = parseInt(process.env.BALANCES_MORALIS_INDEX_DELAY_MINUTES) * 60;
-  const storeKey = addressParam;
+  const store = getStore(`moralis-balances-${storeName}-${networkParam}`);
+
   try {
-    const balances = await fetchFromStore(store, storeKey);
+    const balances = await fetchFromStore(store, addressParam);
 
-    // Determine whether to return cached token balances or fetch new data from Moralis API:
-    // 1. Check if the cached data is still valid:
-    //    - The cache is considered valid if the 'fetched' timestamp plus the cache interval is greater than the current time ('nowSeconds').
-    // 2. Validate the data:
-    //    - Data is considered valid if:
-    //      a. The 'firstFetched' timestamp plus the Moralis index delay is less than the current time, meaning the delay period has passed.
-    //      b. The data array is not empty, indicating that valid data was previously fetched.
-    //      c. If the data array is empty, but the 'firstFetched' timestamp is within the Moralis index delay period, the cache is not yet considered valid.
-    // If the cached data is valid according to these checks, return the cached data. Otherwise, proceed to fetch new data from the Moralis API.
+    const refetchParams = {
+      fetchFromMoralis,
+      chain: networkParam,
+      address: addressParam,
+      balances,
+      nowSeconds,
+      store,
+    };
+
+    if (!balances) {
+      return await refetch(refetchParams);
+    }
+
+    const insideMoralisIndexingBuffer =
+      balances.metadata.firstFetched + moralisIndexDelaySeconds > nowSeconds;
+    const lastFetchedDuringMoralisIndexingBuffer =
+      balances.metadata.firstFetched + moralisIndexDelaySeconds > balances.metadata.fetched;
+    const haveData = balances.data.length > 0;
+    const expiredCache = balances.metadata.fetched + cacheTimeSeconds < nowSeconds;
+
+    // inside buffer, no data: refetch
+    if (insideMoralisIndexingBuffer && !haveData) {
+      return await refetch(refetchParams);
+    }
+
+    // inside buffer, have data: return cache
+    if (insideMoralisIndexingBuffer && haveData) {
+      return returnCache(balances.data);
+    }
+
+    // outside buffer, no data, last fetch during buffer: refetch
+    if (!insideMoralisIndexingBuffer && !haveData && lastFetchedDuringMoralisIndexingBuffer) {
+      return await refetch(refetchParams);
+    }
+
+    // outside buffer, no data, last fetch after buffer, expired cache: refetch
     if (
-      balances &&
-      balances.metadata.fetched + cacheTimeSeconds > nowSeconds &&
-      (balances.metadata.firstFetched + moralisIndexDelaySeconds < nowSeconds ||
-        (balances.data.length > 0 &&
-          balances.metadata.firstFetched + moralisIndexDelaySeconds > nowSeconds))
+      !insideMoralisIndexingBuffer &&
+      !haveData &&
+      !lastFetchedDuringMoralisIndexingBuffer &&
+      expiredCache
     ) {
-      return Response.json({ data: balances.data });
+      return await refetch(refetchParams);
     }
 
-    if (!Moralis.Core.isStarted) {
-      await Moralis.start({
-        apiKey: process.env.MORALIS_API_KEY,
-      });
+    // outside buffer, no data, last fetch after buffer, valid cache: return cache
+    if (
+      !insideMoralisIndexingBuffer &&
+      !haveData &&
+      !lastFetchedDuringMoralisIndexingBuffer &&
+      !expiredCache
+    ) {
+      return returnCache(balances.data);
     }
 
-    let mappedData: T[] = [];
-
-    try {
-      mappedData = await fetchFromMoralis({ chain: chainId.toString(), address: addressParam });
-
-      const firstFetched = balances?.metadata.firstFetched ?? nowSeconds;
-      await store.setJSON(storeKey, mappedData, {
-        metadata: { fetched: nowSeconds, firstFetched },
-      });
-    } catch (e) {
-      console.error('Unexpected error while fetching balances', e);
+    // outside buffer, have data, expired cache: refresh
+    if (!insideMoralisIndexingBuffer && haveData && expiredCache) {
+      return await refetch(refetchParams);
     }
 
-    return Response.json({ data: mappedData });
+    // outside buffer, have data, valid cache: return cache
+    if (!insideMoralisIndexingBuffer && haveData && !expiredCache) {
+      return returnCache(balances.data);
+    }
+
+    throw new Error(
+      `How did we get here?\n
+      ${{ networkParam, addressParam }}\n
+      ${{ expiredCache, insideMoralisIndexingBuffer, haveData, lastFetchedDuringMoralisIndexingBuffer }}`,
+    );
   } catch (e) {
     console.error(e);
     return Response.json({ error: 'Unexpected error while fetching balances' }, { status: 503 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src", "tests", "test", "app", "netlify/functions", "vite.config.mts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,13 @@
     "incremental": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["src", "tests", "test", "app", "netlify/functions", "vite.config.mts"]
+  "include": [
+    "src",
+    "tests",
+    "test",
+    "app",
+    "netlify/functions",
+    "netlify/shared",
+    "vite.config.mts"
+  ]
 }


### PR DESCRIPTION
Fixes https://github.com/decentdao/decent-interface/issues/2192

There are two things happening in this PR:

1. Implement the new logic which fixes the issues encountered with Netlify caching Moralis empty responses which are only empty because it hasn't been indexed yet.
2. DRY the code, because the two functions were super similar.

### To Test:

1. Create new Azorius safe, sending some tokens to the new Safe's treasury
2. Notice that upon initial deployment there are no balances for this Safe. It's because Moralis hasn't indexed this address in the very short amount of time between Safe being deployed and us trying to fetch its token balance.
3. Wait a few seconds, then refresh the page.
4. Notice how there is a token balance now.

### Details

These are the various conditions that we may find ourselves in, and what to do in those conditions:

```
// inside buffer, no data: refetch
// inside buffer, have data: return cache
// outside buffer, no data, last fetch during buffer: refetch
// outside buffer, no data, last fetch after buffer, expired cache: refetch
// outside buffer, no data, last fetch after buffer, valid cache: return cache
// outside buffer, have data, expired cache: refresh
// outside buffer, have data, valid cache: return cache
```

- "inside buffer" means we have not yet elapsed the time spanned between when we first call Moralis for a given address plus `x` minutes (where `x` is an environment variable, likely something like 2 minutes in prod).
- "outside buffer" means it has been at least `x` minutes since the first time we've queried Moralis for a given address.
- "no data" means the last time we queried Moralis, it returned no data for a given address.
- "have data" means the last time we queried Moralis, it did return data for the given address.
- "last fetch during buffer" means the last time we queried Moralis, it was during the aforementioned "buffer" period.
- "last fetch after buffer" means the last time we queried Moralis, it was after the aforementioned "buffer" period.
- "expired cache" means it has been at least `y` minutes since we queried Moralis for data, `y` being an environment variable, currently set to 60 minutes in prod.
- "valid cache" means it has not yet been `y` minutes since we queried Moralis for data.