### PR TITLE
Add Hotjar for them heatmaps + Amplitude for event analysis

### DIFF
--- a/.env
+++ b/.env
@@ -15,8 +15,10 @@ SENTRY_AUTH_TOKEN=""
 # App name displayed as Title
 VITE_APP_NAME="Decent"
 
-# Hotjar Site ID
+# Hotjar Site ID. Type is `number`
 VITE_APP_HOTJAR_SITE_ID=""
+
+# Hotjar Version. Should be retrieved from the Hotjar dashboard. Type is `number`
 VITE_APP_HOTJAR_VERSION=""
 
 # Alchemy provider API key

--- a/.env
+++ b/.env
@@ -21,6 +21,9 @@ VITE_APP_HOTJAR_SITE_ID=""
 # Hotjar Version. Should be retrieved from the Hotjar dashboard. This should be parseable to an integer.
 VITE_APP_HOTJAR_VERSION=""
 
+# API key for Amplitude analytics
+VITE_APP_AMPLITUDE_API_KEY=""
+
 # Alchemy provider API key
 VITE_APP_ALCHEMY_API_KEY=""
 

--- a/.env
+++ b/.env
@@ -15,10 +15,10 @@ SENTRY_AUTH_TOKEN=""
 # App name displayed as Title
 VITE_APP_NAME="Decent"
 
-# Hotjar Site ID. Type is `number`
+# Hotjar Site ID. This should be parseable to an integer.
 VITE_APP_HOTJAR_SITE_ID=""
 
-# Hotjar Version. Should be retrieved from the Hotjar dashboard. Type is `number`
+# Hotjar Version. Should be retrieved from the Hotjar dashboard. This should be parseable to an integer.
 VITE_APP_HOTJAR_VERSION=""
 
 # Alchemy provider API key

--- a/.env
+++ b/.env
@@ -15,6 +15,10 @@ SENTRY_AUTH_TOKEN=""
 # App name displayed as Title
 VITE_APP_NAME="Decent"
 
+# Hotjar Site ID
+VITE_APP_HOTJAR_SITE_ID=""
+VITE_APP_HOTJAR_VERSION=""
+
 # Alchemy provider API key
 VITE_APP_ALCHEMY_API_KEY=""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.13",
       "hasInstallScript": true,
       "dependencies": {
+        "@amplitude/analytics-browser": "^2.11.1",
         "@apollo/client": "^3.7.10",
         "@chakra-ui/anatomy": "^2.2.2",
         "@chakra-ui/react": "^2.8.2",
@@ -115,6 +116,82 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+    },
+    "node_modules/@amplitude/analytics-browser": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.11.1.tgz",
+      "integrity": "sha512-dLej5BZLbnlOw40lQJs5KnJx6EQRwcUJJlnZsFH72LyBq8WvxnDb40yHqSxOl/b7tCJWRozBw75B3Fzkz5OOLw==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": "^2.3.1",
+        "@amplitude/analytics-core": "^2.5.0",
+        "@amplitude/analytics-remote-config": "^0.4.0",
+        "@amplitude/analytics-types": "^2.8.0",
+        "@amplitude/plugin-autocapture-browser": "^1.0.0",
+        "@amplitude/plugin-page-view-tracking-browser": "^2.2.20",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-client-common": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.3.1.tgz",
+      "integrity": "sha512-HR5kdLkyz2niUqTA+9fP3MQgqixk5ToY0ohxNrsiqExFDftyKMplQenlFxjh/w5vb72lLf5gI3T2ssIUCkGuvw==",
+      "dependencies": {
+        "@amplitude/analytics-connector": "^1.4.8",
+        "@amplitude/analytics-core": "^2.5.0",
+        "@amplitude/analytics-types": "^2.8.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-connector": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
+      "integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
+    },
+    "node_modules/@amplitude/analytics-core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.5.0.tgz",
+      "integrity": "sha512-WQSF6u2k+c+EvC0nVd1kVWvUV/dGyyU2fVBHlcqWtEadCFFZRgty94K5JDC3E+W41+PQeNnTbiH8Wkf98rPYdg==",
+      "dependencies": {
+        "@amplitude/analytics-types": "^2.8.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-remote-config": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.0.tgz",
+      "integrity": "sha512-ilp9Dz8Z92V9Wilmz8XIbvEbtuVaN65+jM06JP8I7wL8eNOHVIi4HcI151BzIyekjbprbS1w18Ps3dj2sHlFXA==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": ">=1 <3",
+        "@amplitude/analytics-core": ">=1 <3",
+        "@amplitude/analytics-types": ">=1 <3",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-types": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.8.0.tgz",
+      "integrity": "sha512-LQ9XWtmv8n0qMGE/JfB0xOvwAc0swy63Xqz7fPhVinz/SUm2buUEKzUNAiq55tZJhEvGs/AsJRmJqu0G563Mgg=="
+    },
+    "node_modules/@amplitude/plugin-autocapture-browser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.0.0.tgz",
+      "integrity": "sha512-qPlR5e1XMPvus32dJTsd8dgFyentR3ugiPv8obwe/bSqpD0Kem31DQic+JadPwG+L3e4UE4QO08hz2lEl9GHMg==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": ">=1 <3",
+        "@amplitude/analytics-types": ">=1 <3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-page-view-tracking-browser": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.2.20.tgz",
+      "integrity": "sha512-/X2OAdqyGe4kEZGUFX6AcuBLEb2g3KcPIdHDXzGHRk7nxsJKv9pH1dqt3Z4RxHi0Ylhrh25ysr2NzZz4HOA/GQ==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": "^2.3.1",
+        "@amplitude/analytics-types": "^2.8.0",
+        "tslib": "^2.4.1"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -41695,6 +41772,14 @@
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
       "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
       "peer": true
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@graphprotocol/client-apollo": "^1.0.16",
         "@hatsprotocol/sdk-v1-core": "^0.9.0",
         "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
+        "@hotjar/browser": "^1.0.9",
         "@lido-sdk/contracts": "^3.0.2",
         "@netlify/blobs": "^6.5.0",
         "@netlify/functions": "^2.6.0",
