### PR TITLE
`[roles-0.2.0]` Claim hat stream

### DIFF
--- a/src/assets/abi/SablierV2LockupLinear.ts
+++ b/src/assets/abi/SablierV2LockupLinear.ts
@@ -902,4 +902,4 @@ export const SablierV2LockupLinearAbi = [
     name: 'SafeERC20FailedOperation',
     inputs: [{ name: 'token', type: 'address', internalType: 'address' }],
   },
-];
+] as const;

--- a/src/components/pages/Roles/RolesDetailsDrawer.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawer.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react';
 import { List, PencilLine, User, X } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
-import { Hex, getAddress } from 'viem';
+import { Address, Hex, getAddress } from 'viem';
 import { useGetDAOName } from '../../../hooks/DAO/useGetDAOName';
 import useAvatar from '../../../hooks/utils/useAvatar';
 import PaymentDetails from '../../../pages/daos/[daoAddress]/roles/details/PaymentDetails';
@@ -43,6 +43,7 @@ interface RoleDetailsDrawerProps {
     name: string;
     wearer: string;
     description: string;
+    smartAddress: Address;
   };
   payments?: SablierPayment[];
   onOpen?: () => void;
@@ -161,7 +162,10 @@ export default function RolesDetailsDrawer({
             </GridItem>
           </Grid>
           {/* @todo: proper styling here */}
-          <PaymentDetails payment={payments?.[0]} />
+          <PaymentDetails
+            payment={payments?.[0]}
+            roleHat={roleHat}
+          />
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/components/pages/Roles/RolesDetailsDrawerMobile.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawerMobile.tsx
@@ -1,7 +1,7 @@
 import { Flex, IconButton, Icon, Text, Box } from '@chakra-ui/react';
 import { PencilLine } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
-import { Hex } from 'viem';
+import { Address, Hex } from 'viem';
 import PaymentDetails from '../../../pages/daos/[daoAddress]/roles/details/PaymentDetails';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { useRolesState } from '../../../state/useRolesState';
@@ -15,6 +15,7 @@ interface RoleDetailsDrawerMobileProps {
     name: string;
     wearer: string;
     description: string;
+    smartAddress: Address;
   };
   payments?: SablierPayment[];
   onOpen?: () => void;
@@ -91,7 +92,10 @@ export default function RolesDetailsDrawerMobile({
         px="1rem"
         mb="1.5rem"
       >
-        <PaymentDetails payment={payments?.[0]} />
+        <PaymentDetails
+          payment={payments?.[0]}
+          roleHat={roleHat}
+        />
       </Box>
     </DraggableDrawer>
   );

--- a/src/hooks/streams/useCreateSablierStream.ts
+++ b/src/hooks/streams/useCreateSablierStream.ts
@@ -24,6 +24,13 @@ type LinearStreamInputs = {
   cliff: StreamSchedule | undefined;
 };
 
+export function convertStreamIdToBigInt(streamId: string) {
+  // streamId is formatted as ${recipientAddress}-${chainId}-${numericId}
+  const lastDash = streamId.lastIndexOf('-');
+  const numericId = streamId.substring(lastDash + 1);
+  return BigInt(numericId);
+}
+
 export default function useCreateSablierStream() {
   const {
     contracts: { sablierV2LockupLinear, sablierV2Batch },
@@ -31,13 +38,6 @@ export default function useCreateSablierStream() {
   const {
     node: { daoAddress },
   } = useFractal();
-
-  const convertStreamIdToBigInt = (streamId: string) => {
-    // streamId is formatted as ${recipientAddress}-${chainId}-${numericId}
-    const lastDash = streamId.lastIndexOf('-');
-    const numericId = streamId.substring(lastDash + 1);
-    return BigInt(numericId);
-  };
 
   const prepareStreamTokenCallData = useCallback(
     (amountInTokenDecimals: bigint) => {
@@ -116,7 +116,7 @@ export default function useCreateSablierStream() {
 
     // @dev This function comes from "basic" SablierV2
     // all the types of streams are inheriting from that
-    // so it's safe to rely on TranchedAbi
+    // so it's safe to rely on any stream ABI
 
     const flushCalldata = encodeFunctionData({
       abi: SablierV2LockupLinearAbi,
@@ -134,7 +134,7 @@ export default function useCreateSablierStream() {
 
     // @dev This function comes from "basic" SablierV2
     // all the types of streams are inheriting from that
-    // so it's safe to rely on TranchedAbi
+    // so it's safe to rely on any stream ABI
     const flushCalldata = encodeFunctionData({
       abi: SablierV2LockupLinearAbi,
       functionName: 'cancel',

--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -187,14 +187,13 @@ export default function useCreateRoles() {
           })),
       );
 
+      // Parse role with edited payroll hats
+      const editedPayrollHats = editedHats.filter(hat => {
+        const payments = hat.payments?.filter(payment => !!payment.streamId);
+        return payments?.length ? { ...hat, payments } : null;
+      });
+
       // Parse role with added payroll hats
-      const editedPayrollHats = [
-        ...editedHats.filter(
-          hat =>
-            hat.editedRole?.status === EditBadgeStatus.Updated &&
-            hat.editedRole.fieldNames.includes('payments'),
-        ),
-      ];
       const addedNewPaymentsHats: RoleValue[] = editedHats
         .map(hat => {
           const payments = hat.payments?.filter(payment => !payment.streamId);
@@ -409,14 +408,15 @@ export default function useCreateRoles() {
             if (roleHat.payments?.length) {
               const wrappedFlushStreamTxs: Hex[] = [];
               const cancelStreamTxs: { calldata: Hex; targetAddress: Address }[] = [];
-              // @todo Do not add flush out stream transaction if available balance to withdraw is 0
               roleHat.payments.forEach(payment => {
-                const { wrappedFlushStreamTx, cancelStreamTx } = prepareHatFlushAndCancelPayment(
-                  payment,
-                  roleHat.wearer,
-                );
-                wrappedFlushStreamTxs.push(wrappedFlushStreamTx);
-                cancelStreamTxs.push(cancelStreamTx);
+                if (payment?.streamId) {
+                  const { wrappedFlushStreamTx, cancelStreamTx } = prepareHatFlushAndCancelPayment(
+                    payment,
+                    roleHat.wearer,
+                  );
+                  wrappedFlushStreamTxs.push(wrappedFlushStreamTx);
+                  cancelStreamTxs.push(cancelStreamTx);
+                }
               });
               hatPaymentHatRemovedTxs.push({
                 calldata: encodeFunctionData({
@@ -469,10 +469,10 @@ export default function useCreateRoles() {
           .map(({ id, currentWearer, newWearer }) => {
             const roleHat = hatsTree.roleHats.find(hat => hat.id === id);
             if (roleHat && roleHat.payments?.length) {
-              if (roleHat.payments && roleHat.payments.length) {
-                // @todo Do not add flush out stream transaction if available balance to withdraw is 0
+              const payment = roleHat.payments[0];
+              if (payment?.streamId) {
                 const wrappedFlushStreamTx = prepareHatsAccountFlushExecData(
-                  roleHat.payments[0],
+                  payment,
                   roleHat.wearer,
                 );
                 hatPaymentWearerChangedTxs.push({
@@ -543,32 +543,33 @@ export default function useCreateRoles() {
         const paymentCancelTxs: { calldata: Hex; targetAddress: Address }[] = [];
         editedPayrollHats.forEach(role =>
           (role.payments ?? []).forEach(payment => {
-            // @todo Do not add flush out stream transaction if available balance to withdraw is 0
-            const { wrappedFlushStreamTx, cancelStreamTx } = prepareHatFlushAndCancelPayment(
-              payment,
-              getAddress(role.wearer),
-            );
-            paymentCancelTxs.push({
-              calldata: encodeFunctionData({
-                abi: HatsAbi,
-                functionName: 'transferHat',
-                args: [BigInt(role.id), getAddress(role.wearer), daoAddress],
-              }),
-              targetAddress: hatsProtocol,
-            });
-            paymentCancelTxs.push({
-              calldata: wrappedFlushStreamTx,
-              targetAddress: role.smartAddress,
-            });
-            paymentCancelTxs.push(cancelStreamTx);
-            paymentCancelTxs.push({
-              calldata: encodeFunctionData({
-                abi: HatsAbi,
-                functionName: 'transferHat',
-                args: [BigInt(role.id), daoAddress, getAddress(role.wearer)],
-              }),
-              targetAddress: hatsProtocol,
-            });
+            if (payment.streamId) {
+              const { wrappedFlushStreamTx, cancelStreamTx } = prepareHatFlushAndCancelPayment(
+                payment,
+                getAddress(role.wearer),
+              );
+              paymentCancelTxs.push({
+                calldata: encodeFunctionData({
+                  abi: HatsAbi,
+                  functionName: 'transferHat',
+                  args: [BigInt(role.id), getAddress(role.wearer), daoAddress],
+                }),
+                targetAddress: hatsProtocol,
+              });
+              paymentCancelTxs.push({
+                calldata: wrappedFlushStreamTx,
+                targetAddress: role.smartAddress,
+              });
+              paymentCancelTxs.push(cancelStreamTx);
+              paymentCancelTxs.push({
+                calldata: encodeFunctionData({
+                  abi: HatsAbi,
+                  functionName: 'transferHat',
+                  args: [BigInt(role.id), daoAddress, getAddress(role.wearer)],
+                }),
+                targetAddress: hatsProtocol,
+              });
+            }
           }),
         );
         const streamsData = editedPayrollHats.flatMap(role =>

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -96,7 +96,7 @@
   "etherscanTip": "Open in Etherscan",
   "wrapToken": "Wrap Token",
   "unwrapToken": "Unwrap Token",
-  "max": "max",
+  "max": "Max",
   "favoriteTooltip": "Toggle your favorite Safes. ",
   "isMeSuffix": " (you)",
   "refresh": "Refresh",

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -55,5 +55,9 @@
   "cliff": "Cliff",
   "cliffSubTitle": "How long until the assets are claimable?",
   "paymentStream": "Payment Stream",
-  "payment": "Payment"
+  "payment": "Payment",
+  "withdraw": "Withdraw",
+  "withdrawHelper": "Withdrawing will transfer the funds to the recipient's address.",
+  "remaining": "Remaining",
+  "withdrawable": "Withdrawable"
 }

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -59,5 +59,9 @@
   "withdraw": "Withdraw",
   "withdrawHelper": "Withdrawing will transfer the funds to the recipient's address.",
   "remaining": "Remaining",
-  "withdrawable": "Withdrawable"
+  "withdrawable": "Withdrawable",
+  "withdrawPendingMessage": "Withdrawing your payment, hang tight",
+  "withdrawSuccessMessage": "Payment successfully withdrawn. Check your wallet :)",
+  "withdrawRevertedMessage": "Transaction for withdrawing your payment reverted :(",
+  "withdrawErrorMessage": "Transaction for withdrawing your payment failed :("
 }

--- a/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
@@ -128,6 +128,7 @@ export default function PaymentDetails({
             args: [bigIntStreamId, getAddress(roleHat.wearer), withdrawAmount.bigintValue],
           });
         }
+        // @todo - Add proper copy
         const withdrawToast = toast('Withdrawing your payment, hand tight', {
           autoClose: false,
           closeOnClick: false,
@@ -144,12 +145,14 @@ export default function PaymentDetails({
         const transaction = await publicClient.waitForTransactionReceipt({ hash: txHash });
         toast.dismiss(withdrawToast);
         if (transaction.status === 'success') {
-          toast('Payment successfully withdrawn. Check your wallet :)');
+          await loadWithdrawableAmount();
+          toast('Payment successfully withdrawn. Check your wallet :)'); // @todo - Add proper copy
         } else {
-          toast('Transaction for withdrawing your payment reverted :(');
+          toast('Transaction for withdrawing your payment reverted :('); // @todo - Add proper copy
         }
       } catch (e) {
         console.error('Error withdrawing from stream', e);
+        toast('Transaction for withdrawing your payment failed :('); // @todo - Add proper copy
       }
     }
   }, [
@@ -161,6 +164,7 @@ export default function PaymentDetails({
     roleHat.smartAddress,
     roleHat.wearer,
     withdrawMax,
+    loadWithdrawableAmount,
   ]);
 
   if (!payment) {

--- a/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
@@ -62,7 +62,7 @@ export default function PaymentDetails({
   };
 }) {
   const { address: account } = useAccount();
-  const { t } = useTranslation('roles');
+  const { t } = useTranslation(['roles', 'common']);
   const [withdrawableAmount, setWithdrawableAmount] = useState(0n);
   const [withdrawAmount, setWithdrawAmount] = useState<BigIntValuePair>({
     value: '0',
@@ -268,7 +268,7 @@ export default function PaymentDetails({
                         >
                           {t('remaining')}
                         </Text>
-                        <Flex>
+                        <Flex alignItems="center">
                           <Image
                             src={payment.asset.logo}
                             fallbackSrc="/images/coin-icon-default.svg"
@@ -291,7 +291,7 @@ export default function PaymentDetails({
                         >
                           {t('withdrawable')}
                         </Text>
-                        <Flex>
+                        <Flex alignItems="center">
                           <Image
                             src={payment.asset.logo}
                             fallbackSrc="/images/coin-icon-default.svg"
@@ -323,7 +323,7 @@ export default function PaymentDetails({
                             onClick={handleSetMax}
                             cursor="pointer"
                           >
-                            {t('max')}
+                            {t('max', { ns: 'common'})}
                           </InputRightElement>
                         </InputGroup>
                         <Flex

--- a/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
@@ -13,7 +13,7 @@ import {
 import { CaretRight, CaretDown, Download } from '@phosphor-icons/react';
 import { ReactNode, useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'react-toastify';
+import { Id, toast } from 'react-toastify';
 import { Address, encodeFunctionData, getContract, Hex, getAddress, formatUnits } from 'viem';
 import { useAccount, usePublicClient, useWalletClient } from 'wagmi';
 import HatsAccount1ofNAbi from '../../../../../assets/abi/HatsAccount1ofN';
@@ -121,6 +121,7 @@ export default function PaymentDetails({
       publicClient &&
       withdrawAmount.bigintValue
     ) {
+      let withdrawToast: Id | undefined = undefined;
       try {
         const hatsAccountContract = getContract({
           abi: HatsAccount1ofNAbi,
@@ -143,7 +144,7 @@ export default function PaymentDetails({
           });
         }
         // @todo - Add proper copy
-        const withdrawToast = toast(t('withdrawPendingMessage'), {
+        withdrawToast = toast(t('withdrawPendingMessage'), {
           autoClose: false,
           closeOnClick: false,
           draggable: false,
@@ -169,6 +170,9 @@ export default function PaymentDetails({
           toast('withdrawRevertedMessage'); // @todo - Add proper copy
         }
       } catch (e) {
+        if (typeof withdrawToast !== 'undefined') {
+          toast.dismiss(withdrawToast);
+        }
         console.error('Error withdrawing from stream', e);
         toast(t('withdrawErrorMessage')); // @todo - Add proper copy
       }

--- a/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
@@ -91,10 +91,7 @@ export default function PaymentDetails({
 
   useEffect(() => {
     if (payment?.asset?.decimals) {
-      if (
-        withdrawAmount.bigintValue ===
-        withdrawableAmount
-      ) {
+      if (withdrawAmount.bigintValue === withdrawableAmount) {
         setWithdrawMax(true);
       } else {
         setWithdrawMax(false);
@@ -291,7 +288,8 @@ export default function PaymentDetails({
                             textStyle="body-base"
                             color="white-0"
                           >
-                            {formatUnits(withdrawableAmount, payment.asset.decimals)} {payment.asset.symbol}
+                            {formatUnits(withdrawableAmount, payment.asset.decimals)}{' '}
+                            {payment.asset.symbol}
                           </Text>
                         </Flex>
                       </Flex>
@@ -299,12 +297,12 @@ export default function PaymentDetails({
                     {withdrawableAmount > 0n && (
                       <>
                         <BigIntInput
-                            value={withdrawAmount.bigintValue}
-                            onChange={valuePair => setWithdrawAmount(valuePair)}
-                            decimalPlaces={payment.asset.decimals}
-                            maxValue={withdrawableAmount}
-                            data-testid="withdraw-stream-amount-input"
-                          />
+                          value={withdrawAmount.bigintValue}
+                          onChange={valuePair => setWithdrawAmount(valuePair)}
+                          decimalPlaces={payment.asset.decimals}
+                          maxValue={withdrawableAmount}
+                          data-testid="withdraw-stream-amount-input"
+                        />
                         <Flex
                           justifyContent="flex-end"
                           w="full"

--- a/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
@@ -143,7 +143,6 @@ export default function PaymentDetails({
             args: [bigIntStreamId, getAddress(roleHat.wearer), withdrawAmount.bigintValue],
           });
         }
-        // @todo - Add proper copy
         withdrawToast = toast(t('withdrawPendingMessage'), {
           autoClose: false,
           closeOnClick: false,
@@ -161,20 +160,20 @@ export default function PaymentDetails({
         toast.dismiss(withdrawToast);
         if (transaction.status === 'success') {
           await loadAmounts();
-          toast('withdrawSuccessMessage'); // @todo - Add proper copy
+          toast(t('withdrawSuccessMessage'));
           setWithdrawAmount({
             value: '0',
             bigintValue: 0n,
           });
         } else {
-          toast('withdrawRevertedMessage'); // @todo - Add proper copy
+          toast(t('withdrawRevertedMessage'));
         }
       } catch (e) {
         if (typeof withdrawToast !== 'undefined') {
           toast.dismiss(withdrawToast);
         }
         console.error('Error withdrawing from stream', e);
-        toast(t('withdrawErrorMessage')); // @todo - Add proper copy
+        toast(t('withdrawErrorMessage'));
       }
     }
   }, [

--- a/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
@@ -143,7 +143,7 @@ export default function PaymentDetails({
           });
         }
         // @todo - Add proper copy
-        const withdrawToast = toast('Withdrawing your payment, hang tight', {
+        const withdrawToast = toast(t('withdrawPendingMessage'), {
           autoClose: false,
           closeOnClick: false,
           draggable: false,
@@ -160,17 +160,17 @@ export default function PaymentDetails({
         toast.dismiss(withdrawToast);
         if (transaction.status === 'success') {
           await loadAmounts();
-          toast('Payment successfully withdrawn. Check your wallet :)'); // @todo - Add proper copy
+          toast('withdrawSuccessMessage'); // @todo - Add proper copy
           setWithdrawAmount({
             value: '0',
             bigintValue: 0n,
           });
         } else {
-          toast('Transaction for withdrawing your payment reverted :('); // @todo - Add proper copy
+          toast('withdrawRevertedMessage'); // @todo - Add proper copy
         }
       } catch (e) {
         console.error('Error withdrawing from stream', e);
-        toast('Transaction for withdrawing your payment failed :('); // @todo - Add proper copy
+        toast(t('withdrawErrorMessage')); // @todo - Add proper copy
       }
     }
   }, [
@@ -183,6 +183,7 @@ export default function PaymentDetails({
     roleHat.wearer,
     withdrawMax,
     loadAmounts,
+    t,
   ]);
 
   if (!payment) {

--- a/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
@@ -169,7 +169,7 @@ export default function PaymentDetails({
           toast(t('withdrawRevertedMessage'));
         }
       } catch (e) {
-        if (typeof withdrawToast !== 'undefined') {
+        if (withdrawToast !== undefined) {
           toast.dismiss(withdrawToast);
         }
         console.error('Error withdrawing from stream', e);

--- a/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/PaymentDetails.tsx
@@ -323,7 +323,7 @@ export default function PaymentDetails({
                             onClick={handleSetMax}
                             cursor="pointer"
                           >
-                            {t('max', { ns: 'common'})}
+                            {t('max', { ns: 'common' })}
                           </InputRightElement>
                         </InputGroup>
                         <Flex


### PR DESCRIPTION
This PR implements basic UI and logic for withdrawing payment to the hat wearer.
It also fixes filtering of added/edited payments as previously added payment was also considered as edited.

Closes #2186 

Testing steps:

1. Create payment for any given role, where you're a wearer. Make total length of the payment short enough so that you could easily withdraw sufficient amount of tokens (1 hour for 1000 tokens should be good).
2. Vote and execute proposal for creating payment to the role
3. Go to the role details - payment info should appear there
4. Notice "Withdraw" section appearing in the payment details
5. Enter amount to withdraw (do not put maximum amount just yet) and hit "Withdraw" - this will prompt to sign transaction
6. Make sure proper amount of tokens were sent to your wallet
7. Now, hit "max" button and hit "Withdraw" and sign transaction
8. Make sure proper amount of all available for withdrawing tokens were sent to your wallet

Basic design was grabbed from https://www.figma.com/design/9hUYtvCKjOyB92vt8ukYtD/Product-Handoff?node-id=4087-18066&m=dev but not implemented 1-1, since that design should change (afaik)
<img width="1172" alt="Screenshot 2024-08-02 at 16 33 30" src="https://github.com/user-attachments/assets/fc38054c-af8c-4260-9b95-580fd3c0de90">

