### PR TITLE
Snapshot proposal breakdown and votes fixes 

### DIFF
--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVoteItem.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVoteItem.tsx
@@ -25,8 +25,8 @@ export default function SnapshotProposalVoteItem({ proposal, vote }: ISnapshotPr
   const isWeighted = proposal.type === 'weighted';
   const voteSymbol = useMemo(() => {
     return proposal.strategies
-      .filter((strategy, index) =>
-        !!strategy.params.symbol &&  vote.votingWeightByStrategy[index] > 0,
+      .filter(
+        (strategy, index) => !!strategy.params.symbol && vote.votingWeightByStrategy[index] > 0,
       )
       .map(strategy => strategy.params.symbol)
       .join();

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVotes.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalVotes.tsx
@@ -1,6 +1,7 @@
-import { Flex, Grid, GridItem, Text } from '@chakra-ui/react';
+import { Box, Flex, Grid, GridItem, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { ExtendedSnapshotProposal, FractalProposalState } from '../../../types';
+import StatusBox from '../../ui/badges/StatusBox';
 import ContentBox from '../../ui/containers/ContentBox';
 import { ProposalCountdown } from '../../ui/proposal/ProposalCountdown';
 import Divider from '../../ui/utils/Divider';
@@ -16,7 +17,6 @@ export default function SnapshotProposalVotes({ proposal }: ISnapshotProposalVot
   const { t } = useTranslation('proposal');
   const { totalVotesCasted } = useTotalVotes({ proposal });
   const { votes, votesBreakdown, choices, strategies, privacy, state, type } = proposal;
-  const strategySymbol = strategies[0].params.symbol;
 
   return (
     <>
@@ -41,7 +41,19 @@ export default function SnapshotProposalVotes({ proposal }: ISnapshotProposalVot
               ml={1}
               textStyle="display-lg"
             >
-              {totalVotesCasted} {strategySymbol}
+              {totalVotesCasted}
+              {strategies.map((strategy, index) =>
+                strategy.params.symbol ? (
+                  <Box
+                    mx={1}
+                    key={index}
+                    display="inline-block"
+                    as="span"
+                  >
+                    <StatusBox>{strategy.params.symbol}</StatusBox>
+                  </Box>
+                ) : null,
+              )}
             </Text>
           </Flex>
         </Flex>
@@ -58,7 +70,7 @@ export default function SnapshotProposalVotes({ proposal }: ISnapshotProposalVot
                   ? votesBreakdownChoice?.total
                   : 0;
               const choicePercentageFromTotal =
-                (votesBreakdownChoiceTotal * 100) / totalVotesCasted;
+                totalVotesCasted > 0 ? (votesBreakdownChoiceTotal * 100) / totalVotesCasted : 0;
 
               return (
                 <VotesPercentage


### PR DESCRIPTION
- Fix Snapshot proposals visualization with multiple strategies
- Providing info about voting weight per strategy for the vote
- Fix `NaN` in the breakdown when there're no votes on snapshot proposal

Note problem with the breakdown:
<img width="1135" alt="Screenshot 2024-09-13 at 17 19 16" src="https://github.com/user-attachments/assets/3f1949ab-89c0-4e0c-8968-42fad5c396a4">


Note how we weren't showing all the voting strategies that are applicable for the proposal and voting weight per strategy on the specific vote entry:
<img width="1135" alt="Screenshot 2024-09-13 at 17 18 05" src="https://github.com/user-attachments/assets/08ae0ed6-99ba-4e56-a5a5-a212f60367d2">

Updated implementation:
<img width="1728" alt="Screenshot 2024-09-13 at 17 10 18" src="https://github.com/user-attachments/assets/92a89d0a-d888-4f5d-aa72-f3b9d0cba959">
