### PR TITLE
Handle malformed metadata

### DIFF
--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -158,13 +158,11 @@ export const useAzoriusProposals = () => {
       });
 
       action.dispatch({
-        type: FractalGovernanceAction.SET_LOADING_PROPOSALS,
+        type: FractalGovernanceAction.SET_LOADING_FIRST_PROPOSAL,
         payload: true,
       });
 
-      // TODO: `SET_LOADING_PROPOSALS` seems like the kind of action to be called once all proposals are finished loading.
-      // So, it's strange that this function takes a single proposals as an argument.
-      const completeProposalLoad = (proposal: AzoriusProposal) => {
+      const completeOneProposalLoadProcess = (proposal: AzoriusProposal) => {
         if (currentAzoriusAddress.current !== azoriusContractAddress) {
           // The DAO has changed, don't load the just-fetched proposal,
           // into state, and get out of this function completely.
@@ -174,7 +172,7 @@ export const useAzoriusProposals = () => {
         _proposalLoaded(proposal);
 
         action.dispatch({
-          type: FractalGovernanceAction.SET_LOADING_PROPOSALS,
+          type: FractalGovernanceAction.SET_LOADING_FIRST_PROPOSAL,
           payload: false,
         });
       };
@@ -201,7 +199,7 @@ export const useAzoriusProposals = () => {
         });
 
         if (cachedProposal) {
-          completeProposalLoad(cachedProposal);
+          completeOneProposalLoadProcess(cachedProposal);
           continue;
         }
 
@@ -264,7 +262,7 @@ export const useAzoriusProposals = () => {
           proposalData,
         );
 
-        completeProposalLoad(proposal);
+        completeOneProposalLoadProcess(proposal);
 
         const isProposalFossilized =
           proposal.state === FractalProposalState.CLOSED ||
@@ -288,7 +286,7 @@ export const useAzoriusProposals = () => {
 
       // Just in case there are no `proposalCreatedEvent`s, we still need to set the loading state to false.
       action.dispatch({
-        type: FractalGovernanceAction.SET_LOADING_PROPOSALS,
+        type: FractalGovernanceAction.SET_LOADING_FIRST_PROPOSAL,
         payload: false,
       });
 

--- a/src/hooks/DAO/loaders/governance/useSafeMultisigProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useSafeMultisigProposals.ts
@@ -28,7 +28,7 @@ export const useSafeMultisigProposals = () => {
       });
 
       action.dispatch({
-        type: FractalGovernanceAction.SET_LOADING_PROPOSALS,
+        type: FractalGovernanceAction.SET_LOADING_FIRST_PROPOSAL,
         payload: false,
       });
       action.dispatch({

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -137,5 +137,6 @@
   "shutterVotesHidden": "Results hidden during voting",
   "totalVotes": "Total votes",
   "clawBackBalancesError": "Failed to process clawback due to unexpected error while retrieving child Safe balances.",
-  "pendingProposalNotice": "Pending proposal still processing"
+  "pendingProposalNotice": "Pending proposal still processing",
+  "metadataFailedParsePlaceholder": "Unknown - Failed to parse metadata"
 }

--- a/src/providers/App/governance/action.ts
+++ b/src/providers/App/governance/action.ts
@@ -13,7 +13,7 @@ import {
 import { ProposalTemplate } from '../../../types/proposalBuilder';
 
 export enum FractalGovernanceAction {
-  SET_LOADING_PROPOSALS = 'SET_LOADING_PROPOSALS',
+  SET_LOADING_FIRST_PROPOSAL = 'SET_LOADING_FIRST_PROPOSAL',
   SET_ALL_PROPOSALS_LOADED = 'SET_ALL_PROPOSALS_LOADED',
   SET_GOVERNANCE_TYPE = 'SET_GOVERNANCE_TYPE',
   SET_PROPOSALS = 'SET_PROPOSALS',
@@ -59,7 +59,7 @@ export type ERC721VotePayload = {
 
 export type FractalGovernanceActions =
   | { type: FractalGovernanceAction.SET_ALL_PROPOSALS_LOADED; payload: boolean }
-  | { type: FractalGovernanceAction.SET_LOADING_PROPOSALS; payload: boolean }
+  | { type: FractalGovernanceAction.SET_LOADING_FIRST_PROPOSAL; payload: boolean }
   | { type: FractalGovernanceAction.SET_GOVERNANCE_TYPE; payload: GovernanceType }
   | { type: FractalGovernanceAction.SET_STRATEGY; payload: VotingStrategy }
   | {

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -48,7 +48,7 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
   switch (action.type) {
     case FractalGovernanceAction.SET_ALL_PROPOSALS_LOADED:
       return { ...state, allProposalsLoaded: action.payload };
-    case FractalGovernanceAction.SET_LOADING_PROPOSALS:
+    case FractalGovernanceAction.SET_LOADING_FIRST_PROPOSAL:
       return { ...state, loadingProposals: action.payload };
     case FractalGovernanceAction.SET_GOVERNANCE_TYPE:
       return { ...state, type: action.payload };


### PR DESCRIPTION
Closes #2069 

"If proposal metadata is malformed for Azorius - we completely skipping further proposal parsing and thus it's not possible to execute proposal. We should move parsing of the proposal's metadata down the line so that we can still show & execute the proposal"

Re: "move parsing down", that didn't happen in this PR, nor did it seem necessary.

A simple try-catch on just the metadata parsing and returning a default JSON on failure did the trick.