### PR TITLE
Streams on new hat tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",
         "@fontsource/space-mono": "^5.0.19",
-        "@fractal-framework/fractal-contracts": "^0.8.1",
+        "@fractal-framework/fractal-contracts": "^0.8.2",
         "@graphprotocol/client-apollo": "^1.0.16",
         "@hatsprotocol/sdk-v1-core": "^0.9.0",
         "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
@@ -5007,9 +5007,10 @@
       "integrity": "sha512-gz9yaKtXCY+HutNvQ4APc15xwZ1f6pWXve5N55x5m/hOoGqgB9Auf3l7CitHNhNJkSKEmaM45M29b0rFeudXlg=="
     },
     "node_modules/@fractal-framework/fractal-contracts": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-0.8.1.tgz",
-      "integrity": "sha512-whtIIZszBICvudFWiipQ+nbkGa7QvkYAA7oXGm915XUTaneAUXE/RcZJQESKNPy6t3tBEUok0SawBWJiF3kJYw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-0.8.2.tgz",
+      "integrity": "sha512-KkJhmns4ePNO5x4/JXR/2cXxHEbt6tlCHAVSkHy9ZRJ+cl1cLtBrlB6Cz4Qr3kikTAfZXkxKfxWwu0ho69V0tQ==",
+      "license": "MIT",
       "dependencies": {
         "solidity-docgen": "^0.6.0-beta.35"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@ethersproject/abstract-signer": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
     "@fontsource/space-mono": "^5.0.19",
-    "@fractal-framework/fractal-contracts": "^0.8.1",
+    "@fractal-framework/fractal-contracts": "^0.8.2",
     "@graphprotocol/client-apollo": "^1.0.16",
     "@hatsprotocol/sdk-v1-core": "^0.9.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",

--- a/src/assets/abi/DecentHats_0_1_0_Abi.ts
+++ b/src/assets/abi/DecentHats_0_1_0_Abi.ts
@@ -73,6 +73,82 @@ const DecentHats010Abi = [
                 name: 'wearer',
                 type: 'address',
               },
+              {
+                components: [
+                  {
+                    internalType: 'contract ISablierV2LockupLinear',
+                    name: 'sablier',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'address',
+                    name: 'sender',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'uint128',
+                    name: 'totalAmount',
+                    type: 'uint128',
+                  },
+                  {
+                    internalType: 'address',
+                    name: 'asset',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'cancelable',
+                    type: 'bool',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'transferable',
+                    type: 'bool',
+                  },
+                  {
+                    components: [
+                      {
+                        internalType: 'uint40',
+                        name: 'start',
+                        type: 'uint40',
+                      },
+                      {
+                        internalType: 'uint40',
+                        name: 'cliff',
+                        type: 'uint40',
+                      },
+                      {
+                        internalType: 'uint40',
+                        name: 'end',
+                        type: 'uint40',
+                      },
+                    ],
+                    internalType: 'struct LockupLinear.Timestamps',
+                    name: 'timestamps',
+                    type: 'tuple',
+                  },
+                  {
+                    components: [
+                      {
+                        internalType: 'address',
+                        name: 'account',
+                        type: 'address',
+                      },
+                      {
+                        internalType: 'uint256',
+                        name: 'fee',
+                        type: 'uint256',
+                      },
+                    ],
+                    internalType: 'struct LockupLinear.Broker',
+                    name: 'broker',
+                    type: 'tuple',
+                  },
+                ],
+                internalType: 'struct DecentHats_0_1_0.SablierStreamParams[]',
+                name: 'sablierParams',
+                type: 'tuple[]',
+              },
             ],
             internalType: 'struct DecentHats_0_1_0.Hat',
             name: 'adminHat',
@@ -104,6 +180,82 @@ const DecentHats010Abi = [
                 internalType: 'address',
                 name: 'wearer',
                 type: 'address',
+              },
+              {
+                components: [
+                  {
+                    internalType: 'contract ISablierV2LockupLinear',
+                    name: 'sablier',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'address',
+                    name: 'sender',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'uint128',
+                    name: 'totalAmount',
+                    type: 'uint128',
+                  },
+                  {
+                    internalType: 'address',
+                    name: 'asset',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'cancelable',
+                    type: 'bool',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'transferable',
+                    type: 'bool',
+                  },
+                  {
+                    components: [
+                      {
+                        internalType: 'uint40',
+                        name: 'start',
+                        type: 'uint40',
+                      },
+                      {
+                        internalType: 'uint40',
+                        name: 'cliff',
+                        type: 'uint40',
+                      },
+                      {
+                        internalType: 'uint40',
+                        name: 'end',
+                        type: 'uint40',
+                      },
+                    ],
+                    internalType: 'struct LockupLinear.Timestamps',
+                    name: 'timestamps',
+                    type: 'tuple',
+                  },
+                  {
+                    components: [
+                      {
+                        internalType: 'address',
+                        name: 'account',
+                        type: 'address',
+                      },
+                      {
+                        internalType: 'uint256',
+                        name: 'fee',
+                        type: 'uint256',
+                      },
+                    ],
+                    internalType: 'struct LockupLinear.Broker',
+                    name: 'broker',
+                    type: 'tuple',
+                  },
+                ],
+                internalType: 'struct DecentHats_0_1_0.SablierStreamParams[]',
+                name: 'sablierParams',
+                type: 'tuple[]',
               },
             ],
             internalType: 'struct DecentHats_0_1_0.Hat[]',

