### PR TITLE
Typing the Push -> The Withdraw Modal+

### DIFF
--- a/src/components/Proposals/ProposalInfo.tsx
+++ b/src/components/Proposals/ProposalInfo.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Flex, Link } from '@chakra-ui/react';
 import { ArrowUpRight } from '@phosphor-icons/react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Shield } from '../../assets/theme/custom/icons/Shield';
 import useSnapshotProposal from '../../hooks/DAO/loaders/snapshot/useSnapshotProposal';
@@ -27,7 +28,19 @@ export function ProposalInfo({
   } = useFractal();
   const { isSnapshotProposal } = useSnapshotProposal(proposal);
 
-  const confirmUrl = useDecentModal(ModalType.CONFIRM_URL, { url: metaData.documentationUrl });
+  const [modalType, props] = useMemo(() => {
+    if (!metaData.documentationUrl) {
+      return [ModalType.NONE] as const;
+    }
+    return [
+      ModalType.CONFIRM_URL,
+      {
+        url: metaData.documentationUrl,
+      },
+    ] as const;
+  }, [metaData.documentationUrl]);
+
+  const confirmUrl = useDecentModal(modalType, props);
 
   return (
     <Box

--- a/src/components/pages/DaoSettings/components/Signers/SignersContainer.tsx
+++ b/src/components/pages/DaoSettings/components/Signers/SignersContainer.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex, Hide, HStack, Icon, Show, Text } from '@chakra-ui/react';
 import { MinusCircle, PlusCircle } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAccount } from 'wagmi';
 import { useFractal } from '../../../../../providers/App/AppProvider';
