### PR TITLE
Consolidate Alchemy keys into single environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -15,16 +15,8 @@ SENTRY_AUTH_TOKEN=""
 # App name displayed as Title
 VITE_APP_NAME="Decent"
 
-# Alchemy provider API key, used on Mainnet
-VITE_APP_ALCHEMY_MAINNET_API_KEY=""
-# Alchemy provider API key, used on Polygon
-VITE_APP_ALCHEMY_POLYGON_API_KEY=""
-# Alchemy provider API key, used on Sepolia
-VITE_APP_ALCHEMY_SEPOLIA_API_KEY=""
-# Alchemy provider API key, used on Base
-VITE_APP_ALCHEMY_BASE_API_KEY=""
-# Alchemy provider API key, used on Optimism
-VITE_APP_ALCHEMY_OPTIMISM_API_KEY=""
+# Alchemy provider API key
+VITE_APP_ALCHEMY_API_KEY=""
 
 # ABI selector, used on Mainnet
 VITE_APP_ETHERSCAN_MAINNET_API_KEY=""

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -30,10 +30,10 @@ const baseConfig: NetworkConfig = {
   order: 10,
   chain: base,
   moralisSupported: true,
-  rpcEndpoint: `https://base-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_BASE_API_KEY}`,
+  rpcEndpoint: `https://base-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-base.safe.global',
   etherscanBaseURL: 'https://basescan.org/',
-  etherscanAPIUrl: `https://api.basescan.com/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_BASE_API_KEY}`,
+  etherscanAPIUrl: `https://api.basescan.com/api?apikey=${import.meta.env.VITE_APP_ETHERSCAN_BASE_API_KEY}`,
   addressPrefix: 'base',
   nativeTokenIcon: '/images/coin-icon-base.svg',
   subgraph: {

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -30,10 +30,10 @@ const mainnetConfig: NetworkConfig = {
   order: 0,
   chain: mainnet,
   moralisSupported: true,
-  rpcEndpoint: `https://eth-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_MAINNET_API_KEY}`,
+  rpcEndpoint: `https://eth-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-mainnet.safe.global',
   etherscanBaseURL: 'https://etherscan.io',
-  etherscanAPIUrl: `https://api.etherscan.io/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
+  etherscanAPIUrl: `https://api.etherscan.io/api?apikey=${import.meta.env.VITE_APP_ETHERSCAN_MAINNET_API_KEY}`,
   addressPrefix: 'eth',
   nativeTokenIcon: '/images/coin-icon-eth.svg',
   subgraph: {

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -30,10 +30,10 @@ const optimismConfig: NetworkConfig = {
   order: 15,
   chain: optimism,
   moralisSupported: true,
-  rpcEndpoint: `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_OPTIMISM_API_KEY}`,
+  rpcEndpoint: `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-optimism.safe.global',
   etherscanBaseURL: 'https://optimistic.etherscan.io/',
-  etherscanAPIUrl: `https://api-optimistic.etherscan.io/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_OPTIMISM_API_KEY}`,
+  etherscanAPIUrl: `https://api-optimistic.etherscan.io/api?apikey=${import.meta.env.VITE_APP_ETHERSCAN_OPTIMISM_API_KEY}`,
   addressPrefix: 'oeth',
   nativeTokenIcon: '/images/coin-icon-op.svg',
   subgraph: {

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -30,10 +30,10 @@ const polygonConfig: NetworkConfig = {
   order: 20,
   chain: polygon,
   moralisSupported: true,
-  rpcEndpoint: `https://polygon-mainnet.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_POLYGON_API_KEY}`,
+  rpcEndpoint: `https://polygon-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-polygon.safe.global',
   etherscanBaseURL: 'https://polygonscan.com',
-  etherscanAPIUrl: `https://api.polygonscan.com/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_POLYGON_API_KEY}`,
+  etherscanAPIUrl: `https://api.polygonscan.com/api?apikey=${import.meta.env.VITE_APP_ETHERSCAN_POLYGON_API_KEY}`,
   addressPrefix: 'matic',
   nativeTokenIcon: '/images/coin-icon-pol.svg',
   subgraph: {

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -30,10 +30,10 @@ const sepoliaConfig: NetworkConfig = {
   order: 30,
   chain: sepolia,
   moralisSupported: true,
-  rpcEndpoint: `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env?.VITE_APP_ALCHEMY_SEPOLIA_API_KEY}`,
+  rpcEndpoint: `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env.VITE_APP_ALCHEMY_API_KEY}`,
   safeBaseURL: 'https://safe-transaction-sepolia.safe.global',
   etherscanBaseURL: 'https://sepolia.etherscan.io',
-  etherscanAPIUrl: `https://api-sepolia.etherscan.io/api?apikey=${import.meta.env?.VITE_APP_ETHERSCAN_SEPOLIA_API_KEY}`,
+  etherscanAPIUrl: `https://api-sepolia.etherscan.io/api?apikey=${import.meta.env.VITE_APP_ETHERSCAN_SEPOLIA_API_KEY}`,
   addressPrefix: 'sep',
   nativeTokenIcon: '/images/coin-icon-sep.svg',
   subgraph: {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,11 +6,7 @@ interface ImportMetaEnv {
 
   readonly VITE_APP_NAME: string;
 
-  readonly VITE_APP_ALCHEMY_MAINNET_API_KEY: string;
-  readonly VITE_APP_ALCHEMY_POLYGON_API_KEY: string;
-  readonly VITE_APP_ALCHEMY_SEPOLIA_API_KEY: string;
-  readonly VITE_APP_ALCHEMY_BASE_API_KEY: string;
-  readonly VITE_APP_ALCHEMY_OPTIMISM_API_KEY: string;
+  readonly VITE_APP_ALCHEMY_API_KEY: string;
 
   readonly VITE_APP_ETHERSCAN_MAINNET_API_KEY: string;
   readonly VITE_APP_ETHERSCAN_POLYGON_API_KEY: string;


### PR DESCRIPTION
Closes #2211 

I've added `VITE_APP_ALCHEMY_API_KEY` to both Netlify sites, values being the current "Mainnet" Alchemy App's API key.

As this is merged into `develop` and `main`, I'll remove the unused environment variables from Netlify config, and I'll delete the apps on the Alchemy accounts (leaving the "Mainnet" app, and renaming it to be more generic, of course).