--- a/src/components/pages/Roles/forms/RoleFormPaymentStream.tsx
+++ b/src/components/pages/Roles/forms/RoleFormPaymentStream.tsx
@@ -140,7 +140,6 @@ export default function RoleFormPaymentStream({ formIndex }: { formIndex: number
         title={t('addPayment')}
         subTitle={t('addPaymentStreamSubTitle')}
         externalLink="https://docs.decentdao.org/app/user-guide/roles-and-streaming/streaming-payroll-and-vesting"
-        tooltipContent={t('addPaymentStreamTooltip')}
       />
       <AssetSelector formIndex={formIndex} />
       <SectionTitle

--- a/src/components/pages/Roles/forms/RoleFormSectionTitle.tsx
+++ b/src/components/pages/Roles/forms/RoleFormSectionTitle.tsx
@@ -45,7 +45,7 @@ export function SectionTitle({
               >
                 {title}
               </Text>
-              <Icon as={Info} />
+              {tooltipContent && <Icon as={Info} />}
             </Flex>
           </ModalTooltip>
         </Box>

--- a/src/components/pages/Roles/forms/RoleFormTabs.tsx
+++ b/src/components/pages/Roles/forms/RoleFormTabs.tsx
@@ -4,12 +4,11 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Hex } from 'viem';
-import { isFeatureEnabled, TOOLTIP_MAXW } from '../../../../constants/common';
+import { isFeatureEnabled } from '../../../../constants/common';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { useRolesStore } from '../../../../store/roles';
-import ModalTooltip from '../../../ui/modals/ModalTooltip';
 import { EditBadgeStatus, RoleFormValues, RoleHatFormValue } from '../types';
 import RoleFormInfo from './RoleFormInfo';
 import RoleFormPaymentStream from './RoleFormPaymentStream';
@@ -32,7 +31,6 @@ export default function RoleFormTabs({
   const { editedRoleData, isRoleUpdated, existingRoleHat } = useRoleFormEditedRole({ hatsTree });
   const { t } = useTranslation(['roles']);
   const { values, errors, setFieldValue, setTouched } = useFormikContext<RoleFormValues>();
-  const paymentsTooltipRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (values.hats.length && !values.roleEditing) {
@@ -67,32 +65,13 @@ export default function RoleFormTabs({
       <Tabs variant="twoTone">
         <TabList>
           <Tab>{t('roleInfo')}</Tab>
-          {isFeatureEnabled('STREAMS') && (
-            <Tab
-              isDisabled={!hatsTree}
-              cursor={!hatsTree ? 'not-allowed' : 'pointer'}
-              ref={paymentsTooltipRef}
-            >
-              {!hatsTree ? (
-                <ModalTooltip
-                  containerRef={paymentsTooltipRef}
-                  label={t('tipPaymentsDisabled')}
-                  placement="right"
-                  maxW={TOOLTIP_MAXW}
-                >
-                  {t('payments')}
-                </ModalTooltip>
-              ) : (
-                t('payments')
-              )}
-            </Tab>
-          )}
+          {isFeatureEnabled('STREAMS') && <Tab>{t('payments')}</Tab>}
         </TabList>
         <TabPanels my="1.75rem">
           <TabPanel>
             <RoleFormInfo />
           </TabPanel>
-          {isFeatureEnabled('STREAMS') && !!hatsTree && (
+          {isFeatureEnabled('STREAMS') && (
             <TabPanel>
               <RoleFormPaymentStreams />
             </TabPanel>

--- a/src/components/pages/Roles/types.tsx
+++ b/src/components/pages/Roles/types.tsx
@@ -83,6 +83,19 @@ export interface HatStruct {
   wearer: Address;
 }
 
+export interface HatStructWithPayments extends HatStruct {
+  sablierParams: {
+    sablier: Address;
+    sender: Address;
+    totalAmount: bigint;
+    asset: Address;
+    cancelable: boolean;
+    transferable: boolean;
+    timestamps: { start: number; cliff: number; end: number };
+    broker: { account: Address; fee: bigint };
+  }[];
+}
+
 export interface HatStructWithId extends HatStruct {
   id: Hex; // uint256 with padded zeros for the tree ID
 }

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -56,7 +56,6 @@
   "activePayments": "Active Payments",
   "payments": "Payments",
   "payment": "Payment",
-  "tipPaymentsDisabled": "Creating payments can be accessed after initializing roles. You need to create at least 1 role in order to create payments for it or for other roles.",
   "withdraw": "Withdraw",
   "available": "Available",
   "withdrawPendingMessage": "Withdrawing your payment, hang tight",


### PR DESCRIPTION
This PR is ready for testing!

Now users are able to create Sablier Payment Streams on new Hats which are being created when _no existing Hats Tree exists for the given DAO_, which was previously blocked.