@@ -20,11 +20,21 @@ function Signer({
   threshold: number | undefined;
   disabled: boolean;
 }) {
-  const removeSigner = useDecentModal(ModalType.REMOVE_SIGNER, {
-    selectedSigner: signer,
-    signers: signers,
-    currentThreshold: threshold,
-  });
+  const [modalType, props] = useMemo(() => {
+    if (!signers || !threshold) {
+      return [ModalType.NONE] as const;
+    }
+    return [
+      ModalType.REMOVE_SIGNER,
+      {
+        selectedSigner: signer,
+        signers: signers,
+        currentThreshold: threshold,
+      },
+    ] as const;
+  }, [signer, signers, threshold]);
+
+  const removeSigner = useDecentModal(modalType, props);
   return (
     <HStack
       key={signer}
@@ -68,10 +78,14 @@ export function SignersContainer() {
   const [signers, setSigners] = useState<string[]>();
   const [userIsSigner, setUserIsSigner] = useState<boolean>();
 
-  const addSigner = useDecentModal(ModalType.ADD_SIGNER, {
-    signers: signers,
-    currentThreshold: safe?.threshold,
-  });
+  const [modalType, props] = useMemo(() => {
+    if (!signers) {
+      return [ModalType.NONE] as const;
+    }
+    return [ModalType.ADD_SIGNER, { signers, currentThreshold: safe?.threshold }] as const;
+  }, [signers, safe?.threshold]);
+
+  const addSigner = useDecentModal(modalType, props);
   const { t } = useTranslation(['common', 'breadcrumbs']);
   const { address: account } = useAccount();
   const enableRemove = userIsSigner && signers && signers?.length > 1;

--- a/src/components/pages/Roles/RolePaymentDetails.tsx
+++ b/src/components/pages/Roles/RolePaymentDetails.tsx
@@ -151,7 +151,7 @@ export function RolePaymentDetails({
     withdrawableAmount,
   ]);
 
-  const withdraw = useDecentModal(modalType ?? ModalType.NONE, props);
+  const withdraw = useDecentModal(modalType, props);
 
   const handleClickWithdraw = useCallback(() => {
     if (safe?.address) {

--- a/src/components/pages/Roles/RolePaymentDetails.tsx
+++ b/src/components/pages/Roles/RolePaymentDetails.tsx
@@ -62,8 +62,8 @@ function GreenStreamingDot({ isStreaming }: { isStreaming: boolean }) {
 }
 
 interface RolePaymentDetailsProps {
-  roleHatWearerAddress: Address;
-  roleHatSmartAddress: Address;
+  roleHatWearerAddress?: Address;
+  roleHatSmartAddress?: Address;
   payment: SablierPayment | SablierPaymentFormValues;
   onClick?: () => void;
   showWithdraw?: boolean;
@@ -115,15 +115,43 @@ export function RolePaymentDetails({
     loadAmounts();
   }, [loadAmounts]);
 
-  const withdraw = useDecentModal(ModalType.WITHDRAW_PAYMENT, {
-    payment,
-    onSuccess: loadAmounts,
-    withdrawInformation: {
-      withdrawableAmount,
-      roleHatWearerAddress,
-      roleHatSmartAddress,
-    },
-  });
+  const [modalType, props] = useMemo(() => {
+    if (
+      !payment.asset ||
+      !payment.streamId ||
+      !payment.contractAddress ||
+      !roleHatWearerAddress ||
+      !roleHatSmartAddress
+    ) {
+      return [ModalType.NONE] as const;
+    }
+    return [
+      ModalType.WITHDRAW_PAYMENT,
+      {
+        paymentAssetLogo: payment.asset.logo,
+        paymentAssetSymbol: payment.asset.symbol,
+        paymentAssetDecimals: payment.asset.decimals,
+        paymentStreamId: payment.streamId,
+        paymentContractAddress: payment.contractAddress,
+        onSuccess: loadAmounts,
+        withdrawInformation: {
+          withdrawableAmount,
+          roleHatWearerAddress,
+          roleHatSmartAddress,
+        },
+      },
+    ] as const;
+  }, [
+    payment.asset,
+    payment.contractAddress,
+    payment.streamId,
+    roleHatSmartAddress,
+    roleHatWearerAddress,
+    loadAmounts,
+    withdrawableAmount,
+  ]);
+
+  const withdraw = useDecentModal(modalType ?? ModalType.NONE, props);
 
   const handleClickWithdraw = useCallback(() => {
     if (safe?.address) {

--- a/src/components/ui/modals/ModalProvider.tsx
+++ b/src/components/ui/modals/ModalProvider.tsx
@@ -97,7 +97,7 @@ export type ModalPropsTypes = {
     paymentContractAddress: Address;
     withdrawInformation: {
       roleHatSmartAddress: Address;
-      roleHatwearerAddress: Address;
+      roleHatWearerAddress: Address;
       withdrawableAmount: bigint;
     };
     onSuccess: () => Promise<void>;
@@ -248,7 +248,7 @@ export function ModalProvider({ children }: { children: ReactNode }) {
           />
         );
         break;
-      case ModalType.WITHDRAW_PAYMENT:
+      case ModalType.WITHDRAW_PAYMENT: {
         modalContent = (
           <PaymentWithdrawModal
             paymentAssetLogo={current.props.paymentAssetLogo}
@@ -262,6 +262,7 @@ export function ModalProvider({ children }: { children: ReactNode }) {
           />
         );
         break;
+      }
       case ModalType.NONE:
       default:
         modalTitle = '';

--- a/src/components/ui/modals/PaymentWithdrawModal.tsx
+++ b/src/components/ui/modals/PaymentWithdrawModal.tsx
@@ -32,17 +32,18 @@ export default function PaymentWithdrawModal({
   paymentContractAddress?: Address;
   withdrawInformation: {
     roleHatSmartAddress: Address;
-    roleHatwearerAddress: Address;
+    roleHatWearerAddress: Address;
     withdrawableAmount: bigint;
   };
   onSuccess: () => Promise<void>;
   onClose: () => void;
 }) {
+  console.log('🚀 ~ withdrawInformation:', withdrawInformation);
   const publicClient = usePublicClient();
   const { data: walletClient } = useWalletClient();
   const { t } = useTranslation(['roles', 'menu', 'common', 'modals']);
   const { displayName: accountDisplayName } = useDisplayName(
-    withdrawInformation.roleHatwearerAddress,
+    withdrawInformation.roleHatWearerAddress,
   );
   const avatarURL = useAvatar(accountDisplayName);
   const iconSize = useBreakpointValue<AvatarSize>({ base: 'sm', md: 'icon' }) || 'sm';
@@ -55,7 +56,7 @@ export default function PaymentWithdrawModal({
       walletClient &&
       publicClient &&
       withdrawInformation.roleHatSmartAddress &&
-      withdrawInformation.roleHatwearerAddress
+      withdrawInformation.roleHatWearerAddress
     ) {
       let withdrawToast: Id | undefined = undefined;
       try {
@@ -68,7 +69,7 @@ export default function PaymentWithdrawModal({
         let hatsAccountCalldata = encodeFunctionData({
           abi: SablierV2LockupLinearAbi,
           functionName: 'withdrawMax',
-          args: [bigIntStreamId, getAddress(withdrawInformation.roleHatwearerAddress)],
+          args: [bigIntStreamId, getAddress(withdrawInformation.roleHatWearerAddress)],
         });
         withdrawToast = toast(t('withdrawPendingMessage'), {
           autoClose: false,
@@ -108,9 +109,13 @@ export default function PaymentWithdrawModal({
     onSuccess,
     onClose,
     withdrawInformation.roleHatSmartAddress,
-    withdrawInformation.roleHatwearerAddress,
+    withdrawInformation.roleHatWearerAddress,
     t,
   ]);
+  console.log(
+    '🚀 ~ withdrawInformation.roleHatWearerAddress:',
+    withdrawInformation.roleHatWearerAddress,
+  );
 
   return (
     <Flex
@@ -204,12 +209,12 @@ export default function PaymentWithdrawModal({
             >
               <Box>
                 <Avatar
-                  address={withdrawInformation.roleHatwearerAddress}
+                  address={withdrawInformation.roleHatWearerAddress}
                   url={avatarURL}
                   size={iconSize}
                 />
               </Box>
-              <Text textStyle="label-base">{withdrawInformation.roleHatwearerAddress}</Text>
+              <Text textStyle="label-base">{withdrawInformation.roleHatWearerAddress}</Text>
             </Flex>
           </Flex>
           <Flex

--- a/src/components/ui/modals/PaymentWithdrawModal.tsx
+++ b/src/components/ui/modals/PaymentWithdrawModal.tsx
@@ -13,16 +13,23 @@ import useAvatar from '../../../hooks/utils/useAvatar';
 import useDisplayName from '../../../hooks/utils/useDisplayName';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { formatCoin } from '../../../utils';
-import { SablierPayment } from '../../pages/Roles/types';
 import Avatar, { AvatarSize } from '../page/Header/Avatar';
 
 export default function PaymentWithdrawModal({
-  payment,
+  paymentAssetLogo,
+  paymentAssetSymbol,
+  paymentAssetDecimals,
+  paymentStreamId,
+  paymentContractAddress,
   withdrawInformation,
   onSuccess,
   onClose,
 }: {
-  payment: SablierPayment;
+  paymentAssetLogo?: string;
+  paymentAssetSymbol: string;
+  paymentStreamId?: string;
+  paymentAssetDecimals: number;
+  paymentContractAddress?: Address;
   withdrawInformation: {
     roleHatSmartAddress: Address;
     roleHatwearerAddress: Address;
@@ -43,8 +50,8 @@ export default function PaymentWithdrawModal({
 
   const handleWithdraw = useCallback(async () => {
     if (
-      payment?.contractAddress &&
-      payment?.streamId &&
+      paymentContractAddress &&
+      paymentStreamId &&
       walletClient &&
       publicClient &&
       withdrawInformation.roleHatSmartAddress &&
@@ -57,7 +64,7 @@ export default function PaymentWithdrawModal({
           address: withdrawInformation.roleHatSmartAddress,
           client: walletClient,
         });
-        const bigIntStreamId = convertStreamIdToBigInt(payment.streamId);
+        const bigIntStreamId = convertStreamIdToBigInt(paymentStreamId);
         let hatsAccountCalldata = encodeFunctionData({
           abi: SablierV2LockupLinearAbi,
           functionName: 'withdrawMax',
@@ -71,7 +78,7 @@ export default function PaymentWithdrawModal({
           progress: 1,
         });
         const txHash = await hatsAccountContract.write.execute([
-          payment.contractAddress,
+          paymentContractAddress,
           0n,
           hatsAccountCalldata,
           0,
@@ -94,8 +101,8 @@ export default function PaymentWithdrawModal({
       }
     }
   }, [
-    payment?.contractAddress,
-    payment?.streamId,
+    paymentContractAddress,
+    paymentStreamId,
     publicClient,
     walletClient,
     onSuccess,
@@ -140,13 +147,13 @@ export default function PaymentWithdrawModal({
             justifyContent="center"
           >
             <Image
-              src={payment.asset.logo}
+              src={paymentAssetLogo}
               fallbackSrc="/images/coin-icon-default.svg"
-              alt={payment.asset.symbol}
+              alt={paymentAssetSymbol}
               w="2rem"
               h="2rem"
             />
-            <Text textStyle="label-large">{payment.asset.symbol}</Text>
+            <Text textStyle="label-large">{paymentAssetSymbol}</Text>
           </Flex>
           <Flex
             px="1rem"
@@ -168,7 +175,7 @@ export default function PaymentWithdrawModal({
               {formatCoin(
                 withdrawInformation.withdrawableAmount,
                 true,
-                payment.asset.decimals,
+                paymentAssetDecimals,
                 undefined,
                 false,
               )}

--- a/src/components/ui/modals/useDecentModal.tsx
+++ b/src/components/ui/modals/useDecentModal.tsx
@@ -1,5 +1,11 @@
 import { useContext } from 'react';
-import { IModalContext, ModalContext, ModalType } from './ModalProvider';
+import {
+  CurrentModal,
+  IModalContext,
+  ModalContext,
+  ModalPropsTypes,
+  ModalType,
+} from './ModalProvider';
 
 /**
  * Returns a Function intended to be used in a click listener to open the provided ModalType.
@@ -8,9 +14,11 @@ import { IModalContext, ModalContext, ModalType } from './ModalProvider';
  * @param props optional arbitrary key:value properties to pass to the modal
  * @returns a Function that when called opens the provided ModalType modal.
  */
-export const useDecentModal = (modal: ModalType, props?: Record<string, any>) => {
+export const useDecentModal = <T extends ModalType>(modal: T, props?: ModalPropsTypes[T]) => {
   const { setCurrent } = useContext<IModalContext>(ModalContext);
   return () => {
-    setCurrent({ type: modal, props: props ? props : [] });
+    const modalObject = { type: modal, props: props ?? {} } as CurrentModal;
+
+    setCurrent(modalObject);
   };
 };


### PR DESCRIPTION
As I was looking at the `RolePaymentDetails` component noticed that the typing for the modal props were a `any`, now they are typed. 

This also updates a few other places where variables could have been passed to the Modal props as undefined. 