### PR TITLE
Modifying governance for subDAO

### DIFF
--- a/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
@@ -9,10 +9,10 @@ import {
   Switch,
 } from '@chakra-ui/react';
 import { WarningCircle } from '@phosphor-icons/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFractal } from '../../../providers/App/AppProvider';
-import { ICreationStepProps, VotingStrategyType } from '../../../types';
+import { FractalModuleType, ICreationStepProps, VotingStrategyType } from '../../../types';
 import ContentBoxTitle from '../../ui/containers/ContentBox/ContentBoxTitle';
 import { BigIntInput } from '../../ui/forms/BigIntInput';
 import { CustomNonceInput } from '../../ui/forms/CustomNonceInput';
@@ -28,8 +28,14 @@ export function AzoriusGovernance(props: ICreationStepProps) {
     node: {
       safe,
       nodeHierarchy: { parentAddress },
+      fractalModules,
     },
   } = useFractal();
+
+  const fractalModule = useMemo(
+    () => fractalModules.find(_module => _module.moduleType === FractalModuleType.FRACTAL),
+    [fractalModules],
+  );
 
   const [showCustomNonce, setShowCustomNonce] = useState<boolean>();
   const { t } = useTranslation(['daoCreate', 'common']);
@@ -192,6 +198,7 @@ export function AzoriusGovernance(props: ICreationStepProps) {
             width="100%"
             justifyContent="space-between"
             display="flex"
+            isDisabled={!!fractalModule}
           >
             <Text>{t('attachFractalModuleLabel')}</Text>
             <Switch
@@ -200,14 +207,17 @@ export function AzoriusGovernance(props: ICreationStepProps) {
               onChange={() =>
                 setFieldValue('freeze.attachFractalModule', !values.freeze.attachFractalModule)
               }
-              isChecked={values.freeze.attachFractalModule}
+              isChecked={!!fractalModule || values.freeze.attachFractalModule}
+              isDisabled={!!fractalModule}
             />
           </FormControl>
           <Text
             color="neutral-7"
             width="50%"
           >
-            {t('attachFractalModuleDescription')}
+            {t(
+              fractalModule ? 'fractalModuleAttachedDescription' : 'attachFractalModuleDescription',
+            )}
           </Text>
         </Box>
       )}

