### PR TITLE
Use `fallbackTokenData`

### DIFF
--- a/src/hooks/DAO/loaders/useDecentTreasury.ts
+++ b/src/hooks/DAO/loaders/useDecentTreasury.ts
@@ -133,16 +133,16 @@ export const useDecentTreasury = () => {
     // Instead of this block of code, check the commented out snippet
     // below this for a half-implemented alternative.
     const transfersTokenInfo = await Promise.all(
-      tokenAddressesOfTransfers.map(async addr => {
+      tokenAddressesOfTransfers.map(async address => {
         try {
-          return await safeAPI.getToken(addr);
+          return await safeAPI.getToken(address);
         } catch (e) {
           const fallbackTokenData = tokenBalances?.find(
-            tokenBalanceData => getAddress(tokenBalanceData.tokenAddress) === addr,
+            tokenBalanceData => getAddress(tokenBalanceData.tokenAddress) === address,
           );
           if (!fallbackTokenData) {
             return {
-              address: addr,
+              address,
               name: 'Unknown',
               symbol: '---',
               decimals: 18,
@@ -150,7 +150,7 @@ export const useDecentTreasury = () => {
           }
 
           return {
-            address: addr,
+            address,
             name: fallbackTokenData.name,
             symbol: fallbackTokenData.symbol,
             decimals: fallbackTokenData.decimals,

--- a/src/hooks/DAO/loaders/useDecentTreasury.ts
+++ b/src/hooks/DAO/loaders/useDecentTreasury.ts
@@ -144,17 +144,17 @@ export const useDecentTreasury = () => {
             return {
               address: addr,
               name: 'Unknown',
-              symbol: '???',
+              symbol: '---',
               decimals: 18,
             };
           }
 
           return {
             address: addr,
-            name: fallbackTokenData?.name,
-            symbol: fallbackTokenData?.symbol,
-            decimals: fallbackTokenData?.decimals,
-            logoUri: fallbackTokenData?.logo,
+            name: fallbackTokenData.name,
+            symbol: fallbackTokenData.symbol,
+            decimals: fallbackTokenData.decimals,
+            logoUri: fallbackTokenData.logo,
           };
         }
       }),


### PR DESCRIPTION
Closes #2369 (~kinda~ fr)

This PR implements a fallback for transferred token data when `safeAPI.getToken` throws.

The cause of the "no token matches given query" exception is still unclear, as the address is quite clearly on etherscan (and Moralis returns its balance if the safe has some). ~While this fallback works for safes that have _some_ balance of the problem token, it doesn't for safes that have a 0-balance even if they at one time had some.~ The fallback retrieves token info from the blockchain directly.

Also the `setTimeout` retry in case of rate limited error was removed because I'm not sure about the end result of this PR yet and didn't want to commit to a lengthy refactor at this point. If needed, this functionality can be restored in some form during review.