### PR TITLE
Fix payment stream usd value

### DIFF
--- a/src/components/pages/Roles/RolesDetailsDrawer.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawer.tsx
@@ -13,7 +13,7 @@ import {
 import { List, PencilLine, User, X } from '@phosphor-icons/react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Hex, getAddress } from 'viem';
+import { Hex } from 'viem';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import { useGetDAOName } from '../../../hooks/DAO/useGetDAOName';
 import useAvatar from '../../../hooks/utils/useAvatar';
@@ -66,7 +66,7 @@ export default function RolesDetailsDrawer({
   const { chain } = useNetworkConfig();
   const { t } = useTranslation(['roles']);
   const { daoName: accountDisplayName } = useGetDAOName({
-    address: getAddress(roleHat.wearer),
+    address: roleHat.wearer,
     chainId: chain.id,
   });
   const avatarURL = useAvatar(roleHat.wearer);
@@ -158,7 +158,7 @@ export default function RolesDetailsDrawer({
               >
                 <Avatar
                   size="icon"
-                  address={getAddress(roleHat.wearer)}
+                  address={roleHat.wearer}
                   url={avatarURL}
                 />
                 <Text
@@ -195,7 +195,7 @@ export default function RolesDetailsDrawer({
                   key={index}
                   payment={payment}
                   roleHatSmartAddress={roleHat.smartAddress}
-                  roleHatWearerAddress={getAddress(roleHat.wearer)}
+                  roleHatWearerAddress={roleHat.wearer}
                   showWithdraw
                 />
               ))}

--- a/src/components/pages/Roles/RolesDetailsDrawerMobile.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawerMobile.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Icon, IconButton, Text } from '@chakra-ui/react';
 import { PencilLine } from '@phosphor-icons/react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getAddress, Hex } from 'viem';
+import { Hex } from 'viem';
 import { useFractal } from '../../../providers/App/AppProvider';
 import {
   paymentSorterByActiveStatus,
@@ -121,7 +121,7 @@ export default function RolesDetailsDrawerMobile({
                 key={index}
                 payment={payment}
                 roleHatSmartAddress={roleHat.smartAddress}
-                roleHatWearerAddress={getAddress(roleHat.wearer)}
+                roleHatWearerAddress={roleHat.wearer}
                 showWithdraw
               />
             ))}

--- a/src/components/ui/modals/PaymentWithdrawModal.tsx
+++ b/src/components/ui/modals/PaymentWithdrawModal.tsx
@@ -3,7 +3,7 @@ import { Download } from '@phosphor-icons/react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { Address, encodeFunctionData, getAddress, getContract } from 'viem';
+import { Address, encodeFunctionData, getContract } from 'viem';
 import { usePublicClient, useWalletClient } from 'wagmi';
 import HatsAccount1ofNAbi from '../../../assets/abi/HatsAccount1ofN';
 import { SablierV2LockupLinearAbi } from '../../../assets/abi/SablierV2LockupLinear';
@@ -68,7 +68,7 @@ export default function PaymentWithdrawModal({
         let hatsAccountCalldata = encodeFunctionData({
           abi: SablierV2LockupLinearAbi,
           functionName: 'withdrawMax',
-          args: [bigIntStreamId, getAddress(withdrawInformation.roleHatWearerAddress)],
+          args: [bigIntStreamId, withdrawInformation.roleHatWearerAddress],
         });
         withdrawToast = toast.loading(t('withdrawPendingMessage'));
         const txHash = await hatsAccountContract.write.execute([

--- a/src/hooks/DAO/loaders/useHatsTree.ts
+++ b/src/hooks/DAO/loaders/useHatsTree.ts
@@ -196,10 +196,7 @@ const useHatsTree = () => {
                   streamId: lockupLinearStream.id,
                   contractAddress: lockupLinearStream.contract.address,
                   asset: {
-                    address: getAddress(
-                      lockupLinearStream.asset.address,
-                      lockupLinearStream.asset.chainId,
-                    ),
+                    address: getAddress(lockupLinearStream.asset.address),
                     name: lockupLinearStream.asset.name,
                     symbol: lockupLinearStream.asset.symbol,
                     decimals: lockupLinearStream.asset.decimals,

--- a/src/hooks/DAO/useDAOController.ts
+++ b/src/hooks/DAO/useDAOController.ts
@@ -1,5 +1,5 @@
 import { useSearchParams } from 'react-router-dom';
-import { isAddress, getAddress } from 'viem';
+import { isAddress } from 'viem';
 import { useFractal } from '../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { useAzoriusListeners } from './loaders/governance/useAzoriusListeners';
@@ -29,7 +29,7 @@ export default function useDAOController() {
     !validDaoQueryString.test(addressWithPrefix) ||
     !isAddress(daoAddressStr);
 
-  const daoAddress = !invalidQuery ? getAddress(daoAddressStr) : undefined;
+  const daoAddress = !invalidQuery ? daoAddressStr : undefined;
 
   const { addressPrefix: connectedAddressPrefix } = useNetworkConfig();
   const wrongNetwork = addressPrefix !== connectedAddressPrefix;

--- a/src/hooks/DAO/useKeyValuePairs.ts
+++ b/src/hooks/DAO/useKeyValuePairs.ts
@@ -1,7 +1,7 @@
 import { abis } from '@fractal-framework/fractal-contracts';
 import { hatIdToTreeId } from '@hatsprotocol/sdk-v1-core';
 import { useEffect } from 'react';
-import { GetContractEventsReturnType, getAddress, getContract } from 'viem';
+import { GetContractEventsReturnType, getContract } from 'viem';
 import { usePublicClient } from 'wagmi';
 import { logError } from '../../helpers/errorLogging';
 import { useFractal } from '../../providers/App/AppProvider';
@@ -70,7 +70,7 @@ const useKeyValuePairs = () => {
 
     const keyValuePairsContract = getContract({
       abi: abis.KeyValuePairs,
-      address: getAddress(keyValuePairs),
+      address: keyValuePairs,
       client: publicClient,
     });
     keyValuePairsContract.getEvents


### PR DESCRIPTION
Fixes #2408 

viem's `getAddress` code:
![screenshot_2024-10-11_at_2 31 46___pm](https://github.com/user-attachments/assets/4713b49e-b74c-4447-9b37-b6062defd193)

our code in the place where we're pulling in payment stream data:
![screenshot_2024-10-11_at_2 32 31___pm](https://github.com/user-attachments/assets/6415839a-bfc1-44a4-9225-5f340b9e9abf)

results in a checksummed address that doesn't follow "normal" checksumming patterns:
<img width="325" alt="Screenshot 2024-10-11 at 2 33 31 PM" src="https://github.com/user-attachments/assets/556c1748-58fe-403e-b376-a3fd4beae21a">