### PR TITLE
Debug reset safe state

### DIFF
--- a/src/components/ui/page/Layout/index.tsx
+++ b/src/components/ui/page/Layout/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Container, Grid, GridItem, Show } from '@chakra-ui/react';
-import { useRef } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { Outlet, useSearchParams } from 'react-router-dom';
 import {
   useContentHeight,
   useHeaderHeight,
@@ -9,6 +9,8 @@ import {
   useFooterHeight,
 } from '../../../../constants/common';
 import useNavigationScrollReset from '../../../../hooks/utils/useNavigationScrollReset';
+import { useFractal } from '../../../../providers/App/AppProvider';
+import { useRolesStore } from '../../../../store/roles';
 import { ErrorBoundary } from '../../utils/ErrorBoundary';
 import { TopErrorFallback } from '../../utils/TopErrorFallback';
 import { Footer } from '../Footer';
@@ -17,6 +19,21 @@ import { NavigationLinks } from '../Navigation/NavigationLinks';
 
 export default function Layout() {
   const headerContainerRef = useRef<HTMLDivElement>(null);
+
+  const [searchParams] = useSearchParams();
+  const safeParam = searchParams.get('dao');
+
+  const { resetHatsStore } = useRolesStore();
+
+  const { action } = useFractal();
+
+  useEffect(() => {
+    if (!safeParam) {
+      console.log('reset safe state from layout');
+      action.resetSafeState();
+      resetHatsStore();
+    }
+  }, [action, resetHatsStore, safeParam]);
 
   const HEADER_HEIGHT = useHeaderHeight();
   const CONTENT_HEIGHT = useContentHeight();

--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -141,7 +141,7 @@ export const useFractalNode = (
       addressPrefix + daoAddress !== currentValidSafe.current
     ) {
       console.count('reset hats store from useFractalNode because:');
-      console.log({ skip, currentValidSafe: currentValidSafe.current, addressPrefix, daoAddress });
+      console.log({ skip, currentValidSafe: currentValidSafe.current, daoAddress });
       reset({ error: false });
       if (addressPrefix && daoAddress) {
         setDAO(addressPrefix, daoAddress);

--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -6,6 +6,7 @@ import { useFractal } from '../../../providers/App/AppProvider';
 import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
 import { NodeAction } from '../../../providers/App/node/action';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
+import { useRolesStore } from '../../../store/roles';
 import { Node } from '../../../types';
 import { mapChildNodes } from '../../../utils/hierarchy';
 import { useGetDAONameDeferred } from '../useGetDAOName';
@@ -35,6 +36,7 @@ export const useFractalNode = (
   const lookupModules = useFractalModules();
 
   const networkConfig = useNetworkConfig();
+  const { resetHatsStore } = useRolesStore();
 
   const formatDAOQuery = useCallback(
     (result: { data?: DAOQueryQuery }, _daoAddress: string) => {
@@ -92,13 +94,16 @@ export const useFractalNode = (
     ({ error }: { error: boolean }) => {
       currentValidSafe.current = undefined;
       action.resetSafeState();
+      resetHatsStore();
       setErrorLoading(error);
     },
-    [action],
+    [action, resetHatsStore],
   );
 
   const setDAO = useCallback(
     async (_addressPrefix: string, _daoAddress: string) => {
+      console.log('setDAO', _daoAddress);
+
       currentValidSafe.current = _addressPrefix + _daoAddress;
       setErrorLoading(false);
 
@@ -135,6 +140,8 @@ export const useFractalNode = (
       daoAddress === undefined ||
       addressPrefix + daoAddress !== currentValidSafe.current
     ) {
+      console.count('reset hats store from useFractalNode because:');
+      console.log({ skip, currentValidSafe: currentValidSafe.current, addressPrefix, daoAddress });
       reset({ error: false });
       if (addressPrefix && daoAddress) {
         setDAO(addressPrefix, daoAddress);

--- a/src/hooks/DAO/loaders/useHatsTree.ts
+++ b/src/hooks/DAO/loaders/useHatsTree.ts
@@ -150,6 +150,7 @@ const useHatsTree = () => {
             decentHats: getAddress(decentHatsMasterCopy),
           });
         } catch (e) {
+          console.log('error in tree load', e);
           if (e instanceof DecentHatsError) {
             toast(e.message);
           }

--- a/src/hooks/DAO/useKeyValuePairs.ts
+++ b/src/hooks/DAO/useKeyValuePairs.ts
@@ -1,5 +1,6 @@
 import { hatIdToTreeId } from '@hatsprotocol/sdk-v1-core';
 import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { GetContractEventsReturnType, getAddress, getContract } from 'viem';
 import { usePublicClient } from 'wagmi';
 import KeyValuePairsAbi from '../../assets/abi/KeyValuePairs';
@@ -62,9 +63,14 @@ const useKeyValuePairs = () => {
     contracts: { keyValuePairs },
   } = useNetworkConfig();
   const { setHatsTreeId } = useRolesStore();
+  const [searchParams] = useSearchParams();
 
   useEffect(() => {
-    if (!publicClient || !node.daoAddress) {
+    const safeParam = searchParams.get('dao');
+    console.log({ safeAddress: node.daoAddress, safeParam });
+
+    if (!publicClient || !node.daoAddress || node.daoAddress !== safeParam?.split(':')[1]) {
+      console.log('not gonna load tree from keyvaluepairs');
       return;
     }
 
@@ -98,7 +104,7 @@ const useKeyValuePairs = () => {
     return () => {
       unwatch();
     };
-  }, [chain.id, keyValuePairs, node.daoAddress, publicClient, setHatsTreeId]);
+  }, [chain.id, keyValuePairs, node.daoAddress, publicClient, searchParams, setHatsTreeId]);
 };
 
 export { useKeyValuePairs };

--- a/src/pages/DAOController.tsx
+++ b/src/pages/DAOController.tsx
@@ -33,7 +33,9 @@ const useTemporaryProposals = () => {
 
 export default function DAOController() {
   const { errorLoading, wrongNetwork, invalidQuery } = useDAOController();
+
   useUpdateSafeData();
+
   const {
     node: { daoName },
   } = useFractal();


### PR DESCRIPTION
### UPDATE:

@decentdao/engineering has decided it is time to take a deeper look at the application's state management. 

To that end, this PR will now serve as the first of a series of PRs with the end goal of migrating to Zustand, AND optimising our state management. 

The logs and guard checks in this PR may or may not change after the work is complete.

In any case we're leaving the changes in - to be merged as _part_ of the state overhaul work - so we can validate that the roles loading issues described below have in fact been fixed. Then we can cleanup whatever needs cleaning up, if any, from the changes on this PR.

---

ORIGINAL DESCRIPTION:

I’m making some progress with the safe state stuff. While there still is the issue of repeated calls to the same set of functions (maybe this already existed and only became visible to me because of debug logging), I think I’ve got to the point where safe changes via the search box do correctly reload its roles.

However.

There a small issue where, only _sometimes_, roles loading fails. We have seen this issue before during pair programming earlier, I think — that was when the roles simply didn’t load for no reason. This is that reason. The hats tree do load, but `sanitize` throws, so roles never get set in state. Now, every time this error has happened, a simple hot reload fixed it. Not even a browser reload — just a “save random VSCode file” reload.

So… the contract call fails randomly, but only when changing safes, BUT it will inevitably work the very next time, implying that if we put it in a retry loop of 2 max calls it’ll work 100% of the time.

Is there any reason that you can think of for this to be the case? I’m stumped atp. Is this worth digging further into?