### PR TITLE
Fix per-proposal voting power display

### DIFF
--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -9,7 +9,7 @@ import useSafeContracts from '../../hooks/safe/useSafeContracts';
 import useBlockTimestamp from '../../hooks/utils/useBlockTimestamp';
 import { useFractal } from '../../providers/App/AppProvider';
 import { AzoriusGovernance, AzoriusProposal, GovernanceType } from '../../types';
-import { DEFAULT_DATE_TIME_FORMAT } from '../../utils/numberFormats';
+import { DEFAULT_DATE_TIME_FORMAT, formatCoin } from '../../utils/numberFormats';
 import ContentBox from '../ui/containers/ContentBox';
 import DisplayTransaction from '../ui/links/DisplayTransaction';
 import EtherscanLink from '../ui/links/EtherscanLink';
@@ -75,7 +75,7 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
         ).toBigInt();
 
         setProposalsERC20VotingWeight(
-          (pastVotingWeight / votesTokenDecimalsDenominator).toLocaleString(),
+          formatCoin(pastVotingWeight, true, votesToken?.decimals, undefined, false),
         );
       }
     }
@@ -86,7 +86,6 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
     baseContracts,
     governanceContracts.ozLinearVotingContractAddress,
     proposal.proposalId,
-    votesTokenDecimalsDenominator,
   ]);
 
   const isERC20 = type === GovernanceType.AZORIUS_ERC20;

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -75,7 +75,7 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
         ).toBigInt();
 
         setProposalsERC20VotingWeight(
-          (pastVotingWeight / votesTokenDecimalsDenominator).toString(),
+          (pastVotingWeight / votesTokenDecimalsDenominator).toLocaleString(),
         );
       }
     }

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -32,6 +32,7 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
   } = proposal;
   const {
     governance,
+    governanceContracts,
     readOnly: {
       user: { votingWeight, address },
     },
@@ -61,11 +62,18 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
 
   useEffect(() => {
     async function loadProposalVotingWeight() {
-      if (address && baseContracts && votesToken) {
-        const tokenContract = baseContracts.votesTokenMasterCopyContract.asProvider.attach(
-          votesToken.address,
+      if (
+        address &&
+        baseContracts &&
+        governanceContracts.ozLinearVotingContractAddress !== undefined
+      ) {
+        const strategyContract = baseContracts.linearVotingMasterCopyContract.asProvider.attach(
+          governanceContracts.ozLinearVotingContractAddress,
         );
-        const pastVotingWeight = (await tokenContract.getPastVotes(address, startBlock)).toBigInt();
+        const pastVotingWeight = (
+          await strategyContract.getVotingWeight(address, proposal.proposalId)
+        ).toBigInt();
+
         setProposalsERC20VotingWeight(
           (pastVotingWeight / votesTokenDecimalsDenominator).toString(),
         );
@@ -73,7 +81,13 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
     }
 
     loadProposalVotingWeight();
-  }, [address, startBlock, votesTokenDecimalsDenominator, baseContracts, votesToken]);
+  }, [
+    address,
+    baseContracts,
+    governanceContracts.ozLinearVotingContractAddress,
+    proposal.proposalId,
+    votesTokenDecimalsDenominator,
+  ]);
 
   const isERC20 = type === GovernanceType.AZORIUS_ERC20;
   const isERC721 = type === GovernanceType.AZORIUS_ERC721;


### PR DESCRIPTION
Fixes #2244

When calculating voting power per proposal, query the strategy contract, not token contract directly.

See the screenshot in the attached issue for the erroneous "0" voting power displayed.

See this screenshot for the fix

<img width="1552" alt="Screenshot 2024-08-14 at 1 05 36 PM" src="https://github.com/user-attachments/assets/465a34b2-c9a7-485e-b2d7-247e11296d05">
