### PR TITLE
Attempt switching chain automatically when on wrong network

### DIFF
--- a/src/hooks/DAO/useDAOController.ts
+++ b/src/hooks/DAO/useDAOController.ts
@@ -56,5 +56,5 @@ export default function useDAOController() {
   useKeyValuePairs();
   useHatsTree();
 
-  return { invalidQuery, wrongNetwork, errorLoading };
+  return { invalidQuery, wrongNetwork, errorLoading, urlAddressPrefix: addressPrefix };
 }

--- a/src/pages/DAOController.tsx
+++ b/src/pages/DAOController.tsx
@@ -48,6 +48,7 @@ export default function DAOController() {
     if (urlAddressPrefix && wrongNetwork) {
       try {
         switchChain({ chainId: getChainIdFromPrefix(urlAddressPrefix) });
+        window.location.reload();
       } catch (e) {
         logError(e);
       }

--- a/src/pages/DAOController.tsx
+++ b/src/pages/DAOController.tsx
@@ -2,9 +2,12 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { useSwitchChain } from 'wagmi';
+import { logError } from '../helpers/errorLogging';
 import useDAOController from '../hooks/DAO/useDAOController';
 import { useUpdateSafeData } from '../hooks/utils/useUpdateSafeData';
 import { useFractal } from '../providers/App/AppProvider';
+import { getChainIdFromPrefix } from '../utils/url';
 import LoadingProblem from './LoadingProblem';
 
 const useTemporaryProposals = () => {
@@ -32,13 +35,24 @@ const useTemporaryProposals = () => {
 };
 
 export default function DAOController() {
-  const { errorLoading, wrongNetwork, invalidQuery } = useDAOController();
+  const { switchChain } = useSwitchChain();
+  const { errorLoading, wrongNetwork, invalidQuery, urlAddressPrefix } = useDAOController();
   useUpdateSafeData();
   const {
     node: { daoName },
   } = useFractal();
 
   useTemporaryProposals();
+
+  useEffect(() => {
+    if (urlAddressPrefix && wrongNetwork) {
+      try {
+        switchChain({ chainId: getChainIdFromPrefix(urlAddressPrefix) });
+      } catch (e) {
+        logError(e);
+      }
+    }
+  }, [wrongNetwork, switchChain, urlAddressPrefix]);
 
   useEffect(() => {
     if (daoName) {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -67,6 +67,7 @@ export const router = (addressPrefix: string) =>
               // @ts-ignore:next-line
               loader: ({ params: { daoAddress } }) =>
                 redirect(DAO_ROUTES.modifyGovernance.relative(addressPrefix, daoAddress)),
+              // @todo - this redirect doesn't work anymore for some reason
             },
             {
               path: DAO_ROUTES.hierarchy.path,
@@ -105,6 +106,7 @@ export const router = (addressPrefix: string) =>
               // @ts-ignore:next-line
               loader: ({ params: { daoAddress } }) =>
                 redirect(DAO_ROUTES.newSubDao.relative(addressPrefix, daoAddress)),
+              // @todo - this redirect doesn't work anymore for some reason
             },
             {
               path: 'proposal-templates',
@@ -122,6 +124,7 @@ export const router = (addressPrefix: string) =>
                   // @ts-ignore:next-line
                   loader: ({ params: { daoAddress } }) =>
                     redirect(DAO_ROUTES.proposalTemplateNew.relative(addressPrefix, daoAddress)),
+                  // @todo - this redirect doesn't work anymore for some reason
                 },
               ],
             },
@@ -145,6 +148,7 @@ export const router = (addressPrefix: string) =>
                   // @ts-ignore:next-line
                   loader: ({ params: { daoAddress } }) =>
                     redirect(DAO_ROUTES.proposalNew.relative(addressPrefix, daoAddress)),
+                  // @todo - this redirect doesn't work anymore for some reason
                 },
                 {
                   path: 'new/sablier/*',
@@ -158,6 +162,7 @@ export const router = (addressPrefix: string) =>
                       DAO_ROUTES.proposalNew
                         .relative(addressPrefix, daoAddress)
                         .replace('new', 'new/sablier'),
+                      // @todo - this redirect doesn't work anymore for some reason
                     ),
                 },
               ],
@@ -179,6 +184,7 @@ export const router = (addressPrefix: string) =>
           // @ts-ignore:next-line
           loader: ({ params: { daoAddress } }) =>
             redirect(DAO_ROUTES.dao.relative(addressPrefix, daoAddress)),
+          // @todo - this redirect doesn't work anymore for some reason
         },
         {
           path: '*', // 404


### PR DESCRIPTION
## The problem

When user navigates directly to the DAO, which is not on mainnet (base - for instance) - app default to mainnet anyway and displays "wrong network" error.

## The solution

This PR implements attempt to automatically switch network. Far from being perfect - wrong network screen will be displayed as long as network is not switched. Automatic attempt might fail due to intermittent RPC errors. If wallet is not connected - it pretty much always works. If wallet is connected - some issues might occur depending on specific wallet used (if wallet does not support adding chain alongside with switching at single request).

This is kinda hot-fix and we'll need longer term solution - temporary patch to improve UX for MCON.

## Testing 
1. Try visiting https://app.decentdao.org/home?dao=base:0x0BcC8861d36B610f19492C8E512Ebb9E99BB7654 - you will just see error screen about wrong network, if you weren't connected to `Base`.
2. Try visiting same DAO on the deployed preview https://deploy-preview-2380.app.decentdao.org/home?dao=base:0x0BcC8861d36B610f19492C8E512Ebb9E99BB7654. 
3. If you weren't connected - app should just switch automatically, error might flash for a moment but then DAO dashboard should appear after page reload. 
4. If you were connected - it should prompt you to switch chain in your wallet and then DAO will load