### PR TITLE
Fix logic for showing option for initiating freeze

### DIFF
--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -240,8 +240,6 @@ export function ManageDAOMenu({
     freezeOption,
   ]);
 
-  console.log(freezeGuard, !!freezeGuard.freezeProposalCreatedTime);
-
   return (
     <OptionMenu
       trigger={

--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -184,7 +184,7 @@ export function ManageDAOMenu({
 
     if (
       freezeGuard.freezeProposalCreatedTime !== null &&
-      freezeGuard.freezeProposalPeriod  !== null &&
+      freezeGuard.freezeProposalPeriod !== null &&
       freezeGuard.freezePeriod !== null &&
       !isWithinFreezeProposalPeriod(
         freezeGuard.freezeProposalCreatedTime,

--- a/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
+++ b/src/components/ui/menus/ManageDAO/ManageDAOMenu.tsx
@@ -183,9 +183,9 @@ export function ManageDAOMenu({
     };
 
     if (
-      freezeGuard.freezeProposalCreatedTime &&
-      freezeGuard.freezeProposalPeriod &&
-      freezeGuard.freezePeriod &&
+      freezeGuard.freezeProposalCreatedTime !== null &&
+      freezeGuard.freezeProposalPeriod  !== null &&
+      freezeGuard.freezePeriod !== null &&
       !isWithinFreezeProposalPeriod(
         freezeGuard.freezeProposalCreatedTime,
         freezeGuard.freezeProposalPeriod,
@@ -204,8 +204,8 @@ export function ManageDAOMenu({
         return [createSubDAOOption, freezeOption, settingsOption];
       }
     } else if (
-      freezeGuard.freezeProposalCreatedTime &&
-      freezeGuard.freezePeriod &&
+      freezeGuard.freezeProposalCreatedTime !== null &&
+      freezeGuard.freezePeriod !== null &&
       isWithinFreezePeriod(
         freezeGuard.freezeProposalCreatedTime,
         freezeGuard.freezePeriod,
@@ -239,6 +239,8 @@ export function ManageDAOMenu({
     addressPrefix,
     freezeOption,
   ]);
+
+  console.log(freezeGuard, !!freezeGuard.freezeProposalCreatedTime);
 
   return (
     <OptionMenu


### PR DESCRIPTION
Closes #2289 

To test:
1. Create parent DAO (Multisig / ERC-20 / ERC-721)
2. If you created ERC-20 Parent DAO - make sure to delegate votes to yourself
3. Create child DAO (Multisig / ERC-20 / ERC-721). Just for visualization - set voting period to something reasonably high (1 day) and freeze voting period for something way lower (5 minutes). Vote and execute proposal for creating child DAO
4. Navigate to child DAO dashboard, click gear icon, make sure "Initiate a freeze" option appeared there. Hit the button
5. This will create and immediately cast your vote on freezing child DAO. If you have enough votes to reach threshold - child DAO will be immediately frozen

<img width="1728" alt="Screenshot 2024-08-21 at 14 03 00" src="https://github.com/user-attachments/assets/6a02054d-b5da-44b1-927a-4ab44cd71e44">
<img width="1728" alt="Screenshot 2024-08-21 at 14 03 15" src="https://github.com/user-attachments/assets/9e81d71c-9172-418d-9f27-504dc17cbf08">
<img width="1728" alt="Screenshot 2024-08-21 at 14 04 28" src="https://github.com/user-attachments/assets/2f8f5a5a-53fc-42cd-b6cf-8e644ee10e12">