--- a/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusGovernance.tsx
@@ -1,4 +1,13 @@
-import { Alert, Box, Flex, InputGroup, InputRightElement, Text } from '@chakra-ui/react';
+import {
+  Alert,
+  Box,
+  Flex,
+  InputGroup,
+  InputRightElement,
+  Text,
+  FormControl,
+  Switch,
+} from '@chakra-ui/react';
 import { WarningCircle } from '@phosphor-icons/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,7 +25,10 @@ import { DAOCreateMode } from './EstablishEssentials';
 export function AzoriusGovernance(props: ICreationStepProps) {
   const { values, setFieldValue, isSubmitting, transactionPending, isSubDAO, mode } = props;
   const {
-    node: { safe },
+    node: {
+      safe,
+      nodeHierarchy: { parentAddress },
+    },
   } = useFractal();
 
   const [showCustomNonce, setShowCustomNonce] = useState<boolean>();
@@ -167,6 +179,38 @@ export function AzoriusGovernance(props: ICreationStepProps) {
           </Alert>
         </Flex>
       </StepWrapper>
+      {!!parentAddress && (
+        <Box
+          padding="1.5rem"
+          bg="neutral-2"
+          borderRadius="0.25rem"
+          mt="1.5rem"
+          mb={showCustomNonce ? '1.5rem' : 0}
+        >
+          <FormControl
+            gap="0.5rem"
+            width="100%"
+            justifyContent="space-between"
+            display="flex"
+          >
+            <Text>{t('attachFractalModuleLabel')}</Text>
+            <Switch
+              size="md"
+              variant="secondary"
+              onChange={() =>
+                setFieldValue('freeze.attachFractalModule', !values.freeze.attachFractalModule)
+              }
+              isChecked={values.freeze.attachFractalModule}
+            />
+          </FormControl>
+          <Text
+            color="neutral-7"
+            width="50%"
+          >
+            {t('attachFractalModuleDescription')}
+          </Text>
+        </Box>
+      )}
       {showCustomNonce && (
         <Box
           padding="1.5rem"

--- a/src/hooks/DAO/useDeployAzorius.ts
+++ b/src/hooks/DAO/useDeployAzorius.ts
@@ -1,20 +1,35 @@
+import { abis } from '@fractal-framework/fractal-contracts';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { encodeFunctionData, isHex } from 'viem';
+import { toast } from 'sonner';
+import { Address, encodeFunctionData, isHex, getContract } from 'viem';
 import { usePublicClient } from 'wagmi';
 import GnosisSafeL2Abi from '../../assets/abi/GnosisSafeL2';
 import MultiSendCallOnlyAbi from '../../assets/abi/MultiSendCallOnly';
+import { SENTINEL_ADDRESS } from '../../constants/common';
 import { DAO_ROUTES } from '../../constants/routes';
 import { TxBuilderFactory } from '../../models/TxBuilderFactory';
 import { useFractal } from '../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
-import { AzoriusERC20DAO, AzoriusERC721DAO, ProposalExecuteData } from '../../types';
+import {
+  AzoriusERC20DAO,
+  AzoriusERC721DAO,
+  FractalModuleType,
+  FractalNode,
+  ProposalExecuteData,
+  SubDAO,
+  VotingStrategyType,
+  WithError,
+} from '../../types';
 import { useCanUserCreateProposal } from '../utils/useCanUserSubmitProposal';
+import { useMasterCopy } from '../utils/useMasterCopy';
+import { useLoadDAONode } from './loaders/useLoadDAONode';
 import useSubmitProposal from './proposal/useSubmitProposal';
 
 const useDeployAzorius = () => {
   const navigate = useNavigate();
+  const { getZodiacModuleProxyMasterCopyData } = useMasterCopy();
   const {
     contracts: {
       compatibilityFallbackHandler,
@@ -40,17 +55,22 @@ const useDeployAzorius = () => {
     addressPrefix,
   } = useNetworkConfig();
   const {
-    node: { daoAddress, safe },
+    node: {
+      daoAddress,
+      safe,
+      nodeHierarchy: { parentAddress },
+    },
   } = useFractal();
 
   const { t } = useTranslation(['transaction', 'proposalMetadata']);
   const { submitProposal } = useSubmitProposal();
   const { canUserCreateProposal } = useCanUserCreateProposal();
   const publicClient = usePublicClient();
+  const { loadDao } = useLoadDAONode();
 
   const deployAzorius = useCallback(
     async (
-      daoData: AzoriusERC20DAO | AzoriusERC721DAO,
+      daoData: AzoriusERC20DAO | AzoriusERC721DAO | SubDAO,
       customNonce: number | undefined,
       opts: {
         shouldSetName: boolean;
@@ -60,6 +80,58 @@ const useDeployAzorius = () => {
       const { shouldSetName, shouldSetSnapshot } = opts;
       if (!daoAddress || !canUserCreateProposal || !safe || !publicClient) {
         return;
+      }
+
+      let parentTokenAddress: Address | undefined;
+      let parentStrategyAddress: Address | undefined;
+      let parentStrategyType: VotingStrategyType | undefined;
+      let attachFractalModule = false;
+      let parentNode: FractalNode | undefined;
+
+      if (parentAddress) {
+        const loadedParentNode = await loadDao(parentAddress);
+        const loadingParentNodeError = (loadedParentNode as WithError).error;
+        if (loadingParentNodeError) {
+          toast.error(t(loadingParentNodeError));
+          return;
+        } else {
+          parentNode = loadedParentNode as FractalNode;
+          const parentAzoriusModule = parentNode.fractalModules.find(
+            fractalModule => fractalModule.moduleType === FractalModuleType.AZORIUS,
+          );
+          if (parentAzoriusModule) {
+            const azoriusContract = getContract({
+              abi: abis.Azorius,
+              address: parentAzoriusModule.moduleAddress,
+              client: publicClient,
+            });
+
+            // @dev assumes the first strategy is the voting contract
+            const strategies = await azoriusContract.read.getStrategies([SENTINEL_ADDRESS, 0n]);
+            parentStrategyAddress = strategies[1];
+
+            const masterCopyData = await getZodiacModuleProxyMasterCopyData(parentStrategyAddress);
+            if (masterCopyData.isLinearVotingErc20) {
+              const votingStrategyContract = getContract({
+                abi: abis.LinearERC20Voting,
+                client: publicClient,
+                address: parentStrategyAddress,
+              });
+              parentTokenAddress = await votingStrategyContract.read.governanceToken();
+              parentStrategyType = VotingStrategyType.LINEAR_ERC20;
+            } else if (masterCopyData.isLinearVotingErc721) {
+              parentStrategyType = VotingStrategyType.LINEAR_ERC721;
+            }
+          }
+
+          const parentFractalModule = parentNode.fractalModules.find(
+            fractalModule => fractalModule.moduleType === FractalModuleType.FRACTAL,
+          );
+          if (!parentFractalModule) {
+            // If FractalModule is not attached - we'll need to attach it only if it was specified through user input
+            attachFractalModule = (daoData as SubDAO).attachFractalModule;
+          }
+        }
       }
 
       const txBuilderFactory = new TxBuilderFactory(
@@ -85,15 +157,17 @@ const useDeployAzorius = () => {
         linearVotingErc20MasterCopy,
         linearVotingErc721MasterCopy,
         moduleAzoriusMasterCopy,
-        undefined,
-        undefined,
+        parentAddress || undefined,
+        parentTokenAddress,
       );
 
       txBuilderFactory.setSafeContract(daoAddress);
 
-      // @todo - useDeployAzorius wasn't ever/enough tested for subDAO creation thus deploying Azorius for subDAO won't work as expected
-      // Need to test and adjust implementation - pass parent address, parent voting strategy and whether we should attach FractalModule
-      const daoTxBuilder = txBuilderFactory.createDaoTxBuilder({});
+      const daoTxBuilder = txBuilderFactory.createDaoTxBuilder({
+        attachFractalModule,
+        parentStrategyAddress,
+        parentStrategyType,
+      });
       const safeTx = await daoTxBuilder.buildAzoriusTx({
         shouldSetName,
         shouldSetSnapshot,
@@ -115,6 +189,10 @@ const useDeployAzorius = () => {
         functionName: 'multiSend',
         args: [safeTx],
       });
+
+      // @todo - If Safe has subDAOs - we'll need to also swap Guard contracts there.
+      // However, it will be possible only if FractalModule is attached
+      // Otherwise - we need to provide some UI / UX that will inform user about the impact of modifying governance without ability to swap Guard contracts.
 
       const proposalData: ProposalExecuteData = {
         targets: [daoAddress, multiSendCallOnly],
@@ -164,6 +242,9 @@ const useDeployAzorius = () => {
       t,
       navigate,
       addressPrefix,
+      loadDao,
+      getZodiacModuleProxyMasterCopyData,
+      parentAddress,
     ],
   );
 

--- a/src/hooks/utils/useVotingStrategyAddress.ts
+++ b/src/hooks/utils/useVotingStrategyAddress.ts
@@ -30,14 +30,6 @@ const useVotingStrategyAddress = () => {
         azoriusModule = getAzoriusModuleFromModules(node.fractalModules);
       }
 
-      // if (!azoriusModule) {
-      //   throw new Error('Azorius module not found');
-      // }
-
-      // if (!publicClient) {
-      //   throw new Error('Public client undefined');
-      // }
-
       if (!azoriusModule || !publicClient) {
         return;
       }

--- a/src/i18n/locales/en/daoCreate.json
+++ b/src/i18n/locales/en/daoCreate.json
@@ -105,5 +105,6 @@
   "tooltipNftVoting": "NFT Voting allows a group of ERC-721 (NFT) holders to propose and vote on transactions. Multiple NFT addresses can be used. <1>Learn more</1>",
   "errorUnsupportedCreateOption": "Previously selected Governance option is not supported on this network.",
   "attachFractalModuleLabel": "Enable Clawback",
-  "attachFractalModuleDescription": "This setting controls whether Parent Safe will be able to execute arbitrary transactions on Child Safe bypassing voting process on Child Safe."
+  "attachFractalModuleDescription": "This setting controls whether Parent Safe will be able to execute arbitrary transactions on Child Safe bypassing voting process on Child Safe.",
+  "fractalModuleAttachedDescription": "This setting can not be modified as Fractal Module already attached to the Safe."
 }

--- a/src/pages/daos/[daoAddress]/edit/governance/index.tsx
+++ b/src/pages/daos/[daoAddress]/edit/governance/index.tsx
@@ -18,6 +18,7 @@ import {
   AzoriusERC721DAO,
   DAOTrigger,
   GovernanceType,
+  SubDAO,
 } from '../../../../../types';
 
 export default function ModifyGovernancePage() {
@@ -52,7 +53,7 @@ export default function ModifyGovernancePage() {
       daoSnapshotENS !== daoData.snapshotENS &&
       (daoSnapshotENS !== null || daoData.snapshotENS !== '');
 
-    deployAzorius(daoData as AzoriusERC20DAO | AzoriusERC721DAO, customNonce, {
+    deployAzorius(daoData as AzoriusERC20DAO | AzoriusERC721DAO | SubDAO, customNonce, {
       shouldSetName,
       shouldSetSnapshot,
     });

--- a/src/types/createDAO.ts
+++ b/src/types/createDAO.ts
@@ -138,7 +138,7 @@ export interface AzoriusERC721DAO<T = bigint>
 export interface SafeMultisigDAO extends DAOEssentials, SafeConfiguration {}
 
 export type DAOTrigger = (
-  daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO,
+  daoData: SafeMultisigDAO | AzoriusERC20DAO | AzoriusERC721DAO | SubDAO,
   customNonce?: number,
 ) => void;
 


### PR DESCRIPTION
## Changes

This PR adjusts the way of modifying governance for subDAOs.
There's one issue that I outlined in the code comment - when DAO has subDAOs - that means we also need to swap guard contracts. However, that is possible only when there's `FractalModule` attached. Otherwise - whole Freezing wouldn't work anymore.

Closes #2387 

## Testing

1. Create parent DAO (ideally - Azorius)
2. Create 2 Multisig child DAOs (for testing with ERC-20 and ERC-721) without attaching `FractalModule` to them
3. Modify governance on 1st child DAO to ERC-20 AND attach Fractal Module during this process 
4. Make sure `FractalModule` get's attached and guard has proper `parentVotingStrategy` and `parentGovernanceToken`
5. Verify Freeze works as expected
6. Modify governance on 2nd child DAO to ERC-721 AND DO NOT ATTACH `FractalModule`
7. Make sure `FractalModule` is not attached, but freezing still works as expected