### PR TITLE
No tab selection

### DIFF
--- a/src/components/ui/proposal/Markdown.tsx
+++ b/src/components/ui/proposal/Markdown.tsx
@@ -154,7 +154,7 @@ export default function Markdown({
     <>
       {collapsed ? (
         <MarkdowContentWithoutTabs
-          collapsed={collapsed}
+          collapsed={true}
           truncate={truncate}
           collapsedLines={collapsedLines}
           markdownTextContainerRef={markdownTextContainerRef}
@@ -163,7 +163,7 @@ export default function Markdown({
         </MarkdowContentWithoutTabs>
       ) : (
         <MarkdowContentWithTabs
-          collapsed={collapsed}
+          collapsed={false}
           truncate={truncate}
           collapsedLines={collapsedLines}
           markdownTextContainerRef={markdownTextContainerRef}

--- a/src/components/ui/proposal/Markdown.tsx
+++ b/src/components/ui/proposal/Markdown.tsx
@@ -1,9 +1,11 @@
 import { Button, Image, Box } from '@chakra-ui/react';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown, { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import '../../../assets/css/Markdown.css';
+import { getRandomBytes } from '../../../helpers';
+import useSkipTab from '../../../hooks/utils/useSkipTab';
 
 function CustomMarkdownImage({ src, alt }: { src?: string; alt?: string }) {
   const [error, setError] = useState(false);
@@ -37,6 +39,56 @@ interface IMarkdown {
   collapsedLines?: number;
   hideCollapsed?: boolean;
   content: string;
+}
+
+interface IMarkdownContent {
+  children: React.ReactNode;
+  collapsed: boolean;
+  truncate: boolean | undefined;
+  collapsedLines: number;
+  markdownTextContainerRef: React.RefObject<HTMLParagraphElement>;
+}
+
+function MarkdowContentWithoutTabs({
+  children,
+  collapsed,
+  truncate,
+  collapsedLines,
+  markdownTextContainerRef,
+}: IMarkdownContent) {
+  const markdownId = getRandomBytes().toString();
+  useSkipTab(markdownId);
+
+  return (
+    <Box
+      id={markdownId}
+      noOfLines={collapsed || truncate ? collapsedLines : undefined}
+      ref={markdownTextContainerRef}
+      maxWidth="100%"
+      width="100%"
+    >
+      {children}
+    </Box>
+  );
+}
+
+function MarkdowContentWithTabs({
+  children,
+  collapsed,
+  truncate,
+  collapsedLines,
+  markdownTextContainerRef,
+}: IMarkdownContent) {
+  return (
+    <Box
+      noOfLines={collapsed || truncate ? collapsedLines : undefined}
+      ref={markdownTextContainerRef}
+      maxWidth="100%"
+      width="100%"
+    >
+      {children}
+    </Box>
+  );
 }
 
 export default function Markdown({
@@ -87,25 +139,38 @@ export default function Markdown({
     return uri;
   };
 
+  const innerContent = (!hideCollapsed || !collapsed) && (
+    <ReactMarkdown
+      remarkPlugins={truncate ? [] : [remarkGfm]}
+      urlTransform={handleTransformURI}
+      components={MarkdownComponents}
+      className="markdown-body"
+    >
+      {content}
+    </ReactMarkdown>
+  );
+
   return (
     <>
-      <Box
-        noOfLines={collapsed || truncate ? collapsedLines : undefined}
-        ref={markdownTextContainerRef}
-        maxWidth="100%"
-        width="100%"
-      >
-        {(!hideCollapsed || !collapsed) && (
-          <ReactMarkdown
-            remarkPlugins={truncate ? [] : [remarkGfm]}
-            urlTransform={handleTransformURI}
-            components={MarkdownComponents}
-            className="markdown-body"
-          >
-            {content}
-          </ReactMarkdown>
-        )}
-      </Box>
+      {collapsed ? (
+        <MarkdowContentWithoutTabs
+          collapsed={collapsed}
+          truncate={truncate}
+          collapsedLines={collapsedLines}
+          markdownTextContainerRef={markdownTextContainerRef}
+        >
+          {innerContent}
+        </MarkdowContentWithoutTabs>
+      ) : (
+        <MarkdowContentWithTabs
+          collapsed={collapsed}
+          truncate={truncate}
+          collapsedLines={collapsedLines}
+          markdownTextContainerRef={markdownTextContainerRef}
+        >
+          {innerContent}
+        </MarkdowContentWithTabs>
+      )}
 
       {((hideCollapsed && content) ||
         (totalLines > collapsedLines && !totalLinesError && !truncate)) && (

--- a/src/hooks/utils/useSkipTab.ts
+++ b/src/hooks/utils/useSkipTab.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+
+const useSkipTab = (sectionId: string) => {
+  useEffect(() => {
+    const section = document.getElementById(sectionId);
+
+    if (!section) return;
+
+    const updateTabIndex = () => {
+      const focusableElements = section.querySelectorAll('a, button, input, [tabindex]');
+      focusableElements.forEach(el => {
+        el.setAttribute('tabindex', '-1');
+      });
+    };
+
+    // Initial call to set tabindex
+    updateTabIndex();
+
+    // Create an observer instance linked to the callback function
+    const observer = new MutationObserver(() => {
+      updateTabIndex();
+    });
+
+    // Start observing the target node for configured mutations
+    observer.observe(section, {
+      childList: true, // observe direct children changes
+      subtree: true, // observe all descendants
+    });
+
+    // Clean up by disconnecting the observer
+    return () => {
+      observer.disconnect();
+    };
+  }, [sectionId]);
+};
+
+export default useSkipTab;


### PR DESCRIPTION
Fixes #2170

When proposal descriptions are being displayed in the "collapsed" view (like on the Dashboard, and Proposal pages), using tab to cycle through links in the page will not include the links in the proposal description which are hidden in the collapsed view, which was causing rendering bugs (see video in issue).

Tab selection behavior is unchanged on Proposal Details view. Still want links in that view to be selectable via tab.