### PR TITLE
Trim down possible state location of safe address to `node.safe`

### DIFF
--- a/netlify/functions/nftBalances.mts
+++ b/netlify/functions/nftBalances.mts
@@ -1,6 +1,6 @@
 import { getStore } from '@netlify/blobs';
 import Moralis from 'moralis';
-import { isAddress } from 'viem';
+import { getAddress, isAddress } from 'viem';
 import { moralisSupportedChainIds } from '../../src/providers/NetworkConfig/NetworkConfigProvider';
 import type { NFTBalance } from '../../src/types';
 import { camelCaseKeys } from '../../src/utils/dataFormatter';
@@ -73,9 +73,14 @@ export default async function getNftBalances(request: Request) {
           chain: chainId.toString(),
           address: addressParam,
         });
-        mappedNftsData = nftsResponse.result.map(nftBalance =>
-          camelCaseKeys<ReturnType<typeof nftBalance.toJSON>>(nftBalance.toJSON()),
-        );
+        mappedNftsData = nftsResponse.result
+          .map(nftBalance =>
+            camelCaseKeys<ReturnType<typeof nftBalance.toJSON>>(nftBalance.toJSON()),
+          )
+          .map(nft => ({
+            ...nft,
+            tokenAddress: getAddress(nft.tokenAddress),
+          }));
         nftsFetched = true;
       } catch (e) {
         console.error('Error while fetching address NFTs', e);

--- a/src/components/Activity/ActivityAddress.tsx
+++ b/src/components/Activity/ActivityAddress.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
+import { Address } from 'viem';
 import useDisplayName from '../../hooks/utils/useDisplayName';
 import EtherscanLink from '../ui/links/EtherscanLink';
 
@@ -8,7 +9,7 @@ export function ActivityAddress({
   isMe = false,
   addComma,
 }: {
-  address: string;
+  address: Address;
   isMe?: boolean;
   addComma?: boolean;
 }) {

--- a/src/components/Activity/ActivityTreasury.tsx
+++ b/src/components/Activity/ActivityTreasury.tsx
@@ -12,8 +12,11 @@ import { ActivityDescription } from './ActivityDescription';
 export function ActivityTreasury({ activity }: { activity: TreasuryActivity }) {
   const { t } = useTranslation();
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
+
+  const daoAddress = safe?.address;
+
   const eventDateLabel = t(
     activity.eventType === ActivityEventType.Treasury
       ? activity.transaction?.to === daoAddress

--- a/src/components/DaoCreator/StepWrapper.tsx
+++ b/src/components/DaoCreator/StepWrapper.tsx
@@ -27,11 +27,13 @@ export function StepWrapper({
   shouldWrapChildren = true,
 }: IStepWrapper) {
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
   const { t } = useTranslation(['daoCreate']);
   const navigate = useNavigate();
+
+  const daoAddress = safe?.address;
 
   const isEdit = mode === DAOCreateMode.EDIT;
   return (

--- a/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
+++ b/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
@@ -24,10 +24,12 @@ export function EstablishEssentials(props: ICreationStepProps) {
   const { values, setFieldValue, isSubmitting, transactionPending, isSubDAO, errors, mode } = props;
 
   const {
-    node: { daoName, daoSnapshotENS, daoAddress },
+    node: { daoName, daoSnapshotENS, safe },
   } = useFractal();
 
   const isEdit = mode === DAOCreateMode.EDIT;
+
+  const daoAddress = safe?.address;
 
   useEffect(() => {
     if (isEdit) {

--- a/src/components/ProposalBuilder/StepButtons.tsx
+++ b/src/components/ProposalBuilder/StepButtons.tsx
@@ -16,7 +16,7 @@ interface StepButtonsProps extends FormikProps<CreateProposalForm> {
 
 export default function StepButtons(props: StepButtonsProps) {
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const navigate = useNavigate();
   const location = useLocation();
@@ -31,6 +31,8 @@ export default function StepButtons(props: StepButtonsProps) {
     values: { proposalMetadata },
   } = props;
   const { t } = useTranslation(['common', 'proposal']);
+
+  const daoAddress = safe?.address;
 
   if (!daoAddress) {
     return null;

--- a/src/components/ProposalBuilder/index.tsx
+++ b/src/components/ProposalBuilder/index.tsx
@@ -42,9 +42,11 @@ export function ProposalBuilder({
   const isProposalMode = mode === ProposalBuilderMode.PROPOSAL;
 
   const {
-    node: { daoAddress, safe },
+    node: { safe },
     readOnly: { dao },
   } = useFractal();
+  const daoAddress = safe?.address;
+
   const { addressPrefix } = useNetworkConfig();
   const { submitProposal, pendingCreateTx } = useSubmitProposal();
   const { canUserCreateProposal } = useCanUserCreateProposal();

--- a/src/components/ProposalTemplates/ProposalTemplateCard.tsx
+++ b/src/components/ProposalTemplates/ProposalTemplateCard.tsx
@@ -28,8 +28,10 @@ export default function ProposalTemplateCard({
   const navigate = useNavigate();
   const { t } = useTranslation('proposalTemplate');
   const {
-    node: { safe, daoAddress },
+    node: { safe },
   } = useFractal();
+  const daoAddress = safe?.address;
+
   const { addressPrefix } = useNetworkConfig();
 
   const { prepareRemoveProposalTemplateProposal } = useRemoveProposalTemplate();

--- a/src/components/ProposalTemplates/index.tsx
+++ b/src/components/ProposalTemplates/index.tsx
@@ -12,11 +12,12 @@ import ProposalTemplateCard from './ProposalTemplateCard';
 export default function ProposalTemplates() {
   const { t } = useTranslation('proposalTemplate');
   const {
-    node: { daoAddress },
+    node: { safe },
     governance: { proposalTemplates },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
   const { canUserCreateProposal } = useCanUserCreateProposal();
+  const daoAddress = safe?.address;
 
   return (
     <Flex

--- a/src/components/Proposals/MultisigProposalDetails/SignerDetails.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/SignerDetails.tsx
@@ -1,6 +1,7 @@
 import { Box, Grid, GridItem, Text } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
+import { Address, getAddress } from 'viem';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { MultisigProposal } from '../../../types';
 import { DEFAULT_DATE_TIME_FORMAT } from '../../../utils/numberFormats';
@@ -14,7 +15,7 @@ function OwnerInfoRow({
   proposal,
   isMe,
 }: {
-  owner: string;
+  owner: Address;
   proposal: MultisigProposal;
   isMe: boolean;
 }) {
@@ -78,7 +79,7 @@ export function SignerDetails({ proposal }: { proposal: MultisigProposal }) {
           overflowX="auto"
           whiteSpace="nowrap"
         >
-          {safe.owners.map(owner => (
+          {safe.owners.map(getAddress).map(owner => (
             <OwnerInfoRow
               key={owner}
               owner={owner}

--- a/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxDetails.tsx
@@ -2,6 +2,7 @@ import { Box, Text, Flex } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { useTranslation } from 'react-i18next';
+import { getAddress } from 'viem';
 import { createAccountSubstring } from '../../../hooks/utils/useDisplayName';
 import { MultisigProposal } from '../../../types';
 import { DEFAULT_DATE_TIME_FORMAT } from '../../../utils/numberFormats';
@@ -53,7 +54,7 @@ export function TxDetails({ proposal }: { proposal: MultisigProposal }) {
         />
         <Flex mt="1rem">
           {proposal.confirmations && (
-            <ProposalCreatedBy proposer={proposal.confirmations[0].owner} />
+            <ProposalCreatedBy proposer={getAddress(proposal.confirmations[0].owner)} />
           )}
         </Flex>
         <InfoRow

--- a/src/components/Proposals/ProposalCard/ProposalCard.tsx
+++ b/src/components/Proposals/ProposalCard/ProposalCard.tsx
@@ -20,10 +20,11 @@ import { ProposalCountdown } from '../../ui/proposal/ProposalCountdown';
 
 function ProposalCard({ proposal }: { proposal: FractalProposal }) {
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
   const { t } = useTranslation('common');
+  const daoAddress = safe?.address;
 
   const eventDateLabel = t(
     proposal.eventType === ActivityEventType.Treasury

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -182,7 +182,7 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
           </Text>
           <EtherscanLink
             type="block"
-            value={startBlock.toString()}
+            value={startBlock}
             pl={0}
             isTextLink
           >

--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -59,8 +59,8 @@ export function VoteContextProvider({
 
   const { loadVotingWeight } = useSnapshotProposal(proposal as SnapshotProposal);
   const { remainingTokenIds, getUserERC721VotingTokens } = useUserERC721VotingTokens(
-    proposal.proposalId,
     undefined,
+    proposal.proposalId,
     true,
   );
   const { isSnapshotProposal } = useSnapshotProposal(proposal);
@@ -109,7 +109,7 @@ export function VoteContextProvider({
             ).toBigInt() > 0n && !hasVoted;
         } else if (type === GovernanceType.AZORIUS_ERC721) {
           if (refetchUserTokens) {
-            await getUserERC721VotingTokens(null);
+            await getUserERC721VotingTokens();
           }
           newCanVote = user.votingWeight > 0 && remainingTokenIds.length > 0;
         } else if (type === GovernanceType.MULTISIG) {

--- a/src/components/Proposals/ProposalsList.tsx
+++ b/src/components/Proposals/ProposalsList.tsx
@@ -13,12 +13,14 @@ import ProposalCard from './ProposalCard/ProposalCard';
 
 export function ProposalsList({ proposals }: { proposals: FractalProposal[] }) {
   const {
-    node: { daoAddress },
+    node: { safe },
     governance: { loadingProposals, allProposalsLoaded },
   } = useFractal();
   const { canUserCreateProposal } = useCanUserCreateProposal();
   const { addressPrefix } = useNetworkConfig();
   const { t } = useTranslation(['proposal']);
+  const daoAddress = safe?.address;
+
   return (
     <Flex
       flexDirection="column"

--- a/src/components/pages/DAOTreasury/components/AssetCoin.tsx
+++ b/src/components/pages/DAOTreasury/components/AssetCoin.tsx
@@ -46,9 +46,10 @@ export function CoinHeader() {
 
 export function CoinRow({ asset }: { asset: TokenBalance }) {
   const {
-    node: { daoAddress },
+    node: { safe },
     treasury: { totalUsdValue },
   } = useFractal();
+  const daoAddress = safe?.address;
 
   const isNativeCoin =
     asset.tokenAddress.toLowerCase() === MOCK_MORALIS_ETH_ADDRESS.toLowerCase() ||

--- a/src/components/pages/DAOTreasury/components/Assets.tsx
+++ b/src/components/pages/DAOTreasury/components/Assets.tsx
@@ -30,7 +30,7 @@ import { NFTHeader, NFTRow } from './AssetNFT';
 
 export function Assets() {
   const {
-    node: { daoAddress },
+    node: { safe },
     treasury: { assetsFungible, assetsNonFungible, totalUsdValue },
   } = useFractal();
   const { canUserCreateProposal } = useCanUserCreateProposal();
@@ -39,6 +39,8 @@ export function Assets() {
   const ethAsset = assetsFungible.find(asset => !asset.tokenAddress);
   const { handleUnstake, handleClaimUnstakedETH } = useLidoStaking();
   const [expandedIndecies, setExpandedIndecies] = useState<number[]>([]);
+
+  const daoAddress = safe?.address;
 
   // --- Lido Stake button setup ---
   const showStakeButton =

--- a/src/components/pages/DAOTreasury/components/Transactions.tsx
+++ b/src/components/pages/DAOTreasury/components/Transactions.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, HStack, Image, Text, Tooltip, Icon, Flex } from '@chakra-ui/react';
 import { ArrowUp, ArrowDown } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
+import { Address } from 'viem';
 import { useDateTimeDisplay } from '../../../../helpers/dateTime';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
@@ -169,7 +170,7 @@ export function PaginationCount({
 }: {
   totalTransfers: number;
   shownTransactions: number;
-  daoAddress: string | null;
+  daoAddress: Address | undefined;
 }) {
   const { t } = useTranslation('treasury');
   if (!totalTransfers || !daoAddress) {

--- a/src/components/pages/DAOTreasury/hooks/useFormatTransfers.tsx
+++ b/src/components/pages/DAOTreasury/hooks/useFormatTransfers.tsx
@@ -1,4 +1,5 @@
 import { TokenInfoResponse } from '@safe-global/api-kit';
+import { Address, getAddress } from 'viem';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { TransferType } from '../../../../types';
@@ -15,7 +16,7 @@ export interface TransferDisplayData {
   image: string;
   assetDisplay: string;
   fullCoinTotal: string | undefined;
-  transferAddress: string;
+  transferAddress: Address;
   isLast: boolean;
   transactionHash: string;
   tokenId: string;
@@ -24,9 +25,12 @@ export interface TransferDisplayData {
 
 export function useFormatTransfers(): TransferDisplayData[] {
   const {
-    node: { daoAddress },
+    node: { safe },
     treasury: { transfers },
   } = useFractal();
+
+  const daoAddress = safe?.address;
+
   const transfersFromTransactions = (transfers?.results || [])
     .map(transaction => transaction.transfers)
     .flat();
@@ -64,7 +68,7 @@ export function useFormatTransfers(): TransferDisplayData[] {
         transfer.type === TransferType.ERC721_TRANSFER
           ? undefined
           : formatCoin(transfer.value, false, info?.decimals, symbol),
-      transferAddress: daoAddress === transfer.from ? transfer.to : transfer.from,
+      transferAddress: getAddress(daoAddress === transfer.from ? transfer.to : transfer.from),
       isLast: transfersFromTransactions[transfersFromTransactions.length - 1] === transfer,
       transactionHash: transfer.transactionHash,
       tokenId: transfer.tokenId,

--- a/src/components/pages/DaoDashboard/Info/InfoGovernance.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoGovernance.tsx
@@ -13,7 +13,7 @@ import { BarLoader } from '../../../ui/loaders/BarLoader';
 export function InfoGovernance() {
   const { t } = useTranslation(['dashboard', 'daoCreate', 'common']);
   const {
-    node: { daoAddress },
+    node: { safe },
     governance,
     guardContracts: { freezeGuardType, freezeGuardContractAddress },
     readOnly: { dao },
@@ -23,6 +23,9 @@ export function InfoGovernance() {
   const baseContracts = useSafeContracts();
   const [timelockPeriod, setTimelockPeriod] = useState<string>();
   const [executionPeriod, setExecutionPeriod] = useState<string>();
+
+  const daoAddress = safe?.address;
+
   useEffect(() => {
     const setTimelockInfo = async () => {
       const formatBlocks = async (blocks: number): Promise<string | undefined> => {

--- a/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoProposals.tsx
@@ -131,9 +131,11 @@ const allActiveProposalsCount = (
 export function InfoProposals() {
   const { t } = useTranslation('dashboard');
   const {
-    node: { daoAddress },
+    node: { safe },
     governance: { proposals, type, skippedProposalCount },
   } = useFractal();
+
+  const daoAddress = safe?.address;
 
   if (!daoAddress || !type) {
     return (

--- a/src/components/pages/DaoDashboard/Info/InfoTreasury.tsx
+++ b/src/components/pages/DaoDashboard/Info/InfoTreasury.tsx
@@ -7,9 +7,11 @@ import { BarLoader } from '../../../ui/loaders/BarLoader';
 
 export function InfoTreasury() {
   const {
-    node: { daoAddress },
+    node: { safe },
     treasury: { totalUsdValue },
   } = useFractal();
+
+  const daoAddress = safe?.address;
 
   const { t } = useTranslation('dashboard');
 

--- a/src/components/pages/DaoHierarchy/DaoHierarchyNode.tsx
+++ b/src/components/pages/DaoHierarchy/DaoHierarchyNode.tsx
@@ -5,7 +5,7 @@ import { Address, getAddress, zeroAddress } from 'viem';
 import { useLoadDAONode } from '../../../hooks/DAO/loaders/useLoadDAONode';
 import { useLoadDAOData } from '../../../hooks/DAO/useDAOData';
 import { useFractal } from '../../../providers/App/AppProvider';
-import { FractalNode, WithError } from '../../../types';
+import { FractalNode, WithError, Node } from '../../../types';
 import { DAONodeInfoCard, NODE_HEIGHT_REM } from '../../ui/cards/DAONodeInfoCard';
 
 /**
@@ -22,22 +22,22 @@ export function DaoHierarchyNode({
   daoAddress,
   depth,
 }: {
-  parentAddress: Address | null;
-  daoAddress: Address | null;
+  parentAddress: Address | undefined;
+  daoAddress: Address | undefined;
   depth: number;
 }) {
   const {
-    node: { daoAddress: currentDAOAddress },
+    node: { safe: currentSafe },
   } = useFractal();
   const [fractalNode, setNode] = useState<FractalNode>();
   const { loadDao } = useLoadDAONode();
   const { daoData } = useLoadDAOData(parentAddress, fractalNode);
 
   // calculates the total number of descendants below the given node
-  const getTotalDescendants = useCallback((node: FractalNode): number => {
+  const getTotalDescendants = useCallback((node: Node): number => {
     let count = node.nodeHierarchy.childNodes.length;
     node.nodeHierarchy.childNodes.forEach(child => {
-      count += getTotalDescendants(child as FractalNode);
+      count += getTotalDescendants(child);
     });
     return count;
   }, []);
@@ -52,11 +52,10 @@ export function DaoHierarchyNode({
         } else if (errorNode.error === 'errorFailedSearch') {
           setNode({
             daoName: null,
-            daoAddress,
             safe: null,
             fractalModules: [],
             nodeHierarchy: {
-              parentAddress: null,
+              parentAddress: undefined,
               childNodes: [],
             },
           });
@@ -91,7 +90,7 @@ export function DaoHierarchyNode({
             ml="0.5rem"
             boxSize="32px"
             color={
-              currentDAOAddress === getAddress(childNode.daoAddress || zeroAddress)
+              currentSafe?.address === getAddress(childNode.daoAddress || zeroAddress)
                 ? 'celery-0'
                 : 'neutral-6'
             }

--- a/src/components/pages/DaoSettings/components/MetadataContainer.tsx
+++ b/src/components/pages/DaoSettings/components/MetadataContainer.tsx
@@ -25,12 +25,14 @@ export function MetadataContainer() {
   const { canUserCreateProposal } = useCanUserCreateProposal();
   const {
     baseContracts,
-    node: { daoName, daoSnapshotENS, daoAddress, safe },
+    node: { daoName, daoSnapshotENS, safe },
     readOnly: {
       user: { votingWeight },
     },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
+
+  const daoAddress = safe?.address;
 
   useEffect(() => {
     if (daoName && daoAddress && createAccountSubstring(daoAddress) !== daoName) {

--- a/src/components/pages/DaoSettings/components/Signers/SignersContainer.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/SignersContainer.tsx
@@ -2,6 +2,7 @@ import { Button, Flex, HStack, Show, Text, Hide, Icon } from '@chakra-ui/react';
 import { PlusCircle, MinusCircle } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Address, getAddress } from 'viem';
 import { useAccount } from 'wagmi';
 import { useFractal } from '../../../../../providers/App/AppProvider';
 import { DisplayAddress } from '../../../../ui/links/DisplayAddress';
@@ -15,7 +16,7 @@ function Signer({
   threshold,
   disabled,
 }: {
-  signer: string;
+  signer: Address;
   signers: string[];
   threshold: number | undefined;
   disabled: boolean;
@@ -65,7 +66,7 @@ export function SignersContainer() {
   const {
     node: { safe },
   } = useFractal();
-  const [signers, setSigners] = useState<string[]>();
+  const [signers, setSigners] = useState<Address[]>();
   const [userIsSigner, setUserIsSigner] = useState<boolean>();
 
   const addSigner = useFractalModal(ModalType.ADD_SIGNER, {
@@ -77,7 +78,7 @@ export function SignersContainer() {
   const enableRemove = userIsSigner && signers && signers?.length > 1;
 
   useEffect(() => {
-    setSigners(safe?.owners.map(owner => owner));
+    setSigners(safe?.owners.map(getAddress));
   }, [safe?.owners]);
 
   useEffect(() => {

--- a/src/components/pages/DaoSettings/components/Signers/hooks/useAddSigner.ts
+++ b/src/components/pages/DaoSettings/components/Signers/hooks/useAddSigner.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getAddress, isHex } from 'viem';
+import { Address, getAddress, isHex } from 'viem';
 import useSubmitProposal from '../../../../../../hooks/DAO/proposal/useSubmitProposal';
 import { useFractal } from '../../../../../../providers/App/AppProvider';
 import { ProposalExecuteData } from '../../../../../../types';
@@ -17,10 +17,10 @@ const useAddSigner = () => {
       daoAddress,
       close,
     }: {
-      newSigner: string;
+      newSigner: Address;
       threshold: number;
       nonce: number;
-      daoAddress: string | null;
+      daoAddress?: Address;
       close: () => void;
     }) => {
       if (!baseContracts || !daoAddress) {

--- a/src/components/pages/DaoSettings/components/Signers/hooks/useRemoveSigner.ts
+++ b/src/components/pages/DaoSettings/components/Signers/hooks/useRemoveSigner.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isHex, getAddress } from 'viem';
+import { isHex, Address } from 'viem';
 import useSubmitProposal from '../../../../../../hooks/DAO/proposal/useSubmitProposal';
 import { useFractal } from '../../../../../../providers/App/AppProvider';
 import { ProposalExecuteData } from '../../../../../../types';
@@ -16,7 +16,7 @@ const useRemoveSigner = ({
   signerToRemove: string;
   threshold: number;
   nonce: number | undefined;
-  daoAddress: string | null;
+  daoAddress?: Address;
 }) => {
   const { submitProposal } = useSubmitProposal();
   const { t } = useTranslation(['modals']);
@@ -41,7 +41,7 @@ const useRemoveSigner = ({
     const calldatas = [encodedRemoveOwner];
 
     const proposalData: ProposalExecuteData = {
-      targets: [getAddress(daoAddress)],
+      targets: [daoAddress],
       values: [0n],
       calldatas,
       metaData: {

--- a/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
@@ -3,11 +3,11 @@ import { WarningCircle } from '@phosphor-icons/react';
 import { Field, FieldAttributes, Formik } from 'formik';
 import { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Address, getAddress, isAddress } from 'viem';
 import * as Yup from 'yup';
 import { useValidationAddress } from '../../../../../../hooks/schemas/common/useValidationAddress';
 import { useFractal } from '../../../../../../providers/App/AppProvider';
 import { useEthersSigner } from '../../../../../../providers/Ethers/hooks/useEthersSigner';
-import { validateENSName } from '../../../../../../utils/url';
 import SupportTooltip from '../../../../../ui/badges/SupportTooltip';
 import { CustomNonceInput } from '../../../../../ui/forms/CustomNonceInput';
 import { AddressInput } from '../../../../../ui/forms/EthAddressInput';
@@ -25,30 +25,42 @@ function AddSignerModal({
   currentThreshold: number;
 }) {
   const {
-    node: { daoAddress, safe },
+    node: { safe },
   } = useFractal();
   const { t } = useTranslation(['modals', 'common']);
   const signer = useEthersSigner();
   const { addressValidationTest, newSignerValidationTest } = useValidationAddress();
   const tooltipContainer = useRef<HTMLDivElement>(null);
 
+  const daoAddress = safe?.address;
+
   const addSigner = useAddSigner();
 
   const onSubmit = useCallback(
-    async (values: { address: string; threshold: number; nonce: number }) => {
-      const { address, nonce, threshold } = values;
-      let validAddress = address;
-      if (validateENSName(validAddress) && signer) {
-        validAddress = await signer.resolveName(address);
-      }
+    async (values: { addressOrENS: string; threshold: number; nonce: number }) => {
+      const { addressOrENS, nonce, threshold } = values;
 
-      await addSigner({
-        newSigner: validAddress,
-        threshold: threshold,
-        nonce: nonce,
-        daoAddress: daoAddress,
-        close: close,
-      });
+      let validAddress: Address;
+      try {
+        if (isAddress(addressOrENS)) {
+          validAddress = getAddress(addressOrENS);
+        } else if (signer) {
+          validAddress = (await signer.resolveName(addressOrENS)) as Address;
+        } else {
+          throw new Error('No signer found');
+        }
+
+        await addSigner({
+          newSigner: validAddress,
+          threshold: threshold,
+          nonce: nonce,
+          daoAddress: daoAddress,
+          close: close,
+        });
+      } catch (e) {
+        console.error(e);
+        throw new Error('Error adding signer');
+      }
     },
     [addSigner, close, daoAddress, signer],
   );
@@ -66,7 +78,7 @@ function AddSignerModal({
     <Box>
       <Formik
         initialValues={{
-          address: '',
+          addressOrENS: '',
           nonce: safe?.nextNonce || 0,
           threshold: currentThreshold,
           thresholdOptions: Array.from({ length: signers.length + 1 }, (_, i) => i + 1),
@@ -83,11 +95,11 @@ function AddSignerModal({
                   // LabelWrapper title styling needs to updated on @decent-org/fractal-ui, it seems
                   <LabelWrapper
                     subLabel={t('addSignerSublabel', { ns: 'modals' })}
-                    errorMessage={field.value && errors.address}
+                    errorMessage={field.value && errors.addressOrENS}
                   >
                     <AddressInput
                       {...field}
-                      isInvalid={!!field.value && !!errors.address}
+                      isInvalid={!!field.value && !!errors.addressOrENS}
                     />
                   </LabelWrapper>
                 )}

--- a/src/components/pages/DaoSettings/components/Signers/modals/RemoveSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/RemoveSignerModal.tsx
@@ -24,7 +24,7 @@ function RemoveSignerModal({
   currentThreshold: number;
 }) {
   const {
-    node: { daoAddress, safe },
+    node: { safe },
   } = useFractal();
   const [thresholdOptions, setThresholdOptions] = useState<number[]>();
   const [prevSigner, setPrevSigner] = useState<string>('');
@@ -37,6 +37,7 @@ function RemoveSignerModal({
   });
   const { t } = useTranslation(['modals', 'common']);
   const tooltipContainer = useRef<HTMLDivElement>(null);
+  const daoAddress = safe?.address;
 
   useEffect(() => {
     setThresholdOptions(Array.from({ length: signers.length - 1 }, (_, i) => i + 1));

--- a/src/components/pages/Roles/RolesDetailsDrawer.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawer.tsx
@@ -59,8 +59,10 @@ export default function RolesDetailsDrawer({
   payments,
 }: RoleDetailsDrawerProps) {
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
+  const daoAddress = safe?.address;
+
   const { chain } = useNetworkConfig();
   const { t } = useTranslation(['roles']);
   const { daoName: accountDisplayName } = useGetDAOName({

--- a/src/components/pages/Roles/RolesDetailsDrawerMobile.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawerMobile.tsx
@@ -32,10 +32,12 @@ export default function RolesDetailsDrawerMobile({
   payments,
 }: RoleDetailsDrawerMobileProps) {
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const { t } = useTranslation('roles');
   const { hatsTree } = useRolesStore();
+
+  const daoAddress = safe?.address;
 
   if (!daoAddress || !hatsTree) return null;
 

--- a/src/components/pages/Roles/forms/RoleFormCreateProposal.tsx
+++ b/src/components/pages/Roles/forms/RoleFormCreateProposal.tsx
@@ -25,10 +25,12 @@ export default function RoleFormCreateProposal({ close }: { close: () => void })
   }, [values.hats]);
 
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const navigate = useNavigate();
   const { addressPrefix } = useNetworkConfig();
+
+  const daoAddress = safe?.address;
 
   const handleEditRoleClick = useCallback(
     (hatId: Hex) => {

--- a/src/components/pages/Roles/forms/RoleFormTabs.tsx
+++ b/src/components/pages/Roles/forms/RoleFormTabs.tsx
@@ -33,13 +33,14 @@ export default function RoleFormTabs({
 }) {
   const { hatsTree } = useRolesStore();
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const navigate = useNavigate();
   const { addressPrefix } = useNetworkConfig();
   const { editedRoleData } = useRoleFormEditedRole({ hatsTree });
   const { t } = useTranslation(['roles']);
   const { values, errors, setFieldValue } = useFormikContext<RoleFormValues>();
+  const daoAddress = safe?.address;
 
   useEffect(() => {
     if (values.hats.length && !values.roleEditing) {

--- a/src/components/ui/cards/DAOInfoCard.tsx
+++ b/src/components/ui/cards/DAOInfoCard.tsx
@@ -27,10 +27,10 @@ export function DAOInfoCard() {
   const { addressPrefix } = useNetworkConfig();
 
   // for non Fractal Safes
-  const { displayName } = useDisplayName(node?.daoAddress);
+  const { displayName } = useDisplayName(node.safe?.address);
 
   // node hasn't loaded yet
-  if (!node || !node.daoAddress) {
+  if (!node || !node.safe?.address) {
     return (
       <Flex
         w="full"
@@ -43,7 +43,7 @@ export function DAOInfoCard() {
     );
   }
 
-  const displayedAddress = node.daoAddress;
+  const displayedAddress = node.safe.address;
 
   return (
     <Box>

--- a/src/components/ui/cards/DAONodeInfoCard.tsx
+++ b/src/components/ui/cards/DAONodeInfoCard.tsx
@@ -31,14 +31,14 @@ export interface InfoProps extends FlexProps {
  */
 export function DAONodeInfoCard({ node, freezeGuard, guardContracts, ...rest }: InfoProps) {
   const {
-    node: { daoAddress: currentDAOAddress }, // used ONLY to determine if we're on the current DAO
+    node: { safe: currentSafe }, // used ONLY to determine if we're on the current DAO
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
   // for non Fractal Safes
-  const { displayName } = useDisplayName(node?.daoAddress);
+  const { displayName } = useDisplayName(node?.safe?.address);
 
   // node hasn't loaded yet
-  if (!node || !node.daoAddress) {
+  if (!node || !node.safe?.address) {
     return (
       <Flex
         w="full"
@@ -52,8 +52,8 @@ export function DAONodeInfoCard({ node, freezeGuard, guardContracts, ...rest }: 
     );
   }
 
-  const displayedAddress = node.daoAddress;
-  const isCurrentDAO = displayedAddress === currentDAOAddress;
+  const displayedAddress = node.safe.address;
+  const isCurrentDAO = displayedAddress === currentSafe?.address;
 
   return (
     <Link

--- a/src/components/ui/links/DisplayAddress.tsx
+++ b/src/components/ui/links/DisplayAddress.tsx
@@ -1,6 +1,7 @@
 import { Flex, Text, Icon, LinkProps } from '@chakra-ui/react';
 import { ArrowUpRight } from '@phosphor-icons/react';
 import { ReactNode } from 'react';
+import { Address } from 'viem';
 import useDisplayName from '../../../hooks/utils/useDisplayName';
 import EtherscanLink from './EtherscanLink';
 
@@ -11,7 +12,7 @@ export function DisplayAddress({
   isTextLink,
   ...rest
 }: {
-  address: string;
+  address: Address;
   truncate?: boolean;
   isTextLink?: boolean;
   children?: ReactNode;

--- a/src/components/ui/links/DisplayTransaction.tsx
+++ b/src/components/ui/links/DisplayTransaction.tsx
@@ -1,5 +1,6 @@
 import { Flex, Text, Icon } from '@chakra-ui/react';
 import { ArrowUpRight } from '@phosphor-icons/react';
+import { Hex } from 'viem';
 import { createAccountSubstring } from '../../../hooks/utils/useDisplayName';
 import EtherscanLink from './EtherscanLink';
 
@@ -7,7 +8,7 @@ export default function DisplayTransaction({
   txHash,
   isTextLink,
 }: {
-  txHash: string;
+  txHash: Hex;
   isTextLink?: boolean;
 }) {
   const displayName = createAccountSubstring(txHash);

--- a/src/components/ui/links/EtherscanLink.tsx
+++ b/src/components/ui/links/EtherscanLink.tsx
@@ -1,13 +1,14 @@
 import { Box, LinkProps } from '@chakra-ui/react';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Hex } from 'viem';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import ModalTooltip from '../modals/ModalTooltip';
 import ExternalLink from './ExternalLink';
 
 export interface EtherscanLinkProps extends LinkProps {
   type: 'address' | 'block' | 'token' | 'tx';
-  value: string | null;
+  value?: Hex | bigint;
   secondaryValue?: string;
   isTextLink?: boolean;
 }
@@ -26,7 +27,7 @@ export default function EtherscanLink({
   if (!value) {
     return null;
   }
-  const href = `${etherscanBaseURL}/${type}/${value}${secondaryValue ? `?a=${secondaryValue}` : ''}`;
+  const href = `${etherscanBaseURL}/${type}/${value.toString()}${secondaryValue ? `?a=${secondaryValue}` : ''}`;
 
   return (
     <ExternalLink

--- a/src/components/ui/menus/DAOSearch/SearchDisplay.tsx
+++ b/src/components/ui/menus/DAOSearch/SearchDisplay.tsx
@@ -28,7 +28,7 @@ export function SearchDisplay({
   const { addressPrefix } = useNetworkConfig();
 
   const isCurrentSafe = useMemo(
-    () => !!node && !!node.daoAddress && node.daoAddress === address,
+    () => !!node && !!node?.safe?.address && node.safe.address === address,
     [node, address],
   );
 

--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -31,7 +31,7 @@ import { useFractalModal } from '../../modals/useFractalModal';
 import { OptionMenu } from '../OptionMenu';
 
 interface IManageDAOMenu {
-  parentAddress: Address | null;
+  parentAddress: Address | undefined;
   fractalNode: FractalNode;
   freezeGuard: FreezeGuard;
   guardContracts: FractalGuardContracts;
@@ -60,7 +60,7 @@ export function ManageDAOMenu({
   const baseContracts = useSafeContracts();
   const currentTime = BigInt(useBlockTimestamp());
   const navigate = useNavigate();
-  const safeAddress = fractalNode.daoAddress;
+  const safeAddress = fractalNode.safe?.address;
   const { getZodiacModuleProxyMasterCopyData } = useMasterCopy();
   const { canUserCreateProposal } = useCanUserCreateProposal();
   const { getUserERC721VotingTokens } = useUserERC721VotingTokens(safeAddress, undefined, false);

--- a/src/components/ui/modals/ConfirmModifyGovernanceModal.tsx
+++ b/src/components/ui/modals/ConfirmModifyGovernanceModal.tsx
@@ -9,9 +9,11 @@ import Divider from '../utils/Divider';
 export function ConfirmModifyGovernanceModal({ close }: { close: () => void }) {
   const { t } = useTranslation('modals');
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
+
+  const daoAddress = safe?.address;
 
   if (!daoAddress) {
     return null;

--- a/src/components/ui/modals/ProposalTemplateModal.tsx
+++ b/src/components/ui/modals/ProposalTemplateModal.tsx
@@ -26,9 +26,11 @@ export default function ProposalTemplateModal({
   onClose,
 }: IProposalTemplateModalProps) {
   const {
-    node: { daoAddress, safe },
+    node: { safe },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
+
+  const daoAddress = safe?.address;
 
   const [filledProposalTransactions, setFilledProposalTransactions] = useState(transactions);
   const [nonce, setNonce] = useState<number | undefined>(safe!.nextNonce);

--- a/src/components/ui/modals/Stake.tsx
+++ b/src/components/ui/modals/Stake.tsx
@@ -11,12 +11,14 @@ import { BigIntInput } from '../forms/BigIntInput';
 
 export default function StakeModal({ close }: { close: () => void }) {
   const {
-    node: { daoAddress },
+    node: { safe },
     treasury: { assetsFungible },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
   const navigate = useNavigate();
   const { t } = useTranslation('stake');
+
+  const daoAddress = safe?.address;
 
   const fungibleAssetsWithBalance = assetsFungible.filter(asset => parseFloat(asset.balance) > 0);
 

--- a/src/components/ui/page/Header/PageHeader.tsx
+++ b/src/components/ui/page/Header/PageHeader.tsx
@@ -45,9 +45,10 @@ function PageHeader({
   children,
 }: PageHeaderProps) {
   const {
-    node: { daoAddress, daoName },
+    node: { safe, daoName },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
+  const daoAddress = safe?.address;
 
   const [links, setLinks] = useState([...breadcrumbs]);
 

--- a/src/components/ui/page/Navigation/NavigationLinks.tsx
+++ b/src/components/ui/page/Navigation/NavigationLinks.tsx
@@ -62,9 +62,11 @@ function ExternalLinks({ closeDrawer }: { closeDrawer?: () => void }) {
 
 function InternalLinks({ closeDrawer }: { closeDrawer?: () => void }) {
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
+
+  const daoAddress = safe?.address;
 
   if (!daoAddress) {
     return null;

--- a/src/components/ui/proposal/InfoRow.tsx
+++ b/src/components/ui/proposal/InfoRow.tsx
@@ -1,4 +1,5 @@
 import { Box, Text, Tooltip } from '@chakra-ui/react';
+import { Hex } from 'viem';
 import DisplayTransaction from '../../ui/links/DisplayTransaction';
 
 export default function InfoRow({
@@ -9,7 +10,7 @@ export default function InfoRow({
 }: {
   property: string;
   value?: string;
-  txHash?: string | null;
+  txHash?: Hex | null;
   tooltip?: string;
 }) {
   return (

--- a/src/components/ui/proposal/ProposalCreatedBy.tsx
+++ b/src/components/ui/proposal/ProposalCreatedBy.tsx
@@ -1,8 +1,9 @@
 import { Box, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
+import { Address } from 'viem';
 import { DisplayAddress } from '../links/DisplayAddress';
 
-function ProposalCreatedBy({ proposer }: { proposer: string }) {
+function ProposalCreatedBy({ proposer }: { proposer: Address }) {
   const { t } = useTranslation('proposal');
   return (
     <Box

--- a/src/hooks/DAO/loaders/governance/useAzoriusListeners.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusListeners.ts
@@ -73,7 +73,7 @@ const proposalCreatedEventListener = (
       erc721StrategyContract,
       strategyType,
       proposalId.toBigInt(),
-      proposer,
+      getAddress(proposer),
       azoriusContract,
       provider,
       Promise.resolve(undefined),

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -255,7 +255,7 @@ export const useAzoriusProposals = () => {
           _erc721StrategyContract,
           _strategyType,
           proposalCreatedEvent.args.proposalId.toBigInt(),
-          proposalCreatedEvent.args.proposer,
+          getAddress(proposalCreatedEvent.args.proposer),
           _azoriusContract,
           _provider,
           _erc20VotedEvents,

--- a/src/hooks/DAO/loaders/governance/useERC20Claim.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20Claim.ts
@@ -9,11 +9,14 @@ import useSafeContracts from '../../../safe/useSafeContracts';
 
 export function useERC20Claim() {
   const {
-    node: { daoAddress },
+    node: { safe },
     governanceContracts: { votesTokenContractAddress },
     action,
   } = useFractal();
   const baseContracts = useSafeContracts();
+
+  const daoAddress = safe?.address;
+
   const loadTokenClaimContract = useCallback(async () => {
     if (!baseContracts || !votesTokenContractAddress) {
       return;

--- a/src/hooks/DAO/loaders/governance/useERC20LinearToken.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20LinearToken.ts
@@ -72,7 +72,7 @@ export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) =
     // @todo We could probably save on some requests here.
     const [tokenBalance, tokenDelegatee, tokenVotingWeight] = await Promise.all([
       (await tokenContract.balanceOf(account)).toBigInt(),
-      tokenContract.delegates(account),
+      getAddress(await tokenContract.delegates(account)),
       (await tokenContract.getVotes(account)).toBigInt(),
     ]);
 

--- a/src/hooks/DAO/loaders/governance/useLockRelease.ts
+++ b/src/hooks/DAO/loaders/governance/useLockRelease.ts
@@ -1,5 +1,6 @@
 import { DelegateChangedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/VotesERC20';
 import { useCallback, useEffect, useRef } from 'react';
+import { getAddress } from 'viem';
 import { LockRelease__factory } from '../../../../assets/typechain-types/dcnt';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { DecentGovernanceAction } from '../../../../providers/App/governance/action';
@@ -31,7 +32,7 @@ export const useLockRelease = ({ onMount = true }: { onMount?: boolean }) => {
       await Promise.all([
         (await lockReleaseContract.getTotal(account)).toBigInt(),
         (await lockReleaseContract.getReleased(account)).toBigInt(),
-        lockReleaseContract.delegates(account),
+        getAddress(await lockReleaseContract.delegates(account)),
         (await lockReleaseContract.getVotes(account)).toBigInt(),
       ]);
 

--- a/src/hooks/DAO/loaders/governance/useSafeMultisigProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useSafeMultisigProposals.ts
@@ -8,12 +8,14 @@ import { useSafeTransactions } from '../../../utils/useSafeTransactions';
 
 export const useSafeMultisigProposals = () => {
   const {
-    node: { daoAddress },
+    node: { safe },
     action,
   } = useFractal();
   const safeAPI = useSafeAPI();
 
   const { parseTransactions } = useSafeTransactions();
+
+  const daoAddress = safe?.address;
 
   const loadSafeMultisigProposals = useCallback(async () => {
     if (!daoAddress || !safeAPI) {

--- a/src/hooks/DAO/loaders/useDecentTreasury.ts
+++ b/src/hooks/DAO/loaders/useDecentTreasury.ts
@@ -11,13 +11,15 @@ export const useDecentTreasury = () => {
   // tracks the current valid DAO address / chain; helps prevent unnecessary calls
   const loadKey = useRef<string | null>();
   const {
-    node: { daoAddress },
+    node: { safe },
     action,
   } = useFractal();
   const safeAPI = useSafeAPI();
   const { getTokenBalances, getNFTBalances } = useBalancesAPI();
 
   const { chain } = useNetworkConfig();
+
+  const daoAddress = safe?.address;
 
   const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
 

--- a/src/hooks/DAO/loaders/useFractalFreeze.ts
+++ b/src/hooks/DAO/loaders/useFractalFreeze.ts
@@ -6,7 +6,7 @@ import {
 import { TypedListener } from '@fractal-framework/fractal-contracts/dist/typechain-types/common';
 import { FreezeVoteCastEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/ERC20FreezeVoting';
 import { useCallback, useEffect, useRef } from 'react';
-import { zeroAddress } from 'viem';
+import { Address, zeroAddress } from 'viem';
 import { useAccount } from 'wagmi';
 import {
   isWithinFreezeProposalPeriod,
@@ -26,7 +26,7 @@ export const useFractalFreeze = ({
   parentSafeAddress,
 }: {
   loadOnMount?: boolean;
-  parentSafeAddress: string | null;
+  parentSafeAddress?: Address;
 }) => {
   // load key for component; helps prevent unnecessary calls
   const loadKey = useRef<string>();

--- a/src/hooks/DAO/loaders/useFractalGovernance.ts
+++ b/src/hooks/DAO/loaders/useFractalGovernance.ts
@@ -18,12 +18,14 @@ export const useFractalGovernance = () => {
   const loadKey = useRef<string>();
 
   const {
-    node: { daoAddress },
+    node: { safe },
     governanceContracts,
     action,
     governance: { type },
     guardContracts: { isGuardLoaded },
   } = useFractal();
+
+  const daoAddress = safe?.address;
 
   const loadDAOProposals = useLoadDAOProposals();
   const loadERC20Strategy = useERC20LinearStrategy();

--- a/src/hooks/DAO/loaders/useFractalGuardContracts.ts
+++ b/src/hooks/DAO/loaders/useFractalGuardContracts.ts
@@ -14,10 +14,12 @@ export const useFractalGuardContracts = ({ loadOnMount = true }: { loadOnMount?:
   // load key for component; helps prevent unnecessary calls
   const loadKey = useRef<string>();
   const {
-    node: { daoAddress, safe, fractalModules, isHierarchyLoaded },
+    node: { safe, fractalModules, isHierarchyLoaded },
     action,
   } = useFractal();
   const baseContracts = useSafeContracts();
+
+  const daoAddress = safe?.address;
 
   const { chain } = useNetworkConfig();
 

--- a/src/hooks/DAO/loaders/useFractalModules.ts
+++ b/src/hooks/DAO/loaders/useFractalModules.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { getAddress } from 'viem';
+import { Address, getAddress } from 'viem';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { FractalModuleData, FractalModuleType } from '../../../types';
 import { useMasterCopy } from '../../utils/useMasterCopy';
@@ -8,7 +8,7 @@ export const useFractalModules = () => {
   const { baseContracts } = useFractal();
   const { getZodiacModuleProxyMasterCopyData } = useMasterCopy();
   const lookupModules = useCallback(
-    async (_moduleAddresses: string[]) => {
+    async (_moduleAddresses: Address[]) => {
       const modules = await Promise.all(
         _moduleAddresses.map(async moduleAddress => {
           const masterCopyData = await getZodiacModuleProxyMasterCopyData(

--- a/src/hooks/DAO/loaders/useGovernanceContracts.ts
+++ b/src/hooks/DAO/loaders/useGovernanceContracts.ts
@@ -18,7 +18,9 @@ export const useGovernanceContracts = () => {
   const { getZodiacModuleProxyMasterCopyData } = useMasterCopy();
   const publicClient = usePublicClient();
 
-  const { fractalModules, isModulesLoaded, daoAddress } = node;
+  const { fractalModules, isModulesLoaded, safe } = node;
+
+  const daoAddress = safe?.address;
 
   const loadGovernanceContracts = useCallback(async () => {
     if (!baseContracts || !publicClient) {

--- a/src/hooks/DAO/loaders/useLoadDAOProposals.ts
+++ b/src/hooks/DAO/loaders/useLoadDAOProposals.ts
@@ -8,10 +8,12 @@ import { useSafeMultisigProposals } from './governance/useSafeMultisigProposals'
 
 export const useLoadDAOProposals = () => {
   const {
-    node: { daoAddress },
+    node: { safe },
     governance: { type },
     action,
   } = useFractal();
+
+  const daoAddress = safe?.address;
 
   const { setMethodOnInterval, clearIntervals } = useUpdateTimer(daoAddress);
   const loadAzoriusProposals = useAzoriusProposals();

--- a/src/hooks/DAO/proposal/useCastVote.ts
+++ b/src/hooks/DAO/proposal/useCastVote.ts
@@ -55,6 +55,7 @@ const useCastVote = ({
   const [contractCallCastVote, contractCallPending] = useTransaction();
 
   const { remainingTokenIds, remainingTokenAddresses } = useUserERC721VotingTokens(
+    undefined,
     proposal.proposalId,
   );
   const { getCanVote, getHasVoted } = useVoteContext();

--- a/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
+++ b/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
@@ -5,7 +5,7 @@ import {
   LinearERC721Voting,
 } from '@fractal-framework/fractal-contracts';
 import { useState, useEffect, useCallback } from 'react';
-import { getAddress } from 'viem';
+import { Address, getAddress } from 'viem';
 import { logError } from '../../../helpers/errorLogging';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
@@ -27,7 +27,7 @@ import { useFractalModules } from '../loaders/useFractalModules';
  * @returns {string[]} `remainingTokenAddresses` - same as `totalVotingTokenAddresses` - repeats contract address of NFT for each token ID in `remainingTokenIds` array.
  */
 export default function useUserERC721VotingTokens(
-  safeAddress: string | null,
+  safeAddress: Address | undefined,
   proposalId?: string,
   loadOnMount: boolean = true,
 ) {
@@ -38,7 +38,7 @@ export default function useUserERC721VotingTokens(
 
   const signerOrProvider = useSignerOrProvider();
   const {
-    node: { daoAddress },
+    node: { safe },
     governanceContracts: { erc721LinearVotingContractAddress },
     governance,
     readOnly: { user },
@@ -50,8 +50,10 @@ export default function useUserERC721VotingTokens(
   const azoriusGovernance = governance as AzoriusGovernance;
   const { erc721Tokens } = azoriusGovernance;
 
+  const daoAddress = safe?.address;
+
   const getUserERC721VotingTokens = useCallback(
-    async (_safeAddress: string | null, _proposalId?: string) => {
+    async (_safeAddress?: Address, _proposalId?: string) => {
       const totalTokenAddresses: string[] = [];
       const totalTokenIds: string[] = [];
       const tokenAddresses: string[] = [];

--- a/src/hooks/DAO/useCastFreezeVote.ts
+++ b/src/hooks/DAO/useCastFreezeVote.ts
@@ -19,7 +19,7 @@ const useCastFreezeVote = ({
     },
   } = useFractal();
   const baseContracts = useSafeContracts();
-  const { getUserERC721VotingTokens } = useUserERC721VotingTokens(null, undefined, false);
+  const { getUserERC721VotingTokens } = useUserERC721VotingTokens(undefined, undefined, false);
 
   useEffect(() => {
     setPending(contractCallPending);

--- a/src/hooks/DAO/useClawBack.ts
+++ b/src/hooks/DAO/useClawBack.ts
@@ -12,7 +12,7 @@ import useSubmitProposal from './proposal/useSubmitProposal';
 
 interface IUseClawBack {
   childSafeInfo: FractalNode;
-  parentAddress: Address | null;
+  parentAddress: Address | undefined;
 }
 
 export default function useClawBack({ childSafeInfo, parentAddress }: IUseClawBack) {
@@ -24,8 +24,8 @@ export default function useClawBack({ childSafeInfo, parentAddress }: IUseClawBa
   const { getTokenBalances } = useBalancesAPI();
 
   const handleClawBack = useCallback(async () => {
-    if (childSafeInfo.daoAddress && parentAddress && safeAPI && provider) {
-      const childSafeBalance = await getTokenBalances(childSafeInfo.daoAddress);
+    if (childSafeInfo?.safe?.address && parentAddress && safeAPI && provider) {
+      const childSafeBalance = await getTokenBalances(childSafeInfo.safe.address);
 
       if (childSafeBalance.error || !childSafeBalance.data) {
         toast(t('clawBackBalancesError', { autoClose: false }));

--- a/src/hooks/DAO/useCreateSubDAOProposal.ts
+++ b/src/hooks/DAO/useCreateSubDAOProposal.ts
@@ -16,10 +16,13 @@ export const useCreateSubDAOProposal = () => {
   const { canUserCreateProposal } = useCanUserCreateProposal();
   const [build] = useBuildDAOTx();
   const {
-    node: { daoAddress },
+    node: { safe },
     governance,
   } = useFractal();
   const azoriusGovernance = governance as AzoriusGovernance;
+
+  const daoAddress = safe?.address;
+
   const proposeDao = useCallback(
     (
       daoData: AzoriusERC20DAO | AzoriusERC721DAO | SafeMultisigDAO,

--- a/src/hooks/DAO/useDAOData.ts
+++ b/src/hooks/DAO/useDAOData.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Address } from 'viem';
 import { initialGuardState } from '../../providers/App/guard/reducer';
 import { initialGuardContractsState } from '../../providers/App/guardContracts/reducer';
 import { FractalNode } from '../../types';
@@ -11,7 +12,7 @@ import { useFractalGuardContracts } from './loaders/useFractalGuardContracts';
  * A hook for loading guard and freeze guard contract data for the provided
  * FractalNode.
  */
-export function useLoadDAOData(parentAddress: string | null, fractalNode?: FractalNode) {
+export function useLoadDAOData(parentAddress?: Address, fractalNode?: FractalNode) {
   const [daoData, setDAOData] = useState<DAOData>();
   const loadFractalGuardContracts = useFractalGuardContracts({ loadOnMount: false });
   const loadFractalFreezeGuard = useFractalFreeze({
@@ -24,7 +25,8 @@ export function useLoadDAOData(parentAddress: string | null, fractalNode?: Fract
       if (!fractalNode) {
         return;
       }
-      const { daoAddress, safe, fractalModules } = fractalNode;
+      const { safe, fractalModules } = fractalNode;
+      const daoAddress = safe?.address;
 
       if (!daoAddress || !safe) {
         return;

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -25,13 +25,16 @@ const useDeployAzorius = () => {
     addressPrefix,
   } = useNetworkConfig();
   const {
-    node: { daoAddress, safe },
+    node: { safe },
     baseContracts,
   } = useFractal();
 
   const { t } = useTranslation(['transaction', 'proposalMetadata']);
   const { submitProposal } = useSubmitProposal();
   const { canUserCreateProposal } = useCanUserCreateProposal();
+
+  const daoAddress = safe?.address;
+
   const deployAzorius = useCallback(
     async (
       daoData: AzoriusERC20DAO | AzoriusERC721DAO,

--- a/src/hooks/DAO/useKeyValuePairs.ts
+++ b/src/hooks/DAO/useKeyValuePairs.ts
@@ -67,9 +67,9 @@ const useKeyValuePairs = () => {
 
   useEffect(() => {
     const safeParam = searchParams.get('dao');
-    console.log({ safeAddress: node.daoAddress, safeParam });
+    console.log({ safeAddress: node.safe?.address, safeParam });
 
-    if (!publicClient || !node.daoAddress || node.daoAddress !== safeParam?.split(':')[1]) {
+    if (!publicClient || !node.safe?.address || node.safe?.address !== safeParam?.split(':')[1]) {
       console.log('not gonna load tree from keyvaluepairs');
       return;
     }
@@ -80,7 +80,7 @@ const useKeyValuePairs = () => {
       client: publicClient,
     });
     keyValuePairsContract.getEvents
-      .ValueUpdated({ theAddress: node.daoAddress }, { fromBlock: 0n })
+      .ValueUpdated({ theAddress: node.safe?.address }, { fromBlock: 0n })
       .then(safeEvents => setHatsTreeId(getHatsTreeId(safeEvents, chain.id)))
       .catch(error => {
         logError(error);
@@ -88,7 +88,7 @@ const useKeyValuePairs = () => {
 
     const unwatch = keyValuePairsContract.watchEvent.ValueUpdated(
       {
-        theAddress: node.daoAddress,
+        theAddress: node.safe?.address,
       },
       {
         onLogs: logs => {
@@ -104,7 +104,7 @@ const useKeyValuePairs = () => {
     return () => {
       unwatch();
     };
-  }, [chain.id, keyValuePairs, node.daoAddress, publicClient, searchParams, setHatsTreeId]);
+  }, [chain.id, keyValuePairs, node.safe?.address, publicClient, searchParams, setHatsTreeId]);
 };
 
 export { useKeyValuePairs };

--- a/src/hooks/stake/lido/useLidoStaking.ts
+++ b/src/hooks/stake/lido/useLidoStaking.ts
@@ -10,7 +10,7 @@ import useSignerOrProvider from '../../utils/useSignerOrProvider';
 
 export default function useLidoStaking() {
   const {
-    node: { daoAddress, safe },
+    node: { safe },
   } = useFractal();
   const {
     staking: { lido },
@@ -18,6 +18,8 @@ export default function useLidoStaking() {
   const signerOrProvider = useSignerOrProvider();
   const { submitProposal } = useSubmitProposal();
   const { t } = useTranslation('proposal');
+
+  const daoAddress = safe?.address;
 
   const handleStake = useCallback(
     async (value: bigint) => {

--- a/src/hooks/streams/useCreateSablierStream.ts
+++ b/src/hooks/streams/useCreateSablierStream.ts
@@ -29,7 +29,7 @@ export default function useCreateSablierStream() {
     contracts: { sablierV2LockupLinear, sablierV2Batch },
   } = useNetworkConfig();
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
 
   const convertStreamIdToBigInt = (streamId: string) => {
@@ -49,6 +49,8 @@ export default function useCreateSablierStream() {
     },
     [sablierV2Batch],
   );
+
+  const daoAddress = safe?.address;
 
   const prepareBasicStreamData = useCallback(
     (recipient: Address, amountInTokenDecimals: bigint) => {

--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -83,7 +83,7 @@ const prepareMintHatsTxArgs = (addedHats: HatStruct[], adminHatId: Hex, hatsCoun
 
 export default function useCreateRoles() {
   const {
-    node: { safe, daoAddress, daoName },
+    node: { safe, daoName },
   } = useFractal();
   const { hatsTree, hatsTreeId, getHat } = useRolesStore();
   const {
@@ -104,6 +104,8 @@ export default function useCreateRoles() {
   const { prepareBatchLinearStreamCreation, prepareFlushStreamTx, prepareCancelStreamTx } =
     useCreateSablierStream();
   const ipfsClient = useIPFSClient();
+
+  const daoAddress = safe?.address;
 
   const navigate = useNavigate();
   const submitProposalSuccessCallback = useCallback(() => {

--- a/src/hooks/utils/useSafeTransactions.ts
+++ b/src/hooks/utils/useSafeTransactions.ts
@@ -6,7 +6,7 @@ import {
   TransferWithTokenInfoResponse,
 } from '@safe-global/api-kit';
 import { useCallback } from 'react';
-import { zeroAddress } from 'viem';
+import { getAddress, Hex, zeroAddress } from 'viem';
 import { isApproved, isRejected } from '../../helpers/activity';
 import { useFractal } from '../../providers/App/AppProvider';
 import { useEthersProvider } from '../../providers/Ethers/hooks/useEthersProvider';
@@ -230,7 +230,9 @@ export const useSafeTransactions = () => {
 
           // maps address for each transfer
           const transferAddresses = transaction.transfers.map(transfer =>
-            transfer.to.toLowerCase() === daoAddress.toLowerCase() ? transfer.from : transfer.to,
+            getAddress(
+              transfer.to.toLowerCase() === daoAddress.toLowerCase() ? transfer.from : transfer.to,
+            ),
           );
 
           // @note this indentifies transaction a simple ETH transfer
@@ -244,7 +246,7 @@ export const useSafeTransactions = () => {
             transferAmountTotals.push(
               `${formatWeiToValue(multiSigTransaction.value, 18)} ${chain.nativeCurrency.symbol}`,
             );
-            transferAddresses.push(multiSigTransaction.to);
+            transferAddresses.push(getAddress(multiSigTransaction.to));
           }
 
           const eventSafeTxHash = multiSigTransaction.safeTxHash;
@@ -308,9 +310,8 @@ export const useSafeTransactions = () => {
             proposalId: eventSafeTxHash,
             targets,
             // @todo typing for `multiSigTransaction.transactionHash` is misleading, as ` multiSigTransaction.transactionHash` is not always defined (if ever). Need to tighten up the typing here.
-            transactionHash:
-              multiSigTransaction.transactionHash ||
-              (transaction as SafeMultisigTransactionWithTransfersResponse).safeTxHash,
+            transactionHash: (multiSigTransaction.transactionHash ||
+              (transaction as SafeMultisigTransactionWithTransfersResponse).safeTxHash) as Hex,
             data: data,
             state: null,
             nonce: eventNonce,

--- a/src/hooks/utils/useUpdateSafeData.ts
+++ b/src/hooks/utils/useUpdateSafeData.ts
@@ -7,11 +7,12 @@ import { NodeAction } from '../../providers/App/node/action';
 export const useUpdateSafeData = () => {
   const {
     action,
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const safeAPI = useSafeAPI();
   const location = useLocation();
   const prevPathname = useRef(location.pathname);
+  const daoAddress = safe?.address;
 
   useEffect(() => {
     if (!safeAPI || !daoAddress) {

--- a/src/pages/daos/[daoAddress]/SettingsPage.tsx
+++ b/src/pages/daos/[daoAddress]/SettingsPage.tsx
@@ -9,10 +9,11 @@ import { useFractal } from '../../../providers/App/AppProvider';
 export function SettingsPage() {
   const { t } = useTranslation('breadcrumbs');
   const {
-    node: { daoAddress, daoName },
+    node: { safe, daoName },
   } = useFractal();
 
   const HEADER_HEIGHT = useHeaderHeight();
+  const daoAddress = safe?.address;
 
   if (!daoAddress) {
     return (

--- a/src/pages/daos/[daoAddress]/edit/governance/index.tsx
+++ b/src/pages/daos/[daoAddress]/edit/governance/index.tsx
@@ -20,7 +20,7 @@ import {
 
 export default function ModifyGovernancePage() {
   const {
-    node: { daoAddress, safe, daoName, daoSnapshotENS },
+    node: { safe, daoName, daoSnapshotENS },
     governance: { type },
     readOnly: { user },
   } = useFractal();
@@ -30,6 +30,8 @@ export default function ModifyGovernancePage() {
   const isMultisig = type === GovernanceType.MULTISIG;
   const isSigner = user.address && safe?.owners.includes(user.address);
   const deployAzorius = useDeployAzorius();
+
+  const daoAddress = safe?.address;
 
   const handleDeployAzorius: DAOTrigger = (daoData, customNonce) => {
     deployAzorius(

--- a/src/pages/daos/[daoAddress]/hierarchy/index.tsx
+++ b/src/pages/daos/[daoAddress]/hierarchy/index.tsx
@@ -9,7 +9,7 @@ import { useFractal } from '../../../../providers/App/AppProvider';
 export default function HierarchyPage() {
   const {
     node: {
-      daoAddress,
+      safe,
       daoName,
       nodeHierarchy: { parentAddress },
       isHierarchyLoaded,
@@ -18,6 +18,8 @@ export default function HierarchyPage() {
   const { t } = useTranslation('breadcrumbs');
 
   const HEADER_HEIGHT = useHeaderHeight();
+
+  const daoAddress = safe?.address;
 
   if (!daoAddress || !isHierarchyLoaded) {
     return (
@@ -42,7 +44,7 @@ export default function HierarchyPage() {
         ]}
       />
       <DaoHierarchyNode
-        parentAddress={null}
+        parentAddress={undefined}
         daoAddress={parentAddress || daoAddress}
         depth={0}
       />

--- a/src/pages/daos/[daoAddress]/proposal-templates/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposal-templates/index.tsx
@@ -12,10 +12,11 @@ import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkCon
 export default function ProposalTemplatesPage() {
   const { t } = useTranslation();
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const { canUserCreateProposal } = useCanUserCreateProposal();
   const { addressPrefix } = useNetworkConfig();
+  const daoAddress = safe?.address;
 
   return (
     <div>

--- a/src/pages/daos/[daoAddress]/proposals/[proposalId]/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/[proposalId]/index.tsx
@@ -17,7 +17,7 @@ import { FractalProposal, AzoriusProposal, SnapshotProposal } from '../../../../
 
 export default function ProposalDetailsPage() {
   const {
-    node: { daoAddress },
+    node: { safe },
     governance: { proposals },
     readOnly: { dao },
   } = useFractal();
@@ -27,6 +27,8 @@ export default function ProposalDetailsPage() {
   const { isSnapshotProposal, snapshotProposal } = useSnapshotProposal(proposal);
   const metaData = useGetMetadata(proposal);
   const { t } = useTranslation(['proposal', 'navigation', 'breadcrumbs', 'dashboard']);
+
+  const daoAddress = safe?.address;
 
   const azoriusProposal = proposal as AzoriusProposal;
 

--- a/src/pages/daos/[daoAddress]/proposals/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/index.tsx
@@ -18,8 +18,10 @@ export default function ProposalsPage() {
   const { t } = useTranslation(['common', 'proposal', 'breadcrumbs']);
   const {
     governance,
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
+  const daoAddress = safe?.address;
+
   const { addressPrefix } = useNetworkConfig();
   const azoriusGovernance = governance as AzoriusGovernance;
   const delegate = useFractalModal(ModalType.DELEGATE);

--- a/src/pages/daos/[daoAddress]/proposals/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/new/index.tsx
@@ -9,9 +9,11 @@ import { ProposalBuilderMode } from '../../../../../types';
 
 export default function CreateProposalPage() {
   const {
-    node: { daoAddress, safe },
+    node: { safe },
     governance: { type },
   } = useFractal();
+  const daoAddress = safe?.address;
+
   const { prepareProposal } = usePrepareProposal();
 
   const HEADER_HEIGHT = useHeaderHeight();

--- a/src/pages/daos/[daoAddress]/roles/details/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/details/index.tsx
@@ -9,7 +9,7 @@ import { useRolesStore } from '../../../../../store/roles';
 
 export default function RoleDetails() {
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const navigate = useNavigate();
   const { addressPrefix } = useNetworkConfig();
@@ -18,6 +18,7 @@ export default function RoleDetails() {
   const [searchParams] = useSearchParams();
   const hatId = searchParams.get('hatId');
   const roleHat = hatsTree?.roleHats.find(hat => hat.id === hatId);
+  const daoAddress = safe?.address;
 
   // @todo add logic for loading
   // @todo add redirect for hat not found

--- a/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
@@ -121,7 +121,7 @@ export default function RoleEditDetails() {
   const headerHeight = useHeaderHeight();
   const { t } = useTranslation(['roles']);
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const { addressPrefix } = useNetworkConfig();
   const navigate = useNavigate();
@@ -129,6 +129,9 @@ export default function RoleEditDetails() {
   const [searchParams] = useSearchParams();
   const hatEditingId = searchParams.get('hatId');
   const hatIndex = values.hats.findIndex(h => h.id === hatEditingId);
+
+  const daoAddress = safe?.address;
+
   if (!isHex(hatEditingId)) return null;
   if (!daoAddress) return null;
   if (hatEditingId === undefined) return null;

--- a/src/pages/daos/[daoAddress]/roles/edit/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/index.tsx
@@ -24,7 +24,7 @@ import { getNewRole, useRolesStore } from '../../../../../store/roles';
 function RolesEdit() {
   const { t } = useTranslation(['roles', 'navigation', 'modals', 'common']);
   const {
-    node: { daoAddress, safe },
+    node: { safe },
   } = useFractal();
   const {
     addressPrefix,
@@ -77,6 +77,8 @@ function RolesEdit() {
       customNonce: safe?.nextNonce || 0,
     };
   }, [hatsTree?.roleHats, safe?.nextNonce]);
+
+  const daoAddress = `${safe?.address}`; // force cast to string to fit with type in navigate's `.relative`
 
   if (daoAddress === null) return null;
 

--- a/src/pages/daos/[daoAddress]/roles/edit/summary/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/summary/index.tsx
@@ -13,10 +13,12 @@ export default function EditProposalSummary() {
   const headerHeight = useHeaderHeight();
   const navigate = useNavigate();
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const { t } = useTranslation(['roles', 'breadcrumbs']);
   const { addressPrefix } = useNetworkConfig();
+  const daoAddress = safe?.address;
+
   if (!daoAddress) return null;
   return (
     <Box>

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -18,11 +18,12 @@ function Roles() {
   const { addressPrefix } = useNetworkConfig();
   const { t } = useTranslation(['roles']);
   const {
-    node: { daoAddress },
+    node: { safe },
   } = useFractal();
   const navigate = useNavigate();
 
   const { canUserCreateProposal } = useCanUserCreateProposal();
+  const daoAddress = safe?.address;
 
   if (!daoAddress) return null;
 

--- a/src/pages/daos/[daoAddress]/treasury/index.tsx
+++ b/src/pages/daos/[daoAddress]/treasury/index.tsx
@@ -17,7 +17,7 @@ import { useFractal } from '../../../../providers/App/AppProvider';
 
 export default function Treasury() {
   const {
-    node: { daoName, daoAddress },
+    node: { daoName, safe },
     treasury: { assetsFungible },
   } = useFractal();
   const [shownTransactions, setShownTransactions] = useState(20);
@@ -32,6 +32,8 @@ export default function Treasury() {
   const showSendButton = canUserCreateProposal && hasAnyBalanceOfAnyFungibleTokens;
   const totalTransfers = formattedTransfers.length;
   const showLoadMoreTransactions = totalTransfers > shownTransactions && shownTransactions < 100;
+
+  const daoAddress = safe?.address;
 
   return (
     <Box>

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -6,6 +6,7 @@ import SafeApiKit, {
   SafeApiKitConfig,
 } from '@safe-global/api-kit';
 import { useMemo } from 'react';
+import { Address } from 'viem';
 import { CacheExpiry } from '../../../hooks/utils/cache/cacheDefaults';
 import {
   DBObjectKeys,
@@ -80,10 +81,10 @@ class EnhancedSafeApiKit extends SafeApiKit {
     return value;
   }
 
-  async getSafeData(safeAddress: string): Promise<SafeWithNextNonce> {
+  async getSafeData(safeAddress: Address): Promise<SafeWithNextNonce> {
     const safeInfoResponse = await this.getSafeInfo(safeAddress);
     const nextNonce = await this.getNextNonce(safeAddress);
-    const safeInfo = { ...safeInfoResponse, nextNonce };
+    const safeInfo = { ...safeInfoResponse, nextNonce } as SafeWithNextNonce;
     return safeInfo;
   }
 }

--- a/src/providers/App/node/reducer.ts
+++ b/src/providers/App/node/reducer.ts
@@ -3,13 +3,12 @@ import { FractalNode, NodeHierarchy } from '../../../types';
 import { NodeAction, NodeActions } from './action';
 
 export const initialNodeHierarchyState: NodeHierarchy = {
-  parentAddress: null,
+  parentAddress: undefined,
   childNodes: [],
 };
 
 export const initialNodeState: FractalNode = {
   daoName: null,
-  daoAddress: null,
   safe: null,
   fractalModules: [],
   nodeHierarchy: initialNodeHierarchyState,

--- a/src/providers/App/useReadOnlyValues.ts
+++ b/src/providers/App/useReadOnlyValues.ts
@@ -67,7 +67,7 @@ export const useReadOnlyValues = ({ node, governance }: Fractal, _account?: stri
         address,
         votingWeight: await getVotingWeight(),
       },
-      dao: !node.daoAddress
+      dao: !node.safe?.address
         ? null // if there is no DAO connected, we return null for this
         : {
             isAzorius:

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -3,7 +3,7 @@ import { Address } from 'viem';
 export interface VotesTokenData extends VotesData, ERC20TokenData {}
 export interface VotesData {
   balance: bigint | null;
-  delegatee: string | null;
+  delegatee: Address | undefined;
   votingWeight: bigint | null;
   isDelegatesSet: boolean | null;
 }

--- a/src/types/daoProposal.ts
+++ b/src/types/daoProposal.ts
@@ -26,7 +26,7 @@ export type ProposalData = {
 };
 
 export interface AzoriusProposal extends GovernanceActivity {
-  proposer: string;
+  proposer: Address;
   votesSummary: ProposalVotesSummary;
   votes: ProposalVote[] | ERC721ProposalVote[];
   /** The deadline timestamp for the proposal, in milliseconds. */

--- a/src/types/daoTreasury.ts
+++ b/src/types/daoTreasury.ts
@@ -1,3 +1,4 @@
+import { Address, Hex } from 'viem';
 import { ContractEvent } from './contract';
 import { ActivityBase } from './fractal';
 import { EthAddress } from './utils';
@@ -8,13 +9,13 @@ export enum TokenEventType {
 }
 
 export interface TokenEvent extends ContractEvent {
-  transactionHash: string;
-  blockNumber: number;
+  transactionHash: Hex;
+  // blockNumber: number;
   eventType: TokenEventType;
 }
 
 export type TokenBalance = {
-  tokenAddress: string;
+  tokenAddress: Address;
   symbol: string;
   name: string;
   logo?: string;
@@ -37,7 +38,7 @@ type NftMediaItem = {
 };
 
 export type NFTBalance = {
-  tokenAddress: string;
+  tokenAddress: Address;
   media:
     | {
         originalMediaUrl?: string | undefined;
@@ -105,7 +106,7 @@ export enum TreasuryActivityTypes {
 }
 
 export interface TreasuryActivity extends ActivityBase {
-  transferAddresses: string[];
+  transferAddresses: Address[];
   transferAmountTotals: string[];
   isDeposit: boolean;
 }

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -24,7 +24,7 @@ import {
   AllTransactionsListResponse,
 } from '@safe-global/api-kit';
 import { Dispatch } from 'react';
-import { Address } from 'viem';
+import { Address, Hex } from 'viem';
 import { MultiSend } from '../assets/typechain-types/usul';
 import { GnosisSafeL2 } from '../assets/typechain-types/usul/@gnosis.pm/safe-contracts/contracts';
 import { FractalGovernanceActions } from '../providers/App/governance/action';
@@ -154,7 +154,7 @@ export interface ActivityBase {
   eventDate: Date;
   eventType: ActivityEventType;
   transaction?: ActivityTransactionType;
-  transactionHash: string;
+  transactionHash: Hex;
 }
 
 export type Activity = TreasuryActivity | MultisigProposal | AzoriusProposal | SnapshotProposal;
@@ -229,11 +229,10 @@ export interface FractalGovernanceContracts {
   isLoaded: boolean;
 }
 
-export type SafeWithNextNonce = SafeInfoResponse & { nextNonce: number };
+export type SafeWithNextNonce = SafeInfoResponse & { nextNonce: number; address: Address };
 
 export interface FractalNode {
   daoName: string | null;
-  daoAddress: Address | null;
   safe: SafeWithNextNonce | null;
   fractalModules: FractalModuleData[];
   nodeHierarchy: NodeHierarchy;
@@ -244,11 +243,13 @@ export interface FractalNode {
 }
 
 export interface Node
-  extends Omit<FractalNode, 'safe' | 'fractalModules' | 'isModulesLoaded' | 'isHierarchyLoaded'> {}
+  extends Omit<FractalNode, 'safe' | 'fractalModules' | 'isModulesLoaded' | 'isHierarchyLoaded'> {
+  daoAddress: Address;
+}
 
 export interface FractalModuleData {
   moduleContract: Azorius | FractalModule | undefined;
-  moduleAddress: string;
+  moduleAddress: Address;
   moduleType: FractalModuleType;
 }
 
@@ -330,7 +331,7 @@ export enum VotingStrategyType {
 }
 
 export interface NodeHierarchy {
-  parentAddress: Address | null;
+  parentAddress: Address | undefined;
   childNodes: Node[];
 }
 

--- a/src/utils/azorius.ts
+++ b/src/utils/azorius.ts
@@ -10,6 +10,7 @@ import {
 import { VotedEvent as ERC20VotedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC20Voting';
 import { VotedEvent as ERC721VotedEvent } from '@fractal-framework/fractal-contracts/dist/typechain-types/contracts/azorius/LinearERC721Voting';
 import { SafeMultisigTransactionWithTransfersResponse } from '@safe-global/api-kit';
+import { Address, Hex } from 'viem';
 import { strategyFractalProposalStates } from '../constants/strategy';
 import { logError } from '../helpers/errorLogging';
 import {
@@ -155,7 +156,7 @@ export const mapProposalCreatedEventToProposal = async (
   erc721StrategyContract: LinearERC721Voting | undefined,
   strategyType: VotingStrategyType,
   proposalId: bigint,
-  proposer: string,
+  proposer: Address,
   azoriusContract: Azorius,
   provider: Providers,
   erc20VotedEvents: Promise<ERC20VotedEvent[] | undefined>,
@@ -214,7 +215,7 @@ export const mapProposalCreatedEventToProposal = async (
 
   const targets = data ? data.decodedTransactions.map(tx => tx.target) : [];
 
-  let transactionHash: string | undefined;
+  let transactionHash: Hex | undefined;
   if (state === FractalProposalState.EXECUTED) {
     const executedEvent = (await executedEvents)?.find(
       event => BigInt(event.args[0]) === proposalId,
@@ -224,9 +225,9 @@ export const mapProposalCreatedEventToProposal = async (
       throw new Error('Proposal state is EXECUTED, but no event found');
     }
 
-    transactionHash = executedEvent.transactionHash;
+    transactionHash = executedEvent.transactionHash as Hex;
   } else {
-    transactionHash = createdEvent.transactionHash;
+    transactionHash = createdEvent.transactionHash as Hex;
   }
 
   const proposal: AzoriusProposal = {


### PR DESCRIPTION
## Overview
There was a pretty significant bug that was showing itself, causing the safe state's `node.address` to go out of sync with either `node.safe.address`, the url safe address query param, or both.

As a first step in debugging this issue, the engineering team thought, "why not rip out one of this double-defined safe addresses from the app state?"

This PR does that. We have removed `daoAddress` from `FractalNode`, which was being used pretty widely across the app for stuff including navigation. We'll now depend exclusively on `FractalNode.safe.address` for a context safe's address.

#### The Good:
- this is a nice first step in overhauling the app state, with the end goal being that redux is replaced with zustand, _while_ simplifying and optimising state management across the app.
- there's just one source of truth for the question "what is this safe's address?"

#### The Not-so-good:
- the address de-sync is still happening, from prelim tests on this branch. No matter -- I'll keep digging deeper into the state and zustand in upcoming PRs. This may or may not fix itself in time.

### Notes
- Most changes in the 94 changed files are super straightforward -- `const daoAddress = safe?.address;`
- I've updated some `string`s to `Address`s and `Hex`s where it seemed to make sense.
- This very important question here: https://decentdao.slack.com/archives/C06QZ68L5SA/p1723204918675769