### PR TITLE
Do not allow clicking(aka editing) soft-deleted roles

### DIFF
--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -210,10 +210,12 @@ export function RoleCardEdit({
   editStatus,
   handleRoleClick,
 }: RoleEditProps) {
+  const isRemovedRole = editStatus === EditBadgeStatus.Removed;
   return (
     <Card
       mb="1rem"
-      onClick={handleRoleClick}
+      onClick={!isRemovedRole ? handleRoleClick : undefined}
+      cursor={isRemovedRole ? 'not-allowed' : 'pointer'}
     >
       <Flex justifyContent="space-between">
         <AvatarAndRoleName

--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -215,7 +215,7 @@ export function RoleCardEdit({
     <Card
       mb="1rem"
       onClick={!isRemovedRole ? handleRoleClick : undefined}
-      cursor={isRemovedRole ? 'not-allowed' : 'pointer'}
+      cursor={!isRemovedRole ? 'pointer' : 'not-allowed'}
     >
       <Flex justifyContent="space-between">
         <AvatarAndRoleName

--- a/src/components/pages/Roles/RolesTable.tsx
+++ b/src/components/pages/Roles/RolesTable.tsx
@@ -206,18 +206,20 @@ export function RolesRowEdit({
   payments,
   handleRoleClick,
 }: RoleEditProps) {
+  const isRemovedRole = editStatus === EditBadgeStatus.Removed;
   return (
     <Tr
       sx={{
         td: { padding: '0.75rem', height: '4rem' },
         '&:hover': {
-          '.edit-role-icon': { opacity: 1 },
+          '.edit-role-icon': { opacity: isRemovedRole ? 0 : 1 },
         },
       }}
       _hover={{ bg: 'neutral-3' }}
       _active={{ bg: 'neutral-2', border: '1px solid', borderColor: 'neutral-3' }}
       transition="all ease-out 300ms"
-      onClick={handleRoleClick}
+      onClick={!isRemovedRole ? handleRoleClick : undefined}
+      cursor={isRemovedRole ? 'not-allowed' : 'pointer'}
     >
       <RoleNameEditColumn
         roleName={name}

--- a/src/components/pages/Roles/RolesTable.tsx
+++ b/src/components/pages/Roles/RolesTable.tsx
@@ -219,7 +219,7 @@ export function RolesRowEdit({
       _active={{ bg: 'neutral-2', border: '1px solid', borderColor: 'neutral-3' }}
       transition="all ease-out 300ms"
       onClick={!isRemovedRole ? handleRoleClick : undefined}
-      cursor={isRemovedRole ? 'not-allowed' : 'pointer'}
+      cursor={!isRemovedRole ? 'pointer' : 'not-allowed'}
     >
       <RoleNameEditColumn
         roleName={name}


### PR DESCRIPTION
These changes are preventing user from clicking on soft-edited role card / table row.
It is not necessary to redirect user from the soft-edited role details as it is only possible through direct navigation, which will essentially reset form's state.

Closes #2292 