### PR TITLE
Use "useLocaleString" for displaying quorum numbers

### DIFF
--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -254,9 +254,9 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
             {
               quorum: strategyQuorum,
               total: isERC721
-                ? totalVotingWeight?.toString()
+                ? totalVotingWeight?.toLocaleString()
                 : votesToken
-                  ? (votesToken.totalSupply / votesTokenDecimalsDenominator).toString()
+                  ? (votesToken.totalSupply / votesTokenDecimalsDenominator).toLocaleString()
                   : undefined,
             },
           )}

--- a/src/components/ui/utils/ProgressBar.tsx
+++ b/src/components/ui/utils/ProgressBar.tsx
@@ -94,7 +94,7 @@ export function QuorumProgressBar({
                   as={Check}
                 />
               )}
-              {reachedQuorum} / {totalQuorum}
+              {reachedQuorum.toLocaleString()} / {totalQuorum.toLocaleString()}
             </Text>
           ) : undefined
         }


### PR DESCRIPTION
Fixes #2088 

Before:
<img width="417" alt="Screenshot 2024-08-02 at 3 14 20 PM" src="https://github.com/user-attachments/assets/ab322e64-5170-4748-9b99-fe4c3cc5f195">

After:
<img width="391" alt="Screenshot 2024-08-02 at 3 13 43 PM" src="https://github.com/user-attachments/assets/8a9aa291-6679-40dc-b976-c898374cace7">
