### PR TITLE
Center TopErrorFallback in da middle of the screen

### DIFF
--- a/src/components/ui/utils/TopErrorFallback.tsx
+++ b/src/components/ui/utils/TopErrorFallback.tsx
@@ -1,16 +1,20 @@
-import { Button, Box, Flex, Text, Image, Hide, Show } from '@chakra-ui/react';
+import { Box, Button, Flex, Hide, Image, Show, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { useHeaderHeight } from '../../../constants/common';
 import { BASE_ROUTES } from '../../../constants/routes';
 
 export function TopErrorFallback() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const HEADER_HEIGHT = useHeaderHeight();
 
   return (
     <Flex
       alignItems="center"
       justifyContent="center"
+      minHeight={`calc(100vh - ${HEADER_HEIGHT} - 15rem)`}
+      mt="6rem"
     >
       <Box
         borderRadius="0.5rem"


### PR DESCRIPTION
I'm quite sure this was the original intention and was implemented this way - but seems like we've broke it at some point a while ago cause I've seen this shitty error display but for who knows which reason thought it's intentional. Now I checked Figma - and there you go. Center as it should be. I'm not mad or something 🤣 
https://www.figma.com/design/9hUYtvCKjOyB92vt8ukYtD/Product-Handoff?node-id=2599-8113&m=dev

Before:
<img width="1728" alt="Screenshot 2024-08-27 at 23 42 50" src="https://github.com/user-attachments/assets/384cd375-f2b3-48b8-ac3c-a6b25987bfd2">
<img width="427" alt="Screenshot 2024-08-27 at 23 43 09" src="https://github.com/user-attachments/assets/ea059932-daad-431c-90d0-83f320c0d4b9">

After:
<img width="1084" alt="Screenshot 2024-08-27 at 23 37 47" src="https://github.com/user-attachments/assets/923d4cfa-5624-4edd-8924-5c6d21c8d55d">
<img width="425" alt="Screenshot 2024-08-27 at 23 38 02" src="https://github.com/user-attachments/assets/83ab6c15-51b5-4d0a-bc04-15b8dd0d2d5a">

@decentdao/engineering though I don't really like the way I implemented this - I wasn't able to come up with meaningful implementation without touching too much of surrounding layout. I'm actually OK keeping this implementation long term, but if someone feels we should implemented it better - feel free to create an issue and we'll tackle it (or plz halp to do that now 🤣 )