### PR TITLE
`1580 | Bugfix` ModuleProxyFactory updated to zodiac deployed contract

### DIFF
--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -84,6 +84,7 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
   }, [
     address,
     baseContracts,
+    votesToken?.decimals,
     governanceContracts.ozLinearVotingContractAddress,
     proposal.proposalId,
   ]);

--- a/src/hooks/utils/cache/cacheDefaults.ts
+++ b/src/hooks/utils/cache/cacheDefaults.ts
@@ -50,6 +50,7 @@ export interface MasterCacheKey extends CacheKey {
   cacheName: CacheKeys.MASTER_COPY;
   chainId: number;
   proxyAddress: Address;
+  moduleProxyFactoryAddress: Address;
 }
 
 export interface ProposalCacheKey extends CacheKey {

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -62,7 +62,8 @@ export const baseConfig: NetworkConfig = {
       version: SAFE_VERSION,
       network: base.id.toString(),
     })?.networkAddresses[base.id.toString()]!,
-    zodiacModuleProxyFactory: ModuleProxyFactory.address,
+    zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
+    zodiacModuleProxyFactoryOld: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,

--- a/src/providers/NetworkConfig/networks/baseSepolia.ts
+++ b/src/providers/NetworkConfig/networks/baseSepolia.ts
@@ -64,7 +64,8 @@ export const baseSepoliaConfig: NetworkConfig = {
       version: SAFE_VERSION,
       network: baseSepolia.id.toString(),
     })?.networkAddresses[baseSepolia.id.toString()]!,
-    zodiacModuleProxyFactory: ModuleProxyFactory.address,
+    zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
+    zodiacModuleProxyFactoryOld: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -62,7 +62,8 @@ export const mainnetConfig: NetworkConfig = {
       version: SAFE_VERSION,
       network: mainnet.id.toString(),
     })?.networkAddresses[mainnet.id.toString()]!,
-    zodiacModuleProxyFactory: ModuleProxyFactory.address,
+    zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
+    zodiacModuleProxyFactoryOld: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -62,7 +62,8 @@ export const optimismConfig: NetworkConfig = {
       version: SAFE_VERSION,
       network: optimism.id.toString(),
     })?.networkAddresses[optimism.id.toString()]!,
-    zodiacModuleProxyFactory: ModuleProxyFactory.address,
+    zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
+    zodiacModuleProxyFactoryOld: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -62,7 +62,8 @@ export const polygonConfig: NetworkConfig = {
       version: SAFE_VERSION,
       network: polygon.id.toString(),
     })?.networkAddresses[polygon.id.toString()]!,
-    zodiacModuleProxyFactory: ModuleProxyFactory.address,
+    zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
+    zodiacModuleProxyFactoryOld: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -62,7 +62,8 @@ export const sepoliaConfig: NetworkConfig = {
       version: SAFE_VERSION,
       network: sepolia.id.toString(),
     })?.networkAddresses[sepolia.id.toString()]!,
-    zodiacModuleProxyFactory: ModuleProxyFactory.address,
+    zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
+    zodiacModuleProxyFactoryOld: ModuleProxyFactory.address,
     linearVotingMasterCopy: LinearERC20Voting.address,
     multisend: getMultiSendCallOnlyDeployment({
       version: SAFE_VERSION,

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -27,6 +27,7 @@ export type NetworkConfig = {
     safeFactory: string;
     fallbackHandler: string;
     zodiacModuleProxyFactory: string;
+    zodiacModuleProxyFactoryOld: string;
     linearVotingMasterCopy: string;
     multisend: string;
     fractalAzoriusMasterCopy: string;


### PR DESCRIPTION
Closes #1580 

TLDR:

During creation our safes we were using our deployed instant of `ModuleProxyFactory` contract instead of the 'official' deployed version by zodiac.

This PR adds the official version as the main contract while persevering the old. This effects any new safe created will now use the new contract, We will continue to support looking up these master copies on both version of the copy