@@ -7667,6 +7668,11 @@
         "graphql-request": "^6.1.0",
         "zod": "^3.22.4"
       }
+    },
+    "node_modules/@hotjar/browser": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@hotjar/browser/-/browser-1.0.9.tgz",
+      "integrity": "sha512-n9akDMod8BLGpYEQCrHwlYWWd63c1HlhUSXNIDfClZtKYXbUjIUOFlNZNNcUxgHTCsi4l2i+SWKsGsO0t93S8w=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@graphprotocol/client-apollo": "^1.0.16",
     "@hatsprotocol/sdk-v1-core": "^0.9.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
+    "@hotjar/browser": "^1.0.9",
     "@lido-sdk/contracts": "^3.0.2",
     "@netlify/blobs": "^6.5.0",
     "@netlify/functions": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.13",
   "private": true,
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.11.1",
     "@apollo/client": "^3.7.10",
     "@chakra-ui/anatomy": "^2.2.2",
     "@chakra-ui/react": "^2.8.2",

--- a/src/helpers/errorLogging.ts
+++ b/src/helpers/errorLogging.ts
@@ -1,48 +1,4 @@
 import * as Sentry from '@sentry/react';
-import { useEffect } from 'react';
-import {
-  useLocation,
-  useNavigationType,
-  createRoutesFromChildren,
-  matchRoutes,
-} from 'react-router-dom';
-
-/**
- * Initializes error logging.
- */
-function initErrorLogging() {
-  Sentry.init({
-    dsn: import.meta.env.VITE_APP_SENTRY_DSN_URL,
-    integrations: [
-      Sentry.reactRouterV6BrowserTracingIntegration({
-        useEffect,
-        useLocation,
-        useNavigationType,
-        createRoutesFromChildren,
-        matchRoutes,
-      }),
-      Sentry.replayIntegration({
-        maskAllText: false,
-        maskAllInputs: false,
-      }),
-      Sentry.feedbackIntegration({
-        colorScheme: 'dark',
-      }),
-    ],
-
-    // Set tracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
-    // We recommend adjusting this value in production
-    tracesSampleRate: 1.0,
-
-    // Capture Replay for 10% of all sessions,
-    // plus for 100% of sessions with an error
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-  });
-}
-
-initErrorLogging();
 
 /**
  * Logs an error to Sentry and the console.

--- a/src/insights/amplitude.ts
+++ b/src/insights/amplitude.ts
@@ -3,7 +3,7 @@ import * as amplitude from '@amplitude/analytics-browser';
 export const initAmplitude = () => {
   const amplitudeApiKey = import.meta.env.VITE_APP_AMPLITUDE_API_KEY;
 
-  if (amplitudeApiKey === "") {
+  if (amplitudeApiKey === '') {
     return;
   }
 

--- a/src/insights/amplitude.ts
+++ b/src/insights/amplitude.ts
@@ -1,0 +1,11 @@
+import * as amplitude from '@amplitude/analytics-browser';
+
+export const initAmplitude = () => {
+  const amplitudeApiKey = import.meta.env.VITE_APP_AMPLITUDE_API_KEY;
+
+  if (!amplitudeApiKey) {
+    return;
+  }
+
+  amplitude.init(amplitudeApiKey);
+};

--- a/src/insights/amplitude.ts
+++ b/src/insights/amplitude.ts
@@ -3,7 +3,7 @@ import * as amplitude from '@amplitude/analytics-browser';
 export const initAmplitude = () => {
   const amplitudeApiKey = import.meta.env.VITE_APP_AMPLITUDE_API_KEY;
 
-  if (!amplitudeApiKey) {
+  if (amplitudeApiKey === "") {
     return;
   }
 

--- a/src/insights/analyticsEvents.ts
+++ b/src/insights/analyticsEvents.ts
@@ -1,0 +1,18 @@
+export const analyticsEvents = {
+  DaoCreatePageOpened: 'DaoCreatePageOpened',
+  DaoCreateFormSubmitted: 'DaoCreateFormSubmitted',
+  DaoDashboardPageOpened: 'DaoDashboardPageOpened',
+  ModifyGovernancePageOpened: 'ModifyGovernancePageOpened',
+  HierarchyPageOpened: 'HierarchyPageOpened',
+  RolesPageOpened: 'RolesPageOpened',
+  RolesEditPageOpened: 'RolesEditPageOpened',
+  SubDaoCreatePageOpened: 'SubDaoCreatePageOpened',
+  ProposalTemplatesPageOpened: 'ProposalTemplatesPageOpened',
+  CreateProposalTemplatePageOpened: 'CreateProposalTemplatePageOpened',
+  ProposalsPageOpened: 'ProposalsPageOpened',
+  ProposalDetailsPageOpened: 'ProposalDetailsPageOpened',
+  CreateProposalPageOpened: 'CreateProposalPageOpened',
+  SafeSettingsPageOpened: 'SafeSettingsPageOpened',
+  TreasuryPageOpened: 'TreasuryPageOpened',
+  SablierProposalCreatePageOpened: 'SablierProposalCreatePageOpened',
+};

--- a/src/insights/hotjar.ts
+++ b/src/insights/hotjar.ts
@@ -1,0 +1,11 @@
+import Hotjar from '@hotjar/browser';
+
+export const initHotjar = () => {
+  console.count("initHotjar");
+  const hotjarSiteId = import.meta.env.VITE_APP_HOTJAR_SITE_ID;
+  const hotjarVersion = import.meta.env.VITE_APP_HOTJAR_VERSION;
+
+  if (hotjarSiteId !== undefined && hotjarVersion !== undefined) {
+    Hotjar.init(hotjarSiteId, hotjarVersion);
+  }
+};

--- a/src/insights/hotjar.ts
+++ b/src/insights/hotjar.ts
@@ -1,11 +1,17 @@
 import Hotjar from '@hotjar/browser';
 
 export const initHotjar = () => {
-  console.count("initHotjar");
-  const hotjarSiteId = import.meta.env.VITE_APP_HOTJAR_SITE_ID;
-  const hotjarVersion = import.meta.env.VITE_APP_HOTJAR_VERSION;
-
-  if (hotjarSiteId !== undefined && hotjarVersion !== undefined) {
-    Hotjar.init(hotjarSiteId, hotjarVersion);
+  if (!import.meta.env.VITE_APP_HOTJAR_SITE_ID || !import.meta.env.VITE_APP_HOTJAR_VERSION) {
+    // Do not initialize Hotjar if the site ID or version are not set, as this would be the case on all non-prod sites.
+    return;
   }
+
+  const hotjarSiteId = Number.parseInt(import.meta.env.VITE_APP_HOTJAR_SITE_ID);
+  const hotjarVersion = Number.parseInt(import.meta.env.VITE_APP_HOTJAR_VERSION);
+
+  if (Number.isNaN(hotjarSiteId) || Number.isNaN(hotjarVersion)) {
+    throw new Error('Hotjar site ID and version must be numbers');
+  }
+
+  Hotjar.init(hotjarSiteId, hotjarVersion);
 };

--- a/src/insights/hotjar.ts
+++ b/src/insights/hotjar.ts
@@ -1,7 +1,7 @@
 import Hotjar from '@hotjar/browser';
 
 export const initHotjar = () => {
-  if (!import.meta.env.VITE_APP_HOTJAR_SITE_ID || !import.meta.env.VITE_APP_HOTJAR_VERSION) {
+  if (import.meta.env.VITE_APP_HOTJAR_SITE_ID === "" || import.meta.env.VITE_APP_HOTJAR_VERSION === "") {
     // Do not initialize Hotjar if the site ID or version are not set, as this would be the case on all non-prod sites.
     return;
   }

--- a/src/insights/hotjar.ts
+++ b/src/insights/hotjar.ts
@@ -1,7 +1,10 @@
 import Hotjar from '@hotjar/browser';
 
 export const initHotjar = () => {
-  if (import.meta.env.VITE_APP_HOTJAR_SITE_ID === "" || import.meta.env.VITE_APP_HOTJAR_VERSION === "") {
+  if (
+    import.meta.env.VITE_APP_HOTJAR_SITE_ID === '' ||
+    import.meta.env.VITE_APP_HOTJAR_VERSION === ''
+  ) {
     // Do not initialize Hotjar if the site ID or version are not set, as this would be the case on all non-prod sites.
     return;
   }

--- a/src/insights/hotjar.tsx
+++ b/src/insights/hotjar.tsx
@@ -1,8 +1,0 @@
-import Hotjar from '@hotjar/browser';
-
-const hotjarSiteId = import.meta.env.VITE_APP_HOTJAR_SITE_ID;
-const hotjarVersion = import.meta.env.VITE_APP_HOTJAR_VERSION;
-
-if (hotjarSiteId !== undefined && hotjarVersion !== undefined) {
-  Hotjar.init(hotjarSiteId, hotjarVersion);
-}

--- a/src/insights/hotjar.tsx
+++ b/src/insights/hotjar.tsx
@@ -1,0 +1,9 @@
+import Hotjar from '@hotjar/browser';
+
+const hotjarSiteId = import.meta.env.VITE_APP_HOTJAR_SITE_ID;
+const hotjarVersion = import.meta.env.VITE_APP_HOTJAR_VERSION;
+
+if (hotjarSiteId !== undefined && hotjarVersion !== undefined) {
+  console.count('initHotjar from hotjar file');
+  Hotjar.init(hotjarSiteId, hotjarVersion);
+}

--- a/src/insights/hotjar.tsx
+++ b/src/insights/hotjar.tsx
@@ -4,6 +4,5 @@ const hotjarSiteId = import.meta.env.VITE_APP_HOTJAR_SITE_ID;
 const hotjarVersion = import.meta.env.VITE_APP_HOTJAR_VERSION;
 
 if (hotjarSiteId !== undefined && hotjarVersion !== undefined) {
-  console.count('initHotjar from hotjar file');
   Hotjar.init(hotjarSiteId, hotjarVersion);
 }

--- a/src/insights/index.ts
+++ b/src/insights/index.ts
@@ -1,5 +1,7 @@
+import { initAmplitude } from './amplitude';
 import { initHotjar } from './hotjar';
 import { initSentry } from './sentry';
 
 initHotjar();
 initSentry();
+initAmplitude();

--- a/src/insights/index.ts
+++ b/src/insights/index.ts
@@ -1,0 +1,5 @@
+import { initHotjar } from './hotjar';
+import { initSentry } from './sentry';
+
+initHotjar();
+initSentry();

--- a/src/insights/sentry.ts
+++ b/src/insights/sentry.ts
@@ -11,7 +11,6 @@ import {
  * Initializes error logging.
  */
 export const initSentry = () => {
-  console.count("initSentry");
   Sentry.init({
     dsn: import.meta.env.VITE_APP_SENTRY_DSN_URL,
     integrations: [

--- a/src/insights/sentry.ts
+++ b/src/insights/sentry.ts
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/react';
+import { useEffect } from 'react';
+import {
+  useLocation,
+  useNavigationType,
+  createRoutesFromChildren,
+  matchRoutes,
+} from 'react-router-dom';
+
+/**
+ * Initializes error logging.
+ */
+console.count('initErrorLogging from sentry file');
+Sentry.init({
+  dsn: import.meta.env.VITE_APP_SENTRY_DSN_URL,
+  integrations: [
+    Sentry.reactRouterV6BrowserTracingIntegration({
+      useEffect,
+      useLocation,
+      useNavigationType,
+      createRoutesFromChildren,
+      matchRoutes,
+    }),
+    Sentry.replayIntegration({
+      maskAllText: false,
+      maskAllInputs: false,
+    }),
+    Sentry.feedbackIntegration({
+      colorScheme: 'dark',
+    }),
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0,
+
+  // Capture Replay for 10% of all sessions,
+  // plus for 100% of sessions with an error
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});

--- a/src/insights/sentry.ts
+++ b/src/insights/sentry.ts
@@ -10,33 +10,35 @@ import {
 /**
  * Initializes error logging.
  */
-console.count('initErrorLogging from sentry file');
-Sentry.init({
-  dsn: import.meta.env.VITE_APP_SENTRY_DSN_URL,
-  integrations: [
-    Sentry.reactRouterV6BrowserTracingIntegration({
-      useEffect,
-      useLocation,
-      useNavigationType,
-      createRoutesFromChildren,
-      matchRoutes,
-    }),
-    Sentry.replayIntegration({
-      maskAllText: false,
-      maskAllInputs: false,
-    }),
-    Sentry.feedbackIntegration({
-      colorScheme: 'dark',
-    }),
-  ],
+export const initSentry = () => {
+  console.count("initSentry");
+  Sentry.init({
+    dsn: import.meta.env.VITE_APP_SENTRY_DSN_URL,
+    integrations: [
+      Sentry.reactRouterV6BrowserTracingIntegration({
+        useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
+      Sentry.replayIntegration({
+        maskAllText: false,
+        maskAllInputs: false,
+      }),
+      Sentry.feedbackIntegration({
+        colorScheme: 'dark',
+      }),
+    ],
 
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    // We recommend adjusting this value in production
+    tracesSampleRate: 1.0,
 
-  // Capture Replay for 10% of all sessions,
-  // plus for 100% of sessions with an error
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-});
+    // Capture Replay for 10% of all sessions,
+    // plus for 100% of sessions with an error
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
-import Hotjar from '@hotjar/browser';
+import './insights/sentry';
+import './insights/hotjar';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
@@ -17,13 +18,6 @@ function FractalRouterProvider() {
 
 const root = document.getElementById('root');
 if (root !== null) {
-  const hotjarSiteId = import.meta.env.VITE_APP_HOTJAR_SITE_ID;
-  const hotjarVersion = import.meta.env.VITE_APP_HOTJAR_VERSION;
-
-  if (hotjarSiteId !== undefined && hotjarVersion !== undefined) {
-    Hotjar.init(hotjarSiteId, hotjarVersion);
-  }
-
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
       <Providers>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,4 @@
-import './insights/sentry';
-import './insights/hotjar';
+import './insights';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,9 +10,6 @@ import 'react-toastify/dist/ReactToastify.min.css';
 import './assets/css/Markdown.css';
 import './assets/css/sentry.css';
 
-const siteId = 5107892;
-const hotjarVersion = 6;
-
 function FractalRouterProvider() {
   const { addressPrefix } = useNetworkConfig();
   return <RouterProvider router={router(addressPrefix)} />;
@@ -20,9 +17,13 @@ function FractalRouterProvider() {
 
 const root = document.getElementById('root');
 if (root !== null) {
+  const hotjarSiteId = import.meta.env.VITE_APP_HOTJAR_SITE_ID;
+  const hotjarVersion = import.meta.env.VITE_APP_HOTJAR_VERSION;
 
-  Hotjar.init(siteId, hotjarVersion);
-  
+  if (hotjarSiteId !== undefined && hotjarVersion !== undefined) {
+    Hotjar.init(hotjarSiteId, hotjarVersion);
+  }
+
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
       <Providers>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import Hotjar from '@hotjar/browser';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
@@ -9,6 +10,9 @@ import 'react-toastify/dist/ReactToastify.min.css';
 import './assets/css/Markdown.css';
 import './assets/css/sentry.css';
 
+const siteId = 5107892;
+const hotjarVersion = 6;
+
 function FractalRouterProvider() {
   const { addressPrefix } = useNetworkConfig();
   return <RouterProvider router={router(addressPrefix)} />;
@@ -16,6 +20,9 @@ function FractalRouterProvider() {
 
 const root = document.getElementById('root');
 if (root !== null) {
+
+  Hotjar.init(siteId, hotjarVersion);
+  
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
       <Providers>

--- a/src/pages/create/index.tsx
+++ b/src/pages/create/index.tsx
@@ -25,7 +25,9 @@ export default function DaoCreatePage() {
 
   const { isConnected } = useAccount();
 
-  amplitude.track(analyticsEvents.DaoCreatePageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.DaoCreatePageOpened);
+  }, []);
 
   useEffect(() => {
     if (isConnected) {

--- a/src/pages/create/index.tsx
+++ b/src/pages/create/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -10,6 +11,7 @@ import { BASE_ROUTES, DAO_ROUTES } from '../../constants/routes';
 import { useAccountFavorites } from '../../hooks/DAO/loaders/useFavorites';
 import useDeployDAO from '../../hooks/DAO/useDeployDAO';
 import { useAsyncRetry } from '../../hooks/utils/useAsyncRetry';
+import { analyticsEvents } from '../../insights/analyticsEvents';
 import { useSafeAPI } from '../../providers/App/hooks/useSafeAPI';
 import { SafeMultisigDAO, AzoriusERC20DAO, AzoriusERC721DAO } from '../../types';
 
@@ -22,6 +24,8 @@ export default function DaoCreatePage() {
   const safeAPI = useSafeAPI();
 
   const { isConnected } = useAccount();
+
+  amplitude.track(analyticsEvents.DaoCreatePageOpened);
 
   useEffect(() => {
     if (isConnected) {

--- a/src/pages/daos/[daoAddress]/DaoDashboardPage.tsx
+++ b/src/pages/daos/[daoAddress]/DaoDashboardPage.tsx
@@ -1,5 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Box } from '@chakra-ui/react';
+import { useEffect } from 'react';
 import { Activities } from '../../../components/pages/DaoDashboard/Activities';
 import { ERCO20Claim } from '../../../components/pages/DaoDashboard/ERC20Claim';
 import { DaoInfoHeader } from '../../../components/pages/DaoDashboard/Info/DaoInfoHeader';
@@ -7,7 +8,9 @@ import { CONTENT_MAXW } from '../../../constants/common';
 import { analyticsEvents } from '../../../insights/analyticsEvents';
 
 export default function DaoDashboardPage() {
-  amplitude.track(analyticsEvents.DaoDashboardPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.DaoDashboardPageOpened);
+  }, []);
   return (
     <>
       <Box

--- a/src/pages/daos/[daoAddress]/DaoDashboardPage.tsx
+++ b/src/pages/daos/[daoAddress]/DaoDashboardPage.tsx
@@ -1,10 +1,13 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Box } from '@chakra-ui/react';
 import { Activities } from '../../../components/pages/DaoDashboard/Activities';
 import { ERCO20Claim } from '../../../components/pages/DaoDashboard/ERC20Claim';
 import { DaoInfoHeader } from '../../../components/pages/DaoDashboard/Info/DaoInfoHeader';
 import { CONTENT_MAXW } from '../../../constants/common';
+import { analyticsEvents } from '../../../insights/analyticsEvents';
 
 export default function DaoDashboardPage() {
+  amplitude.track(analyticsEvents.DaoDashboardPageOpened);
   return (
     <>
       <Box

--- a/src/pages/daos/[daoAddress]/SettingsPage.tsx
+++ b/src/pages/daos/[daoAddress]/SettingsPage.tsx
@@ -1,12 +1,16 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Center } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { DAOSettingsContent } from '../../../components/pages/DaoSettings/DAOSettingsContent';
 import { BarLoader } from '../../../components/ui/loaders/BarLoader';
 import PageHeader from '../../../components/ui/page/Header/PageHeader';
 import { useHeaderHeight } from '../../../constants/common';
+import { analyticsEvents } from '../../../insights/analyticsEvents';
 import { useFractal } from '../../../providers/App/AppProvider';
 
 export function SettingsPage() {
+  amplitude.track(analyticsEvents.SafeSettingsPageOpened);
+
   const { t } = useTranslation('breadcrumbs');
   const {
     node: { daoAddress, daoName },

--- a/src/pages/daos/[daoAddress]/SettingsPage.tsx
+++ b/src/pages/daos/[daoAddress]/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Center } from '@chakra-ui/react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DAOSettingsContent } from '../../../components/pages/DaoSettings/DAOSettingsContent';
 import { BarLoader } from '../../../components/ui/loaders/BarLoader';
@@ -9,7 +10,9 @@ import { analyticsEvents } from '../../../insights/analyticsEvents';
 import { useFractal } from '../../../providers/App/AppProvider';
 
 export function SettingsPage() {
-  amplitude.track(analyticsEvents.SafeSettingsPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.SafeSettingsPageOpened);
+  }, []);
 
   const { t } = useTranslation('breadcrumbs');
   const {

--- a/src/pages/daos/[daoAddress]/edit/governance/index.tsx
+++ b/src/pages/daos/[daoAddress]/edit/governance/index.tsx
@@ -1,6 +1,7 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Box } from '@chakra-ui/react';
 import { X } from '@phosphor-icons/react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import DaoCreator from '../../../../../components/DaoCreator';
@@ -21,7 +22,9 @@ import {
 } from '../../../../../types';
 
 export default function ModifyGovernancePage() {
-  amplitude.track(analyticsEvents.ModifyGovernancePageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.ModifyGovernancePageOpened);
+  }, []);
 
   const {
     node: { daoAddress, safe, daoName, daoSnapshotENS },

--- a/src/pages/daos/[daoAddress]/edit/governance/index.tsx
+++ b/src/pages/daos/[daoAddress]/edit/governance/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Box } from '@chakra-ui/react';
 import { X } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +10,7 @@ import PageHeader from '../../../../../components/ui/page/Header/PageHeader';
 import { DAO_ROUTES } from '../../../../../constants/routes';
 import useDeployAzorius from '../../../../../hooks/DAO/useDeployAzorius';
 import { createAccountSubstring } from '../../../../../hooks/utils/useDisplayName';
+import { analyticsEvents } from '../../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../../providers/NetworkConfig/NetworkConfigProvider';
 import {
@@ -19,6 +21,8 @@ import {
 } from '../../../../../types';
 
 export default function ModifyGovernancePage() {
+  amplitude.track(analyticsEvents.ModifyGovernancePageOpened);
+
   const {
     node: { daoAddress, safe, daoName, daoSnapshotENS },
     governance: { type },

--- a/src/pages/daos/[daoAddress]/hierarchy/index.tsx
+++ b/src/pages/daos/[daoAddress]/hierarchy/index.tsx
@@ -1,5 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Center } from '@chakra-ui/react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DaoHierarchyNode } from '../../../../components/pages/DaoHierarchy/DaoHierarchyNode';
 import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
@@ -9,7 +10,9 @@ import { analyticsEvents } from '../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../providers/App/AppProvider';
 
 export default function HierarchyPage() {
-  amplitude.track(analyticsEvents.HierarchyPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.HierarchyPageOpened);
+  }, []);
 
   const {
     node: {

--- a/src/pages/daos/[daoAddress]/hierarchy/index.tsx
+++ b/src/pages/daos/[daoAddress]/hierarchy/index.tsx
@@ -1,12 +1,16 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Center } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { DaoHierarchyNode } from '../../../../components/pages/DaoHierarchy/DaoHierarchyNode';
 import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
 import PageHeader from '../../../../components/ui/page/Header/PageHeader';
 import { useHeaderHeight } from '../../../../constants/common';
+import { analyticsEvents } from '../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../providers/App/AppProvider';
 
 export default function HierarchyPage() {
+  amplitude.track(analyticsEvents.HierarchyPageOpened);
+
   const {
     node: {
       daoAddress,

--- a/src/pages/daos/[daoAddress]/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/new/index.tsx
@@ -1,5 +1,5 @@
 import * as amplitude from '@amplitude/analytics-browser';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DaoCreator from '../../../../components/DaoCreator';
 import { DAOCreateMode } from '../../../../components/DaoCreator/formComponents/EstablishEssentials';
@@ -10,7 +10,9 @@ import { useFractal } from '../../../../providers/App/AppProvider';
 import { SafeMultisigDAO, AzoriusGovernanceDAO, SubDAO } from '../../../../types';
 
 export default function SubDaoCreate() {
-  amplitude.track(analyticsEvents.SubDaoCreatePageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.SubDaoCreatePageOpened);
+  }, []);
 
   const navigate = useNavigate();
   const [redirectPending, setRedirectPending] = useState(false);

--- a/src/pages/daos/[daoAddress]/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/new/index.tsx
@@ -1,13 +1,17 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DaoCreator from '../../../../components/DaoCreator';
 import { DAOCreateMode } from '../../../../components/DaoCreator/formComponents/EstablishEssentials';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { useCreateSubDAOProposal } from '../../../../hooks/DAO/useCreateSubDAOProposal';
+import { analyticsEvents } from '../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { SafeMultisigDAO, AzoriusGovernanceDAO, SubDAO } from '../../../../types';
 
 export default function SubDaoCreate() {
+  amplitude.track(analyticsEvents.SubDaoCreatePageOpened);
+
   const navigate = useNavigate();
   const [redirectPending, setRedirectPending] = useState(false);
   const {

--- a/src/pages/daos/[daoAddress]/proposal-templates/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposal-templates/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Button, Show } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -6,10 +7,13 @@ import ProposalTemplates from '../../../../components/ProposalTemplates';
 import PageHeader from '../../../../components/ui/page/Header/PageHeader';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { useCanUserCreateProposal } from '../../../../hooks/utils/useCanUserSubmitProposal';
+import { analyticsEvents } from '../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 
 export default function ProposalTemplatesPage() {
+  amplitude.track(analyticsEvents.ProposalTemplatesPageOpened);
+
   const { t } = useTranslation();
   const {
     node: { daoAddress },

--- a/src/pages/daos/[daoAddress]/proposal-templates/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposal-templates/index.tsx
@@ -1,5 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Button, Show } from '@chakra-ui/react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { AddPlus } from '../../../../assets/theme/custom/icons/AddPlus';
@@ -12,7 +13,9 @@ import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 
 export default function ProposalTemplatesPage() {
-  amplitude.track(analyticsEvents.ProposalTemplatesPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.ProposalTemplatesPageOpened);
+  }, []);
 
   const { t } = useTranslation();
   const {

--- a/src/pages/daos/[daoAddress]/proposal-templates/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposal-templates/new/index.tsx
@@ -1,13 +1,17 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { useEffect, useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { ProposalBuilder } from '../../../../../components/ProposalBuilder';
 import { DEFAULT_PROPOSAL } from '../../../../../components/ProposalBuilder/constants';
 import { logError } from '../../../../../helpers/errorLogging';
 import useCreateProposalTemplate from '../../../../../hooks/DAO/proposal/useCreateProposalTemplate';
+import { analyticsEvents } from '../../../../../insights/analyticsEvents';
 import useIPFSClient from '../../../../../providers/App/hooks/useIPFSClient';
 import { ProposalBuilderMode, ProposalTemplate } from '../../../../../types/proposalBuilder';
 
 export default function CreateProposalTemplatePage() {
+  amplitude.track(analyticsEvents.CreateProposalTemplatePageOpened);
+
   const ipfsClient = useIPFSClient();
   const [initialProposalTemplate, setInitialProposalTemplate] = useState(DEFAULT_PROPOSAL);
   const { prepareProposalTemplateProposal } = useCreateProposalTemplate();

--- a/src/pages/daos/[daoAddress]/proposal-templates/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposal-templates/new/index.tsx
@@ -10,7 +10,9 @@ import useIPFSClient from '../../../../../providers/App/hooks/useIPFSClient';
 import { ProposalBuilderMode, ProposalTemplate } from '../../../../../types/proposalBuilder';
 
 export default function CreateProposalTemplatePage() {
-  amplitude.track(analyticsEvents.CreateProposalTemplatePageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.CreateProposalTemplatePageOpened);
+  }, []);
 
   const ipfsClient = useIPFSClient();
   const [initialProposalTemplate, setInitialProposalTemplate] = useState(DEFAULT_PROPOSAL);

--- a/src/pages/daos/[daoAddress]/proposals/[proposalId]/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/[proposalId]/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Box } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,11 +12,13 @@ import PageHeader from '../../../../../components/ui/page/Header/PageHeader';
 import { DAO_ROUTES } from '../../../../../constants/routes';
 import useSnapshotProposal from '../../../../../hooks/DAO/loaders/snapshot/useSnapshotProposal';
 import { useGetMetadata } from '../../../../../hooks/DAO/proposal/useGetMetadata';
+import { analyticsEvents } from '../../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { FractalProposal, AzoriusProposal, SnapshotProposal } from '../../../../../types';
 
 export default function ProposalDetailsPage() {
+  amplitude.track(analyticsEvents.ProposalDetailsPageOpened);
   const {
     node: { daoAddress },
     governance: { proposals },

--- a/src/pages/daos/[daoAddress]/proposals/[proposalId]/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/[proposalId]/index.tsx
@@ -18,7 +18,9 @@ import { useNetworkConfig } from '../../../../../providers/NetworkConfig/Network
 import { FractalProposal, AzoriusProposal, SnapshotProposal } from '../../../../../types';
 
 export default function ProposalDetailsPage() {
-  amplitude.track(analyticsEvents.ProposalDetailsPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.ProposalDetailsPageOpened);
+  }, []);
   const {
     node: { daoAddress },
     governance: { proposals },

--- a/src/pages/daos/[daoAddress]/proposals/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Button, Flex, Show, Text } from '@chakra-ui/react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,11 +11,13 @@ import { useDecentModal } from '../../../../components/ui/modals/useDecentModal'
 import PageHeader from '../../../../components/ui/page/Header/PageHeader';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { useCanUserCreateProposal } from '../../../../hooks/utils/useCanUserSubmitProposal';
+import { analyticsEvents } from '../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { AzoriusGovernance, DecentGovernance, GovernanceType } from '../../../../types';
 
 export default function ProposalsPage() {
+  amplitude.track(analyticsEvents.ProposalsPageOpened);
   const { t } = useTranslation(['common', 'proposal', 'breadcrumbs']);
   const {
     governance,

--- a/src/pages/daos/[daoAddress]/proposals/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/index.tsx
@@ -1,6 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Button, Flex, Show, Text } from '@chakra-ui/react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { AddPlus } from '../../../../assets/theme/custom/icons/AddPlus';
@@ -17,7 +17,9 @@ import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkCon
 import { AzoriusGovernance, DecentGovernance, GovernanceType } from '../../../../types';
 
 export default function ProposalsPage() {
-  amplitude.track(analyticsEvents.ProposalsPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.ProposalsPageOpened);
+  }, []);
   const { t } = useTranslation(['common', 'proposal', 'breadcrumbs']);
   const {
     governance,

--- a/src/pages/daos/[daoAddress]/proposals/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/new/index.tsx
@@ -1,13 +1,16 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Center } from '@chakra-ui/react';
 import { ProposalBuilder } from '../../../../../components/ProposalBuilder';
 import { DEFAULT_PROPOSAL } from '../../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../../components/ui/loaders/BarLoader';
 import { useHeaderHeight } from '../../../../../constants/common';
 import { usePrepareProposal } from '../../../../../hooks/DAO/proposal/usePrepareProposal';
+import { analyticsEvents } from '../../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../../providers/App/AppProvider';
 import { ProposalBuilderMode } from '../../../../../types';
 
 export default function CreateProposalPage() {
+  amplitude.track(analyticsEvents.CreateProposalPageOpened);
   const {
     node: { daoAddress, safe },
     governance: { type },

--- a/src/pages/daos/[daoAddress]/proposals/new/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/new/index.tsx
@@ -1,5 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Center } from '@chakra-ui/react';
+import { useEffect } from 'react';
 import { ProposalBuilder } from '../../../../../components/ProposalBuilder';
 import { DEFAULT_PROPOSAL } from '../../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../../components/ui/loaders/BarLoader';
@@ -10,7 +11,9 @@ import { useFractal } from '../../../../../providers/App/AppProvider';
 import { ProposalBuilderMode } from '../../../../../types';
 
 export default function CreateProposalPage() {
-  amplitude.track(analyticsEvents.CreateProposalPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.CreateProposalPageOpened);
+  }, []);
   const {
     node: { daoAddress, safe },
     governance: { type },

--- a/src/pages/daos/[daoAddress]/proposals/new/sablier/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/new/sablier/index.tsx
@@ -731,7 +731,9 @@ function StreamsBuilder({
 }
 
 export default function SablierProposalCreatePage() {
-  amplitude.track(analyticsEvents.SablierProposalCreatePageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.SablierProposalCreatePageOpened);
+  }, []);
 
   const {
     node: { daoAddress, safe },

--- a/src/pages/daos/[daoAddress]/proposals/new/sablier/index.tsx
+++ b/src/pages/daos/[daoAddress]/proposals/new/sablier/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import {
   Accordion,
   AccordionButton,
@@ -69,6 +70,7 @@ import { useHeaderHeight } from '../../../../../../constants/common';
 import { BASE_ROUTES, DAO_ROUTES } from '../../../../../../constants/routes';
 import useSubmitProposal from '../../../../../../hooks/DAO/proposal/useSubmitProposal';
 import { useCanUserCreateProposal } from '../../../../../../hooks/utils/useCanUserSubmitProposal';
+import { analyticsEvents } from '../../../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { BigIntValuePair, CreateProposalSteps } from '../../../../../../types';
@@ -729,6 +731,8 @@ function StreamsBuilder({
 }
 
 export default function SablierProposalCreatePage() {
+  amplitude.track(analyticsEvents.SablierProposalCreatePageOpened);
+
   const {
     node: { daoAddress, safe },
     governance: { type },

--- a/src/pages/daos/[daoAddress]/roles/edit/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/index.tsx
@@ -2,7 +2,7 @@ import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Button, Flex, Hide, Show } from '@chakra-ui/react';
 import { Plus } from '@phosphor-icons/react';
 import { Formik } from 'formik';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { Hex, getAddress } from 'viem';
@@ -28,7 +28,9 @@ import { getNewRole, useRolesStore } from '../../../../../store/roles';
 import { UnsavedChangesWarningContent } from './unsavedChangesWarningContent';
 
 function RolesEdit() {
-  amplitude.track(analyticsEvents.RolesEditPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.RolesEditPageOpened);
+  }, []);
 
   const { t } = useTranslation(['roles', 'navigation', 'modals', 'common']);
   const {

--- a/src/pages/daos/[daoAddress]/roles/edit/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Button, Flex, Hide, Show } from '@chakra-ui/react';
 import { Plus } from '@phosphor-icons/react';
 import { Formik } from 'formik';
@@ -20,12 +21,15 @@ import { DAO_ROUTES } from '../../../../../constants/routes';
 import { useRolesSchema } from '../../../../../hooks/schemas/roles/useRolesSchema';
 import useCreateRoles from '../../../../../hooks/utils/useCreateRoles';
 import { useNavigationBlocker } from '../../../../../hooks/utils/useNavigationBlocker';
+import { analyticsEvents } from '../../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { getNewRole, useRolesStore } from '../../../../../store/roles';
 import { UnsavedChangesWarningContent } from './unsavedChangesWarningContent';
 
 function RolesEdit() {
+  amplitude.track(analyticsEvents.RolesEditPageOpened);
+
   const { t } = useTranslation(['roles', 'navigation', 'modals', 'common']);
   const {
     node: { daoAddress, safe },

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -1,5 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Show } from '@chakra-ui/react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { Hex, zeroAddress } from 'viem';
@@ -16,7 +17,9 @@ import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkCon
 import { useRolesStore } from '../../../../store/roles';
 
 function Roles() {
-  amplitude.track(analyticsEvents.RolesPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.RolesPageOpened);
+  }, []);
 
   const { hatsTree } = useRolesStore();
   const { addressPrefix } = useNetworkConfig();

--- a/src/pages/daos/[daoAddress]/roles/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Show } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useNavigate } from 'react-router-dom';
@@ -9,11 +10,14 @@ import PencilWithLineIcon from '../../../../components/ui/icons/PencilWithLineIc
 import PageHeader from '../../../../components/ui/page/Header/PageHeader';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { useCanUserCreateProposal } from '../../../../hooks/utils/useCanUserSubmitProposal';
+import { analyticsEvents } from '../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { useRolesStore } from '../../../../store/roles';
 
 function Roles() {
+  amplitude.track(analyticsEvents.RolesPageOpened);
+
   const { hatsTree } = useRolesStore();
   const { addressPrefix } = useNetworkConfig();
   const { t } = useTranslation(['roles']);

--- a/src/pages/daos/[daoAddress]/treasury/index.tsx
+++ b/src/pages/daos/[daoAddress]/treasury/index.tsx
@@ -1,6 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Divider, Flex, Grid, GridItem, Show } from '@chakra-ui/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Assets } from '../../../../components/pages/DAOTreasury/components/Assets';
 import {
@@ -17,7 +17,9 @@ import { analyticsEvents } from '../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../providers/App/AppProvider';
 
 export default function Treasury() {
-  amplitude.track(analyticsEvents.TreasuryPageOpened);
+  useEffect(() => {
+    amplitude.track(analyticsEvents.TreasuryPageOpened);
+  }, []);
   const {
     node: { daoName },
     treasury: { assetsFungible, transfers },

--- a/src/pages/daos/[daoAddress]/treasury/index.tsx
+++ b/src/pages/daos/[daoAddress]/treasury/index.tsx
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Divider, Flex, Grid, GridItem, Show } from '@chakra-ui/react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,9 +13,11 @@ import { ModalType } from '../../../../components/ui/modals/ModalProvider';
 import { useDecentModal } from '../../../../components/ui/modals/useDecentModal';
 import PageHeader from '../../../../components/ui/page/Header/PageHeader';
 import { useCanUserCreateProposal } from '../../../../hooks/utils/useCanUserSubmitProposal';
+import { analyticsEvents } from '../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../providers/App/AppProvider';
 
 export default function Treasury() {
+  amplitude.track(analyticsEvents.TreasuryPageOpened);
   const {
     node: { daoName },
     treasury: { assetsFungible, transfers },

--- a/src/providers/App/useReadOnlyValues.ts
+++ b/src/providers/App/useReadOnlyValues.ts
@@ -62,8 +62,11 @@ export const useReadOnlyValues = ({ node, governance }: Fractal, _account?: stri
 
     const address = _account ? getAddress(_account) : undefined;
     Sentry.setUser(address ? { id: address } : null);
+
     if (address) {
       amplitude.setUserId(address);
+    } else {
+      amplitude.reset();
     }
 
     const newReadOnlyValues = {

--- a/src/providers/App/useReadOnlyValues.ts
+++ b/src/providers/App/useReadOnlyValues.ts
@@ -1,3 +1,4 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import { ERC721__factory } from '@fractal-framework/fractal-contracts';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash.isequal';
@@ -61,6 +62,9 @@ export const useReadOnlyValues = ({ node, governance }: Fractal, _account?: stri
 
     const address = _account ? getAddress(_account) : undefined;
     Sentry.setUser(address ? { id: address } : null);
+    if (address) {
+      amplitude.setUserId(address);
+    }
 
     const newReadOnlyValues = {
       user: {

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -16,6 +16,7 @@ import { wagmiConfig, queryClient } from './NetworkConfig/web3-modal.config';
 
 export default function Providers({ children }: { children: ReactNode }) {
   useMigrate();
+
   return (
     <ChakraProvider
       theme={theme}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,6 +19,9 @@ interface ImportMetaEnv {
 
   readonly VITE_APP_SENTRY_DSN_URL: string;
 
+  readonly VITE_APP_HOTJAR_SITE_ID: number;
+  readonly VITE_APP_HOTJAR_VERSION: number;
+
   readonly VITE_APP_SHUTTER_EON_PUBKEY: string;
 
   readonly VITE_APP_SITE_URL: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference types="vite/client" />
 
+// These are all typed as `string`s, because they exist in `.env`. If they didn't, they would be typed as `string | undefined`.
+// Netlify (or a local `.env.local` file) will override these environment variables.
 interface ImportMetaEnv {
   readonly PACKAGE_VERSION: string;
 
@@ -19,8 +21,8 @@ interface ImportMetaEnv {
 
   readonly VITE_APP_SENTRY_DSN_URL: string;
 
-  readonly VITE_APP_HOTJAR_SITE_ID: number;
-  readonly VITE_APP_HOTJAR_VERSION: number;
+  readonly VITE_APP_HOTJAR_SITE_ID: string;
+  readonly VITE_APP_HOTJAR_VERSION: string;
 
   readonly VITE_APP_SHUTTER_EON_PUBKEY: string;
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -24,6 +24,8 @@ interface ImportMetaEnv {
   readonly VITE_APP_HOTJAR_SITE_ID: string;
   readonly VITE_APP_HOTJAR_VERSION: string;
 
+  readonly VITE_APP_AMPLITUDE_API_KEY: string;
+
   readonly VITE_APP_SHUTTER_EON_PUBKEY: string;
 
   readonly VITE_APP_SITE_URL: string;


### PR DESCRIPTION
This PR will enable Hotjar tracking on the websites that will have the `VITE_APP_HOTJAR_SITE_ID` env variable on it (currently decision is to keep this to prod only).

Caveat: _"Hotjar is currently measuring your site's traffic. This requires 7 days worth of data."_ 

We'll need to wait at least a week after merging to prod and setting up the dashboard for any data to be visible.

UPDATE: This PR is being updated to also include Amplitude analytics.
