### PR TITLE
Fix PAX price and treasury transactions

### DIFF
--- a/netlify/functions/tokenBalances.mts
+++ b/netlify/functions/tokenBalances.mts
@@ -14,16 +14,24 @@ export default async function getTokenBalancesWithPrices(request: Request) {
 
   const fetchFromMoralis = async (scope: { chain: string; address: Address }) => {
     const tokensResponse = await Moralis.EvmApi.wallets.getWalletTokenBalancesPrice(scope);
-
     const mappedTokensData = tokensResponse.result
       .filter(tokenBalance => tokenBalance.balance.value.toBigInt() > 0n)
-      .map(
-        tokenBalance =>
-          ({
-            ...camelCaseKeys(tokenBalance.toJSON()),
-            decimals: Number(tokenBalance.decimals),
-          }) as unknown as TokenBalance,
-      );
+      .map(tokenBalance => {
+        const tokenData = {
+          ...camelCaseKeys(tokenBalance.toJSON()),
+        } as unknown as TokenBalance;
+
+        if (
+          scope.chain === '1' &&
+          tokenData.tokenAddress === '0x8e870d67f660d95d5be530380d0ec0bd388289e1'
+        ) {
+          // USDP and just hardcode it to $1 because Moralis is saying (as of Sept 11 2024) that the price is $0
+          tokenData.usdPrice = 1;
+          tokenData.usdValue = Number(tokenData.balanceFormatted) * tokenData.usdPrice;
+        }
+
+        return tokenData;
+      });
 
     return mappedTokensData;
   };

--- a/src/hooks/DAO/loaders/useDecentTreasury.ts
+++ b/src/hooks/DAO/loaders/useDecentTreasury.ts
@@ -109,8 +109,8 @@ export const useDecentTreasury = () => {
     const tokenAddresses = transfers.results
       // map down to just the addresses, with a type of `string | undefined`
       .map(transfer => transfer.tokenAddress)
-      // no undefined addresses
-      .filter(address => address !== undefined)
+      // no undefined or null addresses
+      .filter(address => address !== undefined && address !== null)
       // make unique
       .filter((value, index, self) => self.indexOf(value) === index)
       // turn them into Address type


### PR DESCRIPTION
Two things in here:

1. Moralis API doesn't return good price data for the PAX token. We will just hardcode this to $1.
2. While implementing the PAX price override, I noticed that no treasury transactions were loading (on local, dev, or prod). Seems like the Safe API started returning `null` instead of `undefined` for certain datapoints, which was causing this error in our app. Fixed that.