### PR TITLE
Fix unsaved changes stuck state

### DIFF
--- a/src/components/pages/Roles/forms/RoleFormTabs.tsx
+++ b/src/components/pages/Roles/forms/RoleFormTabs.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-u
 import { useFormikContext } from 'formik';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Blocker, useNavigate } from 'react-router-dom';
 import { Hex } from 'viem';
 import { isFeatureEnabled } from '../../../../constants/common';
 import { DAO_ROUTES } from '../../../../constants/routes';
@@ -18,9 +18,11 @@ import { useRoleFormEditedRole } from './useRoleFormEditedRole';
 export default function RoleFormTabs({
   hatId,
   pushRole,
+  blocker,
 }: {
   hatId: Hex;
   pushRole: (roleHatFormValue: RoleHatFormValue) => void;
+  blocker: Blocker;
 }) {
   const { hatsTree } = useRolesStore();
   const {
@@ -99,8 +101,11 @@ export default function RoleFormTabs({
               );
             }
             setFieldValue('roleEditing', undefined);
+            setTouched({});
+            if (blocker.reset) {
+              blocker.reset();
+            }
             setTimeout(() => {
-              setTouched({});
               navigate(DAO_ROUTES.rolesEdit.relative(addressPrefix, daoAddress));
             }, 50);
           }}

--- a/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
@@ -200,7 +200,7 @@ export default function RoleEditDetails() {
                 onKeepEditing={() => {
                   setFieldValue('roleEditing', backupRoleEditing.current);
                   setTouched({ roleEditing: backupTouched.current });
-                  setTimeout(() => blocker.reset(), 50);
+                  blocker.reset();
                 }}
               />
             </ModalBase>

--- a/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
@@ -200,7 +200,7 @@ export default function RoleEditDetails() {
                 onKeepEditing={() => {
                   setFieldValue('roleEditing', backupRoleEditing.current);
                   setTouched({ roleEditing: backupTouched.current });
-                  blocker.reset();
+                  setTimeout(() => blocker.reset(), 50);
                 }}
               />
             </ModalBase>
@@ -251,6 +251,7 @@ export default function RoleEditDetails() {
                     <RoleFormTabs
                       hatId={hatEditingId}
                       pushRole={push}
+                      blocker={blocker}
                     />
                   </Box>
                 </Box>
@@ -300,6 +301,7 @@ export default function RoleEditDetails() {
                     <RoleFormTabs
                       hatId={hatEditingId}
                       pushRole={push}
+                      blocker={blocker}
                     />
                   </DrawerBody>
                 </DrawerContent>

--- a/src/pages/daos/[daoAddress]/roles/edit/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/index.tsx
@@ -219,6 +219,9 @@ function RolesEdit() {
                     generateRoleProposalTitle({ formValues: values }),
                   );
                 }
+                if (blocker.reset) {
+                  blocker.reset();
+                }
                 navigate(
                   DAO_ROUTES.rolesEditCreateProposalSummary.relative(addressPrefix, daoAddress),
                 );


### PR DESCRIPTION
## Changes

This PR resets blocker state when saving role form.

## Addressed Issues

- Closes #2395 

## Testing

1. Go to editing some role. Change any field.
2. Click outside of drawer
3. You should see "Unsaved changes" modal - click "Keep Editing"
4. Now hit Save button
5. Verify that changes were saved and you navigated back to roles list.