### PR TITLE
`state-overhaul` | Refactor resolve address logic

### DIFF
--- a/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
@@ -56,7 +56,7 @@ function AddSignerModal({
   );
 
   const addSignerValidationSchema = Yup.object().shape({
-    address: Yup.string().test(addressValidationTest).test(newSignerValidationTest),
+    addressOrENS: Yup.string().test(addressValidationTest).test(newSignerValidationTest),
     nonce: Yup.number()
       .required()
       .moreThan((!!safe && safe.nonce - 1) || 0),
@@ -80,9 +80,8 @@ function AddSignerModal({
           return (
             <form onSubmit={handleSubmit}>
               <Text>{t('addSignerLabel', { ns: 'modals' })}</Text>
-              <Field name={'address'}>
+              <Field name={'addressOrENS'}>
                 {({ field }: FieldAttributes<any>) => (
-                  // LabelWrapper title styling needs to updated on @decent-org/fractal-ui, it seems
                   <LabelWrapper
                     subLabel={t('addSignerSublabel', { ns: 'modals' })}
                     errorMessage={field.value && errors.addressOrENS}

--- a/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
@@ -3,11 +3,11 @@ import { WarningCircle } from '@phosphor-icons/react';
 import { Field, FieldAttributes, Formik } from 'formik';
 import { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Address, getAddress, isAddress } from 'viem';
 import * as Yup from 'yup';
 import { useValidationAddress } from '../../../../../../hooks/schemas/common/useValidationAddress';
 import { useFractal } from '../../../../../../providers/App/AppProvider';
 import { useEthersProvider } from '../../../../../../providers/Ethers/hooks/useEthersProvider';
+import { resolveAddress } from '../../../../../../utils/address';
 import SupportTooltip from '../../../../../ui/badges/SupportTooltip';
 import { CustomNonceInput } from '../../../../../ui/forms/CustomNonceInput';
 import { AddressInput } from '../../../../../ui/forms/EthAddressInput';
@@ -42,29 +42,10 @@ function AddSignerModal({
 
       const { addressOrENS, nonce, threshold } = values;
 
-      let validAddress: Address;
-
-      if (isAddress(addressOrENS)) {
-        validAddress = getAddress(addressOrENS);
-      } else if (provider) {
-        let resolvedAddress: string | null;
-        try {
-          resolvedAddress = await provider.resolveName(addressOrENS);
-        } catch (e) {
-          throw e;
-        }
-
-        if (resolvedAddress === null) {
-          throw new Error('Given ENS name does not resolve to an address.');
-        }
-
-        validAddress = getAddress(resolvedAddress);
-      } else {
-        throw new Error('No provider found');
-      }
+      const newSigner = await resolveAddress(addressOrENS, provider);
 
       await addSigner({
-        newSigner: validAddress,
+        newSigner,
         threshold: threshold,
         nonce: nonce,
         safeAddress: safe.address,

--- a/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/modals/AddSignerModal.tsx
@@ -47,7 +47,7 @@ function AddSignerModal({
 
         const newSigner = await resolveAddress(addressOrENS, provider);
         if (!newSigner) {
-          toast.error(t('unknownENS', { ns: 'common' }));
+          toast.error(t('errorInvalidENSAddress', { ns: 'common' }));
           return;
         }
 

--- a/src/components/ui/modals/DelegateModal.tsx
+++ b/src/components/ui/modals/DelegateModal.tsx
@@ -48,7 +48,7 @@ export function DelegateModal({ close }: { close: Function }) {
       const delegatee = await resolveAddress(values.address, provider);
 
       if (!delegatee) {
-        toast.error(t('unknownENS', { ns: 'common' }));
+        toast.error(t('errorInvalidENSAddress', { ns: 'common' }));
         return;
       }
 
@@ -75,7 +75,7 @@ export function DelegateModal({ close }: { close: Function }) {
       const delegatee = await resolveAddress(values.address, provider);
 
       if (!delegatee) {
-        toast.error(t('unknownENS', { ns: 'common' }));
+        toast.error(t('errorInvalidENSAddress', { ns: 'common' }));
         return;
       }
 

--- a/src/hooks/schemas/common/useValidationAddress.tsx
+++ b/src/hooks/schemas/common/useValidationAddress.tsx
@@ -138,12 +138,13 @@ export const useValidationAddress = () => {
     return {
       name: 'New Signer Validation',
       message: t('alreadySigner', { ns: 'modals' }),
-      test: async function (address: string | undefined) {
-        if (!address || !safe || !signer) return false;
-        if (normalize(address)) {
-          address = await signer.resolveName(address);
+      test: async function (addressOrENS: string | undefined) {
+        if (!addressOrENS || !safe || !signer) return false;
+        let resolvedAddress = addressOrENS;
+        if (normalize(addressOrENS)) {
+          resolvedAddress = await signer.resolveName(addressOrENS);
         }
-        return !safe.owners.includes(address);
+        return !safe.owners.includes(resolvedAddress);
       },
     };
   }, [safe, signer, t]);

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -49,7 +49,6 @@
   "errorInvalidAddress": "Invalid ETH address",
   "errorNotProposer": "You do not have the necessary permissions to create a proposal for this Safe.",
   "errorSentryFallbackTitle": "Oops! Something went wrong",
-  "unknownENS": "The ENS name does not resolve to an address.",
   "errorSentryFallbackMessage": "We apologize for the inconvenience. Please try again later.",
   "errorMySafesNotLoaded": "Safe(s) could not be loaded. Please try again later.",
   "errorGeneral": "An unexpected error occurred. Please try again later.",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -49,6 +49,7 @@
   "errorInvalidAddress": "Invalid ETH address",
   "errorNotProposer": "You do not have the necessary permissions to create a proposal for this Safe.",
   "errorSentryFallbackTitle": "Oops! Something went wrong",
+  "unknownENS": "The ENS name does not resolve to an address.",
   "errorSentryFallbackMessage": "We apologize for the inconvenience. Please try again later.",
   "errorMySafesNotLoaded": "Safe(s) could not be loaded. Please try again later.",
   "errorGeneral": "An unexpected error occurred. Please try again later.",

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -29,11 +29,7 @@ export const resolveAddress = async (
     return addressOrENS;
   } else if (provider) {
     let resolvedAddress: string | null;
-    try {
-      resolvedAddress = await provider.resolveName(addressOrENS);
-    } catch (e) {
-      throw e;
-    }
+    resolvedAddress = await provider.resolveName(addressOrENS);
 
     if (resolvedAddress === null) {
       throw new Error('Given ENS name does not resolve to an address.');

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,3 +1,4 @@
+import { JsonRpcProvider, FallbackProvider } from '@ethersproject/providers';
 import { Address, getAddress, isAddress } from 'viem';
 
 export const MOCK_MORALIS_ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
@@ -18,7 +19,10 @@ export const encodePrefixedAddress = (address: Address, network: string) => {
   return `${network}:${address}`;
 };
 
-export const resolveAddress = async (addressOrENS: string, provider?: any): Promise<Address> => {
+export const resolveAddress = async (
+  addressOrENS: string,
+  provider?: JsonRpcProvider | FallbackProvider,
+): Promise<Address> => {
   let validAddress: Address;
 
   if (isAddress(addressOrENS)) {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -22,7 +22,7 @@ export const encodePrefixedAddress = (address: Address, network: string) => {
 export const resolveAddress = async (
   addressOrENS: string,
   provider?: JsonRpcProvider | FallbackProvider,
-): Promise<Address> => {
+): Promise<Address | null> => {
   let validAddress: Address;
 
   if (isAddress(addressOrENS)) {
@@ -32,7 +32,7 @@ export const resolveAddress = async (
     resolvedAddress = await provider.resolveName(addressOrENS);
 
     if (resolvedAddress === null) {
-      throw new Error('Given ENS name does not resolve to an address.');
+      return null;
     }
 
     validAddress = getAddress(resolvedAddress);

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,4 +1,7 @@
-import { Address } from 'viem';
+import { Address, getAddress, isAddress } from 'viem';
+
+export const MOCK_MORALIS_ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+export const SENTINEL_MODULE = '0x0000000000000000000000000000000000000001';
 
 export const decodePrefixedAddress = (address: string) => {
   const [prefix, addressWithoutPrefix] = address.split(':');
@@ -15,5 +18,27 @@ export const encodePrefixedAddress = (address: Address, network: string) => {
   return `${network}:${address}`;
 };
 
-export const MOCK_MORALIS_ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
-export const SENTINEL_MODULE = '0x0000000000000000000000000000000000000001';
+export const resolveAddress = async (addressOrENS: string, provider?: any): Promise<Address> => {
+  let validAddress: Address;
+
+  if (isAddress(addressOrENS)) {
+    return addressOrENS;
+  } else if (provider) {
+    let resolvedAddress: string | null;
+    try {
+      resolvedAddress = await provider.resolveName(addressOrENS);
+    } catch (e) {
+      throw e;
+    }
+
+    if (resolvedAddress === null) {
+      throw new Error('Given ENS name does not resolve to an address.');
+    }
+
+    validAddress = getAddress(resolvedAddress);
+  } else {
+    throw new Error('No provider found');
+  }
+
+  return validAddress;
+};


### PR DESCRIPTION
I found that the `validAddress`-obtaining logic was also needed in 2 places in `DelegateModal`.

So I've refactored that so we can reuse it, as `resolveAddress`.