### PR TITLE
Revert safe reset refactor

### DIFF
--- a/src/pages/DAOController.tsx
+++ b/src/pages/DAOController.tsx
@@ -5,7 +5,6 @@ import { toast } from 'react-toastify';
 import useDAOController from '../hooks/DAO/useDAOController';
 import { useUpdateSafeData } from '../hooks/utils/useUpdateSafeData';
 import { useFractal } from '../providers/App/AppProvider';
-import { useRolesStore } from '../store/roles';
 import LoadingProblem from './LoadingProblem';
 
 const useTemporaryProposals = () => {
@@ -34,12 +33,9 @@ const useTemporaryProposals = () => {
 
 export default function DAOController() {
   const { errorLoading, wrongNetwork, invalidQuery } = useDAOController();
-  const { resetHatsStore } = useRolesStore();
-
   useUpdateSafeData();
   const {
-    node: { daoName, daoAddress },
-    action,
+    node: { daoName },
   } = useFractal();
 
   useTemporaryProposals();
@@ -53,14 +49,6 @@ export default function DAOController() {
       document.title = import.meta.env.VITE_APP_NAME;
     };
   }, [daoName]);
-
-  // Reset Safe state when daoAddress is goes null
-  useEffect(() => {
-    if (!daoAddress) {
-      action.resetSafeState();
-      resetHatsStore();
-    }
-  }, [action, resetHatsStore, daoName, daoAddress]);
 
   let display;
 

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { DecentSignature } from '../../assets/theme/custom/icons/DecentSignature';
 import { BASE_ROUTES } from '../../constants/routes';
 import { useFractal } from '../../providers/App/AppProvider';
-import { useRolesState } from '../../state/useRolesState';
+import { useRolesStore } from '../../store/roles';
 import { MySafes } from './MySafes';
 
 export default function HomePage() {
@@ -15,7 +15,7 @@ export default function HomePage() {
   } = useFractal();
 
   const { t } = useTranslation('home');
-  const { resetHatsStore } = useRolesState();
+  const { resetHatsStore } = useRolesStore();
 
   useEffect(() => {
     if (daoAddress) {

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,12 +1,28 @@
 import { Flex, Button, Text, Spacer, Hide } from '@chakra-ui/react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { DecentSignature } from '../../assets/theme/custom/icons/DecentSignature';
 import { BASE_ROUTES } from '../../constants/routes';
+import { useFractal } from '../../providers/App/AppProvider';
+import { useRolesState } from '../../state/useRolesState';
 import { MySafes } from './MySafes';
 
 export default function HomePage() {
+  const {
+    node: { daoAddress },
+    action,
+  } = useFractal();
+
   const { t } = useTranslation('home');
+  const { resetHatsStore } = useRolesState();
+
+  useEffect(() => {
+    if (daoAddress) {
+      action.resetSafeState();
+      resetHatsStore();
+    }
+  }, [daoAddress, action, resetHatsStore]);
 
   return (
     <Flex


### PR DESCRIPTION
In a previous commit, we moved the calls to `resetSafeState` and `resetHatsStore` from the home page to the dao controller component, as that felt like the more logical place to put it. 

While the argument is still valid, this just led to more bugs due to the brittle nature of the flow of safe state changes.

We have tried moving the `reset`s higher up the hierarchy into `Layout/index.tsx` with slightly better result, but far from good enough. 

That said, the decision was made to revert this move for now. This fixes the original bug described in #2084, with the caveat that there are edge cases around switching safes instantly using the search bar, when already on the roles page of the current safe.

This will have to do for now as the most common UX flows to end up on different safes should be fine. I do plan to continue to dig into the original safe state issues in the meantime until more pressing issues get on the radar.