### PR TITLE
2411 fix wearer ens continued

### DIFF
--- a/src/components/DaoCreator/formComponents/AzoriusNFTDetail.tsx
+++ b/src/components/DaoCreator/formComponents/AzoriusNFTDetail.tsx
@@ -27,7 +27,7 @@ export default function AzoriusNFTDetail({
   const publicClient = usePublicClient();
   const { data: walletClient } = useWalletClient();
 
-  const { displayName } = useDisplayName(tokenDetails?.address, true);
+  const { displayName } = useDisplayName(tokenDetails?.address);
 
   useEffect(() => {
     const loadNFTDetails = async () => {

--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -1,13 +1,10 @@
 import { Box, Flex, Icon, Image, Text } from '@chakra-ui/react';
 import { CaretCircleRight, CaretRight } from '@phosphor-icons/react';
 import { formatDuration, intervalToDuration } from 'date-fns';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address, getAddress, zeroAddress } from 'viem';
 import useAvatar from '../../../hooks/utils/useAvatar';
-import { useGetSafeName } from '../../../hooks/utils/useGetSafeName';
-import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
-import { getChainIdFromPrefix } from '../../../utils/url';
+import useDisplayName from '../../../hooks/utils/useDisplayName';
 import { Card } from '../../ui/cards/Card';
 import EtherscanLink from '../../ui/links/EtherscanLink';
 import Avatar from '../../ui/page/Header/Avatar';
@@ -23,23 +20,7 @@ export function AvatarAndRoleName({
   name?: string;
   paymentsCount?: number;
 }) {
-  const { addressPrefix } = useNetworkConfig();
-
-  const { getSafeName } = useGetSafeName(getChainIdFromPrefix(addressPrefix));
-  const [accountName, setAccountName] = useState<string>();
-
-  useEffect(() => {
-    if (!wearerAddress) {
-      setAccountName(undefined);
-      return;
-    }
-
-    const fetchSafeName = async () => {
-      setAccountName(await getSafeName(wearerAddress));
-    };
-
-    fetchSafeName();
-  }, [wearerAddress, getSafeName]);
+  const { displayName } = useDisplayName(wearerAddress);
 
   const avatarURL = useAvatar(wearerAddress || zeroAddress);
   const { t } = useTranslation(['roles']);
@@ -73,7 +54,7 @@ export function AvatarAndRoleName({
           textStyle="button-small"
           color="neutral-7"
         >
-          {accountName ?? t('unassigned')}
+          {displayName ?? t('unassigned')}
         </Text>
         {paymentsCount !== undefined && (
           <Flex

--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address, getAddress, zeroAddress } from 'viem';
 import useAvatar from '../../../hooks/utils/useAvatar';
-import { useGetAccountName } from '../../../hooks/utils/useGetAccountName';
+import { useGetSafeName } from '../../../hooks/utils/useGetSafeName';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix } from '../../../utils/url';
 import { Card } from '../../ui/cards/Card';
@@ -25,7 +25,7 @@ export function AvatarAndRoleName({
 }) {
   const { addressPrefix } = useNetworkConfig();
 
-  const { getAccountName } = useGetAccountName(getChainIdFromPrefix(addressPrefix));
+  const { getSafeName } = useGetSafeName(getChainIdFromPrefix(addressPrefix));
   const [accountName, setAccountName] = useState<string>();
 
   useEffect(() => {
@@ -34,12 +34,12 @@ export function AvatarAndRoleName({
       return;
     }
 
-    const fetchAccountName = async () => {
-      setAccountName(await getAccountName(wearerAddress));
+    const fetchSafeName = async () => {
+      setAccountName(await getSafeName(wearerAddress));
     };
 
-    fetchAccountName();
-  }, [wearerAddress, getAccountName]);
+    fetchSafeName();
+  }, [wearerAddress, getSafeName]);
 
   const avatarURL = useAvatar(wearerAddress || zeroAddress);
   const { t } = useTranslation(['roles']);

--- a/src/components/pages/Roles/RoleCard.tsx
+++ b/src/components/pages/Roles/RoleCard.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address, getAddress, zeroAddress } from 'viem';
 import useAvatar from '../../../hooks/utils/useAvatar';
-import { useGetAccountNameDeferred } from '../../../hooks/utils/useGetAccountName';
+import { useGetAccountName } from '../../../hooks/utils/useGetAccountName';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix } from '../../../utils/url';
 import { Card } from '../../ui/cards/Card';
@@ -25,7 +25,7 @@ export function AvatarAndRoleName({
 }) {
   const { addressPrefix } = useNetworkConfig();
 
-  const { getAccountName } = useGetAccountNameDeferred(getChainIdFromPrefix(addressPrefix));
+  const { getAccountName } = useGetAccountName(getChainIdFromPrefix(addressPrefix));
   const [accountName, setAccountName] = useState<string>();
 
   useEffect(() => {

--- a/src/components/pages/Roles/RolesDetailsDrawer.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawer.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import useAddress from '../../../hooks/utils/useAddress';
 import useAvatar from '../../../hooks/utils/useAvatar';
-import { useGetAccountNameDeferred } from '../../../hooks/utils/useGetAccountName';
+import { useGetAccountName } from '../../../hooks/utils/useGetAccountName';
 import { useFractal } from '../../../providers/App/AppProvider';
 import {
   paymentSorterByActiveStatus,
@@ -61,7 +61,7 @@ export default function RolesDetailsDrawer({
   const { address: roleHatWearerAddress, isLoading: loadingRoleHatWearerAddress } =
     useAddress(roleHatWearer);
 
-  const { getAccountName } = useGetAccountNameDeferred();
+  const { getAccountName } = useGetAccountName();
   const [accountDisplayName, setAccountDisplayName] = useState(roleHatWearer);
   useEffect(() => {
     if (!!roleHatWearerAddress) {

--- a/src/components/pages/Roles/RolesDetailsDrawer.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawer.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import useAddress from '../../../hooks/utils/useAddress';
 import useAvatar from '../../../hooks/utils/useAvatar';
-import { useGetAccountName } from '../../../hooks/utils/useGetAccountName';
+import { useGetSafeName } from '../../../hooks/utils/useGetSafeName';
 import { useFractal } from '../../../providers/App/AppProvider';
 import {
   paymentSorterByActiveStatus,
@@ -61,13 +61,13 @@ export default function RolesDetailsDrawer({
   const { address: roleHatWearerAddress, isLoading: loadingRoleHatWearerAddress } =
     useAddress(roleHatWearer);
 
-  const { getAccountName } = useGetAccountName();
+  const { getSafeName } = useGetSafeName();
   const [accountDisplayName, setAccountDisplayName] = useState(roleHatWearer);
   useEffect(() => {
     if (!!roleHatWearerAddress) {
-      getAccountName(roleHatWearerAddress).then(setAccountDisplayName);
+      getSafeName(roleHatWearerAddress).then(setAccountDisplayName);
     }
-  }, [getAccountName, roleHatWearerAddress]);
+  }, [getSafeName, roleHatWearerAddress]);
 
   const { t } = useTranslation(['roles']);
   const avatarURL = useAvatar(roleHatWearer);

--- a/src/components/pages/Roles/RolesDetailsDrawer.tsx
+++ b/src/components/pages/Roles/RolesDetailsDrawer.tsx
@@ -11,12 +11,12 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { List, PencilLine, User, X } from '@phosphor-icons/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BACKGROUND_SEMI_TRANSPARENT } from '../../../constants/common';
 import useAddress from '../../../hooks/utils/useAddress';
 import useAvatar from '../../../hooks/utils/useAvatar';
-import { useGetSafeName } from '../../../hooks/utils/useGetSafeName';
+import useDisplayName from '../../../hooks/utils/useDisplayName';
 import { useFractal } from '../../../providers/App/AppProvider';
 import {
   paymentSorterByActiveStatus,
@@ -61,13 +61,7 @@ export default function RolesDetailsDrawer({
   const { address: roleHatWearerAddress, isLoading: loadingRoleHatWearerAddress } =
     useAddress(roleHatWearer);
 
-  const { getSafeName } = useGetSafeName();
-  const [accountDisplayName, setAccountDisplayName] = useState(roleHatWearer);
-  useEffect(() => {
-    if (!!roleHatWearerAddress) {
-      getSafeName(roleHatWearerAddress).then(setAccountDisplayName);
-    }
-  }, [getSafeName, roleHatWearerAddress]);
+  const { displayName } = useDisplayName(roleHatWearerAddress);
 
   const { t } = useTranslation(['roles']);
   const avatarURL = useAvatar(roleHatWearer);
@@ -170,7 +164,7 @@ export default function RolesDetailsDrawer({
                   textStyle="body-base"
                   color="white-0"
                 >
-                  {accountDisplayName}
+                  {displayName}
                 </Text>
               </Flex>
             </GridItem>

--- a/src/components/pages/Roles/RolesTable.tsx
+++ b/src/components/pages/Roles/RolesTable.tsx
@@ -6,7 +6,6 @@ import { Address, Hex, zeroAddress } from 'viem';
 import useAddress from '../../../hooks/utils/useAddress';
 import useAvatar from '../../../hooks/utils/useAvatar';
 import useDisplayName from '../../../hooks/utils/useDisplayName';
-import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { DecentTree, useRolesStore } from '../../../store/roles';
 import NoDataCard from '../../ui/containers/NoDataCard';
 import Avatar from '../../ui/page/Header/Avatar';
@@ -94,9 +93,8 @@ function RoleNameEditColumn({
 }
 
 function MemberColumn({ wearer }: { wearer: string | undefined }) {
-  const { chain } = useNetworkConfig();
   const { address } = useAddress(wearer || zeroAddress);
-  const { displayName: accountDisplayName } = useDisplayName(address || null, true, chain.id);
+  const { displayName: accountDisplayName } = useDisplayName(address);
   const avatarURL = useAvatar(accountDisplayName);
 
   const { t } = useTranslation('roles');

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -3,10 +3,10 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Address } from 'viem';
-import { usePublicClient, useSwitchChain } from 'wagmi';
+import { useSwitchChain } from 'wagmi';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import useAvatar from '../../../../hooks/utils/useAvatar';
-import { getSafeNameFallback, useGetSafeName } from '../../../../hooks/utils/useGetSafeName';
+import { useGetSafeName } from '../../../../hooks/utils/useGetSafeName';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix, getNetworkIcon } from '../../../../utils/url';
 import Avatar from '../../page/Header/Avatar';
@@ -20,12 +20,8 @@ export interface SafeMenuItemProps {
 
 export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
   const navigate = useNavigate();
-  const publicClient = usePublicClient();
 
-  const {
-    addressPrefix,
-    contracts: { fractalRegistry },
-  } = useNetworkConfig();
+  const { addressPrefix } = useNetworkConfig();
   const { switchChain } = useSwitchChain({
     mutation: {
       onSuccess: () => {
@@ -34,16 +30,12 @@ export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
     },
   });
 
-  const { getSafeName } = useGetSafeName();
+  const { getSafeName } = useGetSafeName(getChainIdFromPrefix(network));
   const [safeName, setSafeName] = useState<string>();
 
   useEffect(() => {
-    if (!safeName) {
-      getSafeName(address, () => getSafeNameFallback(address, fractalRegistry, publicClient)).then(
-        setSafeName,
-      );
-    }
-  }, [address, fractalRegistry, getSafeName, publicClient, safeName]);
+    getSafeName(address).then(setSafeName);
+  }, [address, getSafeName]);
 
   // if by chance the safe name is an ENS name, let's attempt to get the avatar for that
   const avatarURL = useAvatar(safeName ?? '');

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -6,7 +6,6 @@ import { Address } from 'viem';
 import { usePublicClient, useSwitchChain } from 'wagmi';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import useAvatar from '../../../../hooks/utils/useAvatar';
-import useDisplayName from '../../../../hooks/utils/useDisplayName';
 import { getSafeNameFallback, useGetSafeName } from '../../../../hooks/utils/useGetSafeName';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix, getNetworkIcon } from '../../../../utils/url';
@@ -46,12 +45,8 @@ export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
     }
   }, [address, fractalRegistry, getSafeName, publicClient, safeName]);
 
-  const { displayName: accountDisplayName } = useDisplayName(
-    address,
-    false,
-    getChainIdFromPrefix(network),
-  );
-  const avatarURL = useAvatar(accountDisplayName);
+  // if by chance the safe name is an ENS name, let's attempt to get the avatar for that
+  const avatarURL = useAvatar(safeName ?? '');
 
   const { t } = useTranslation('dashboard');
 

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -7,7 +7,7 @@ import { usePublicClient, useSwitchChain } from 'wagmi';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import useAvatar from '../../../../hooks/utils/useAvatar';
 import useDisplayName from '../../../../hooks/utils/useDisplayName';
-import { getSafeNameFallback, useGetAccountName } from '../../../../hooks/utils/useGetAccountName';
+import { getSafeNameFallback, useGetSafeName } from '../../../../hooks/utils/useGetSafeName';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix, getNetworkIcon } from '../../../../utils/url';
 import Avatar from '../../page/Header/Avatar';
@@ -35,16 +35,16 @@ export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
     },
   });
 
-  const { getAccountName } = useGetAccountName();
+  const { getSafeName } = useGetSafeName();
   const [safeName, setSafeName] = useState<string>();
 
   useEffect(() => {
     if (!safeName) {
-      getAccountName(address, () =>
-        getSafeNameFallback(address, fractalRegistry, publicClient),
-      ).then(setSafeName);
+      getSafeName(address, () => getSafeNameFallback(address, fractalRegistry, publicClient)).then(
+        setSafeName,
+      );
     }
-  }, [address, fractalRegistry, getAccountName, publicClient, safeName]);
+  }, [address, fractalRegistry, getSafeName, publicClient, safeName]);
 
   const { displayName: accountDisplayName } = useDisplayName(
     address,

--- a/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
+++ b/src/components/ui/menus/SafesMenu/SafeMenuItem.tsx
@@ -7,10 +7,7 @@ import { usePublicClient, useSwitchChain } from 'wagmi';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import useAvatar from '../../../../hooks/utils/useAvatar';
 import useDisplayName from '../../../../hooks/utils/useDisplayName';
-import {
-  getSafeNameFallback,
-  useGetAccountNameDeferred,
-} from '../../../../hooks/utils/useGetAccountName';
+import { getSafeNameFallback, useGetAccountName } from '../../../../hooks/utils/useGetAccountName';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix, getNetworkIcon } from '../../../../utils/url';
 import Avatar from '../../page/Header/Avatar';
@@ -38,7 +35,7 @@ export function SafeMenuItem({ address, network }: SafeMenuItemProps) {
     },
   });
 
-  const { getAccountName } = useGetAccountNameDeferred();
+  const { getAccountName } = useGetAccountName();
   const [safeName, setSafeName] = useState<string>();
 
   useEffect(() => {

--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Address } from 'viem';
-import { usePublicClient } from 'wagmi';
 import { DAO, DAOQueryDocument, DAOQueryQuery } from '../../../../.graphclient';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
@@ -9,7 +8,7 @@ import { NodeAction } from '../../../providers/App/node/action';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { Node } from '../../../types';
 import { mapChildNodes } from '../../../utils/hierarchy';
-import { getSafeNameFallback, useGetSafeName } from '../../utils/useGetSafeName';
+import { useGetSafeName } from '../../utils/useGetSafeName';
 import { loadDemoData } from './loadDemoData';
 import { useFractalModules } from './useFractalModules';
 
@@ -35,12 +34,7 @@ export const useFractalNode = (
 
   const lookupModules = useFractalModules();
 
-  const {
-    chain,
-    contracts: { fractalRegistry },
-  } = useNetworkConfig();
-
-  const publicClient = usePublicClient();
+  const { chain } = useNetworkConfig();
 
   const formatDAOQuery = useCallback(
     (result: { data?: DAOQueryQuery }, _daoAddress: Address) => {
@@ -77,11 +71,7 @@ export const useFractalNode = (
     onCompleted: async data => {
       if (!daoAddress) return;
       const graphNodeInfo = formatDAOQuery({ data }, daoAddress);
-      const daoName =
-        graphNodeInfo?.daoName ??
-        (await getSafeName(daoAddress, () =>
-          getSafeNameFallback(daoAddress, fractalRegistry, publicClient),
-        ));
+      const daoName = graphNodeInfo?.daoName ?? (await getSafeName(daoAddress));
 
       action.dispatch({
         type: NodeAction.SET_DAO_INFO,

--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -9,7 +9,7 @@ import { NodeAction } from '../../../providers/App/node/action';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { Node } from '../../../types';
 import { mapChildNodes } from '../../../utils/hierarchy';
-import { getSafeNameFallback, useGetAccountName } from '../../utils/useGetAccountName';
+import { getSafeNameFallback, useGetSafeName } from '../../utils/useGetSafeName';
 import { loadDemoData } from './loadDemoData';
 import { useFractalModules } from './useFractalModules';
 
@@ -31,7 +31,7 @@ export const useFractalNode = (
 
   const { action } = useFractal();
   const safeAPI = useSafeAPI();
-  const { getAccountName } = useGetAccountName();
+  const { getSafeName } = useGetSafeName();
 
   const lookupModules = useFractalModules();
 
@@ -79,7 +79,7 @@ export const useFractalNode = (
       const graphNodeInfo = formatDAOQuery({ data }, daoAddress);
       const daoName =
         graphNodeInfo?.daoName ??
-        (await getAccountName(daoAddress, () =>
+        (await getSafeName(daoAddress, () =>
           getSafeNameFallback(daoAddress, fractalRegistry, publicClient),
         ));
 

--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -9,7 +9,7 @@ import { NodeAction } from '../../../providers/App/node/action';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { Node } from '../../../types';
 import { mapChildNodes } from '../../../utils/hierarchy';
-import { getSafeNameFallback, useGetAccountNameDeferred } from '../../utils/useGetAccountName';
+import { getSafeNameFallback, useGetAccountName } from '../../utils/useGetAccountName';
 import { loadDemoData } from './loadDemoData';
 import { useFractalModules } from './useFractalModules';
 
@@ -31,7 +31,7 @@ export const useFractalNode = (
 
   const { action } = useFractal();
   const safeAPI = useSafeAPI();
-  const { getAccountName } = useGetAccountNameDeferred();
+  const { getAccountName } = useGetAccountName();
 
   const lookupModules = useFractalModules();
 

--- a/src/hooks/DAO/loaders/useLoadDAONode.ts
+++ b/src/hooks/DAO/loaders/useLoadDAONode.ts
@@ -8,13 +8,13 @@ import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { FractalNode, Node, WithError } from '../../../types';
 import { mapChildNodes } from '../../../utils/hierarchy';
-import { getSafeNameFallback, useGetAccountName } from '../../utils/useGetAccountName';
+import { getSafeNameFallback, useGetSafeName } from '../../utils/useGetSafeName';
 import { loadDemoData } from './loadDemoData';
 import { useFractalModules } from './useFractalModules';
 
 export const useLoadDAONode = () => {
   const safeAPI = useSafeAPI();
-  const { getAccountName } = useGetAccountName();
+  const { getSafeName } = useGetSafeName();
   const lookupModules = useFractalModules();
   const {
     chain,
@@ -79,7 +79,7 @@ export const useLoadDAONode = () => {
           const node: FractalNode = Object.assign(graphNodeInfo, {
             daoName:
               graphNodeInfo.daoName ??
-              (await getAccountName(daoAddress, () =>
+              (await getSafeName(daoAddress, () =>
                 getSafeNameFallback(daoAddress, fractalRegistry, publicClient),
               )),
             safe: safeInfoWithGuard,
@@ -103,7 +103,7 @@ export const useLoadDAONode = () => {
       safeAPI,
       formatDAOQuery,
       getDAOInfo,
-      getAccountName,
+      getSafeName,
       lookupModules,
       fractalRegistry,
       publicClient,

--- a/src/hooks/DAO/loaders/useLoadDAONode.ts
+++ b/src/hooks/DAO/loaders/useLoadDAONode.ts
@@ -1,14 +1,13 @@
 import { useLazyQuery } from '@apollo/client';
 import { useCallback } from 'react';
 import { isAddress, Address, getAddress } from 'viem';
-import { usePublicClient } from 'wagmi';
 import { DAO, DAOQueryDocument, DAOQueryQuery } from '../../../../.graphclient';
 import { logError } from '../../../helpers/errorLogging';
 import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { FractalNode, Node, WithError } from '../../../types';
 import { mapChildNodes } from '../../../utils/hierarchy';
-import { getSafeNameFallback, useGetSafeName } from '../../utils/useGetSafeName';
+import { useGetSafeName } from '../../utils/useGetSafeName';
 import { loadDemoData } from './loadDemoData';
 import { useFractalModules } from './useFractalModules';
 
@@ -16,11 +15,7 @@ export const useLoadDAONode = () => {
   const safeAPI = useSafeAPI();
   const { getSafeName } = useGetSafeName();
   const lookupModules = useFractalModules();
-  const {
-    chain,
-    subgraph,
-    contracts: { fractalRegistry },
-  } = useNetworkConfig();
+  const { chain, subgraph } = useNetworkConfig();
   const [getDAOInfo] = useLazyQuery(DAOQueryDocument, {
     context: {
       subgraphSpace: subgraph.space,
@@ -28,8 +23,6 @@ export const useLoadDAONode = () => {
       subgraphVersion: subgraph.version,
     },
   });
-
-  const publicClient = usePublicClient();
 
   const formatDAOQuery = useCallback(
     (result: { data?: DAOQueryQuery }, _daoAddress: Address) => {
@@ -77,11 +70,7 @@ export const useLoadDAONode = () => {
           const safeInfoWithGuard = await safeAPI.getSafeData(checksummedAddress);
 
           const node: FractalNode = Object.assign(graphNodeInfo, {
-            daoName:
-              graphNodeInfo.daoName ??
-              (await getSafeName(daoAddress, () =>
-                getSafeNameFallback(daoAddress, fractalRegistry, publicClient),
-              )),
+            daoName: graphNodeInfo.daoName ?? (await getSafeName(daoAddress)),
             safe: safeInfoWithGuard,
             fractalModules: await lookupModules(safeInfoWithGuard.modules),
           });
@@ -99,15 +88,7 @@ export const useLoadDAONode = () => {
         return { error: 'errorFailedSearch' };
       }
     },
-    [
-      safeAPI,
-      formatDAOQuery,
-      getDAOInfo,
-      getSafeName,
-      lookupModules,
-      fractalRegistry,
-      publicClient,
-    ],
+    [formatDAOQuery, getDAOInfo, getSafeName, lookupModules, safeAPI],
   );
 
   return { loadDao };

--- a/src/hooks/DAO/loaders/useLoadDAONode.ts
+++ b/src/hooks/DAO/loaders/useLoadDAONode.ts
@@ -8,13 +8,13 @@ import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { FractalNode, Node, WithError } from '../../../types';
 import { mapChildNodes } from '../../../utils/hierarchy';
-import { getSafeNameFallback, useGetAccountNameDeferred } from '../../utils/useGetAccountName';
+import { getSafeNameFallback, useGetAccountName } from '../../utils/useGetAccountName';
 import { loadDemoData } from './loadDemoData';
 import { useFractalModules } from './useFractalModules';
 
 export const useLoadDAONode = () => {
   const safeAPI = useSafeAPI();
-  const { getAccountName } = useGetAccountNameDeferred();
+  const { getAccountName } = useGetAccountName();
   const lookupModules = useFractalModules();
   const {
     chain,

--- a/src/hooks/utils/useDisplayName.ts
+++ b/src/hooks/utils/useDisplayName.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Address } from 'viem';
 import { useEnsName } from 'wagmi';
-import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 
 export const createAccountSubstring = (account: string) => {
   return `${account.substring(0, 6)}...${account.slice(-4)}`;
@@ -13,15 +12,14 @@ export const createAccountSubstring = (account: string) => {
  * 0xbFC4...7551
  *
  * This is intended to be used for NON DAO display names.  If you would like to get the
- * display name for a DAO, use the useDAOName hook instead.
+ * display name for a DAO, use the useGetSafeName hook instead.
  * @todo Should switch to object for props
  */
-const useDisplayName = (account?: Address | null, truncate?: boolean, chainId?: number) => {
+const useDisplayName = (account?: Address | null, truncate?: boolean) => {
   if (truncate === undefined) truncate = true;
-  const { chain } = useNetworkConfig();
+
   const { data: ensName } = useEnsName({
     address: !!account ? account : undefined,
-    chainId: chainId || chain.id,
   });
 
   const [accountSubstring, setAccountSubstring] = useState<string>();

--- a/src/hooks/utils/useGetAccountName.ts
+++ b/src/hooks/utils/useGetAccountName.ts
@@ -72,7 +72,7 @@ const getAccountName = async ({
   return createAccountSubstring(address);
 };
 
-const useGetAccountNameDeferred = (chainId?: number) => {
+const useGetAccountName = (chainId?: number) => {
   const publicClient = usePublicClient({ chainId });
 
   const getAccountNameDeferred = useCallback(
@@ -85,4 +85,4 @@ const useGetAccountNameDeferred = (chainId?: number) => {
   return { getAccountName: getAccountNameDeferred };
 };
 
-export { useGetAccountNameDeferred };
+export { useGetAccountName };

--- a/src/hooks/utils/useGetAccountName.ts
+++ b/src/hooks/utils/useGetAccountName.ts
@@ -1,5 +1,5 @@
 import { abis } from '@fractal-framework/fractal-contracts';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { Address, PublicClient, getContract } from 'viem';
 import { usePublicClient } from 'wagmi';
 import { demoData } from '../DAO/loaders/loadDemoData';
@@ -72,35 +72,17 @@ const getAccountName = async ({
   return createAccountSubstring(address);
 };
 
-const useGetAccountName = ({
-  address,
-  chainId,
-  getAccountNameFallback,
-}: {
-  address: Address;
-  getAccountNameFallback?: GetAccountNameFallback;
-  chainId?: number;
-}) => {
+const useGetAccountNameDeferred = (chainId?: number) => {
   const publicClient = usePublicClient({ chainId });
 
-  const [accountName, setAccountName] = useState<string>();
-  useEffect(() => {
-    getAccountName({ address, publicClient, getAccountNameFallback }).then(setAccountName);
-  }, [address, publicClient, getAccountNameFallback]);
+  const getAccountNameDeferred = useCallback(
+    (address: Address, getAccountNameFallback?: GetAccountNameFallback) => {
+      return getAccountName({ address, publicClient, getAccountNameFallback });
+    },
+    [publicClient],
+  );
 
-  return { accountName };
+  return { getAccountName: getAccountNameDeferred };
 };
 
-const useGetAccountNameDeferred = () => {
-  const publicClient = usePublicClient();
-
-  return {
-    getAccountName: useCallback(
-      (address: Address, getAccountNameFallback?: GetAccountNameFallback) =>
-        getAccountName({ address, publicClient, getAccountNameFallback }),
-      [publicClient],
-    ),
-  };
-};
-
-export { useGetAccountName, useGetAccountNameDeferred };
+export { useGetAccountNameDeferred };

--- a/src/hooks/utils/useGetSafeName.ts
+++ b/src/hooks/utils/useGetSafeName.ts
@@ -10,7 +10,7 @@ export const useGetSafeName = (chainId?: number) => {
   const publicClient = usePublicClient({ chainId });
   const {
     contracts: { fractalRegistry },
-  } = useNetworkConfig();
+  } = useNetworkConfig(chainId);
 
   const getSafeName = useCallback(
     async (address: Address) => {

--- a/src/hooks/utils/useGetSafeName.ts
+++ b/src/hooks/utils/useGetSafeName.ts
@@ -37,10 +37,10 @@ export const getSafeNameFallback = async (
   }
 };
 
-export const useGetAccountName = (chainId?: number) => {
+export const useGetSafeName = (chainId?: number) => {
   const publicClient = usePublicClient({ chainId });
 
-  const getAccountName = useCallback(
+  const getSafeName = useCallback(
     async (address: Address, getAccountNameFallback?: () => Promise<string | undefined>) => {
       if (!publicClient || !publicClient.chain) {
         throw new Error('Public client not available');
@@ -68,5 +68,5 @@ export const useGetAccountName = (chainId?: number) => {
     [publicClient],
   );
 
-  return { getAccountName };
+  return { getSafeName };
 };

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -8,10 +8,7 @@ import Avatar from '../../components/ui/page/Header/Avatar';
 import { DAO_ROUTES } from '../../constants/routes';
 import useAvatar from '../../hooks/utils/useAvatar';
 import useDisplayName, { createAccountSubstring } from '../../hooks/utils/useDisplayName';
-import {
-  getSafeNameFallback,
-  useGetAccountNameDeferred,
-} from '../../hooks/utils/useGetAccountName';
+import { getSafeNameFallback, useGetAccountName } from '../../hooks/utils/useGetAccountName';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix, getChainName, getNetworkIcon } from '../../utils/url';
 
@@ -32,7 +29,7 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
 
   const publicClient = usePublicClient();
 
-  const { getAccountName } = useGetAccountNameDeferred(getChainIdFromPrefix(network));
+  const { getAccountName } = useGetAccountName(getChainIdFromPrefix(network));
   const [safeName, setSafeName] = useState<string>();
 
   useEffect(() => {

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -8,7 +8,7 @@ import Avatar from '../../components/ui/page/Header/Avatar';
 import { DAO_ROUTES } from '../../constants/routes';
 import useAvatar from '../../hooks/utils/useAvatar';
 import useDisplayName, { createAccountSubstring } from '../../hooks/utils/useDisplayName';
-import { getSafeNameFallback, useGetAccountName } from '../../hooks/utils/useGetAccountName';
+import { getSafeNameFallback, useGetSafeName } from '../../hooks/utils/useGetSafeName';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix, getChainName, getNetworkIcon } from '../../utils/url';
 
@@ -29,20 +29,20 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
 
   const publicClient = usePublicClient();
 
-  const { getAccountName } = useGetAccountName(getChainIdFromPrefix(network));
+  const { getSafeName } = useGetSafeName(getChainIdFromPrefix(network));
   const [safeName, setSafeName] = useState<string>();
 
   useEffect(() => {
     const fetchSafeName = async () => {
       setSafeName(
-        await getAccountName(address, () =>
+        await getSafeName(address, () =>
           getSafeNameFallback(address, fractalRegistry, publicClient),
         ),
       );
     };
 
     fetchSafeName();
-  }, [address, getAccountName, fractalRegistry, publicClient]);
+  }, [address, getSafeName, fractalRegistry, publicClient]);
 
   const { t } = useTranslation('dashboard');
 

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -2,21 +2,18 @@ import { Flex, Image, Show, Spacer, Text } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { usePublicClient, useSwitchChain } from 'wagmi';
+import { useSwitchChain } from 'wagmi';
 import { SafeMenuItemProps } from '../../components/ui/menus/SafesMenu/SafeMenuItem';
 import Avatar from '../../components/ui/page/Header/Avatar';
 import { DAO_ROUTES } from '../../constants/routes';
 import useAvatar from '../../hooks/utils/useAvatar';
 import { createAccountSubstring } from '../../hooks/utils/useDisplayName';
-import { getSafeNameFallback, useGetSafeName } from '../../hooks/utils/useGetSafeName';
+import { useGetSafeName } from '../../hooks/utils/useGetSafeName';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix, getChainName, getNetworkIcon } from '../../utils/url';
 
 export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeMenuItemProps) {
-  const {
-    addressPrefix,
-    contracts: { fractalRegistry },
-  } = useNetworkConfig();
+  const { addressPrefix } = useNetworkConfig();
   const navigate = useNavigate();
 
   const { switchChain } = useSwitchChain({
@@ -27,22 +24,12 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
     },
   });
 
-  const publicClient = usePublicClient();
-
   const { getSafeName } = useGetSafeName(getChainIdFromPrefix(network));
   const [safeName, setSafeName] = useState<string>();
 
   useEffect(() => {
-    const fetchSafeName = async () => {
-      setSafeName(
-        await getSafeName(address, () =>
-          getSafeNameFallback(address, fractalRegistry, publicClient),
-        ),
-      );
-    };
-
-    fetchSafeName();
-  }, [address, getSafeName, fractalRegistry, publicClient]);
+    getSafeName(address).then(setSafeName);
+  }, [address, getSafeName]);
 
   const { t } = useTranslation('dashboard');
 

--- a/src/pages/home/SafeDisplayRow.tsx
+++ b/src/pages/home/SafeDisplayRow.tsx
@@ -7,7 +7,7 @@ import { SafeMenuItemProps } from '../../components/ui/menus/SafesMenu/SafeMenuI
 import Avatar from '../../components/ui/page/Header/Avatar';
 import { DAO_ROUTES } from '../../constants/routes';
 import useAvatar from '../../hooks/utils/useAvatar';
-import useDisplayName, { createAccountSubstring } from '../../hooks/utils/useDisplayName';
+import { createAccountSubstring } from '../../hooks/utils/useDisplayName';
 import { getSafeNameFallback, useGetSafeName } from '../../hooks/utils/useGetSafeName';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { getChainIdFromPrefix, getChainName, getNetworkIcon } from '../../utils/url';
@@ -46,12 +46,8 @@ export function SafeDisplayRow({ address, network, onClick, showAddress }: SafeM
 
   const { t } = useTranslation('dashboard');
 
-  const { displayName: accountDisplayName } = useDisplayName(
-    address,
-    false,
-    getChainIdFromPrefix(network),
-  );
-  const avatarURL = useAvatar(accountDisplayName);
+  // if the safe name is an ENS name, let's attempt to get the avatar for that
+  const avatarURL = useAvatar(safeName ?? '');
 
   const onClickNav = () => {
     if (onClick) onClick();


### PR DESCRIPTION
Fixes on top of the base PR #2414 that @DarksightKellar is working on:

- Renames `useGetAccountName` to `useGetSafeName`. This hook is _only for getting Safe / DAO names_. We have a different hook, `useDisplayName`, for getting ENS names of accounts.
- This `useGetSafeName` hook will, in order, attempt to get and return the name for a safe: 1) by ENS name of the Safe Address, 2) by FractalRegistry name of the Safe address, 3) by truncating the address
- This `useGetSafeName.ts` file now only exports one function instead of three. Much cleaner. We can use it everywhere we need to get a Safe name, whether on the current network or not (as in the case of Favorites which might be on any network).
- Small cleanups to the `useDisplayName` hook, to remove unused parameters
- Small improvement to `useNetworkConfig`, to allow passing in an optional `networkId` to get contract information of any network (used in `useGetAccountName` to get the correct `FractalRegistry` address if the network wanted is not currently connected network, as in the case of Favorites).
