### PR TITLE
Undo typesafe formik

### DIFF
--- a/src/components/pages/Roles/RolesTable.tsx
+++ b/src/components/pages/Roles/RolesTable.tsx
@@ -1,12 +1,12 @@
 import { Box, Flex, Icon, Table, Tbody, Td, Text, Th, Thead, Tr } from '@chakra-ui/react';
 import { PencilLine } from '@phosphor-icons/react';
+import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { Address, Hex } from 'viem';
 import useAvatar from '../../../hooks/utils/useAvatar';
 import { useGetAccountName } from '../../../hooks/utils/useGetAccountName';
 import { DecentTree } from '../../../store/roles/rolesStoreUtils';
 import { useRolesStore } from '../../../store/roles/useRolesStore';
-import { useTypesafeFormikContext } from '../../../utils/TypesafeForm';
 import NoDataCard from '../../ui/containers/NoDataCard';
 import Avatar from '../../ui/page/Header/Avatar';
 import EditBadge from './EditBadge';
@@ -271,9 +271,7 @@ export function RolesTable({
 
 export function RolesEditTable({ handleRoleClick }: { handleRoleClick: (hatId: Hex) => void }) {
   const { hatsTree } = useRolesStore();
-  const {
-    formik: { values, setFieldValue },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, setFieldValue } = useFormikContext<RoleFormValues>();
   if (hatsTree === undefined) {
     return <RoleCardLoading />;
   }

--- a/src/components/pages/Roles/forms/RoleFormAssetSelector.tsx
+++ b/src/components/pages/Roles/forms/RoleFormAssetSelector.tsx
@@ -12,14 +12,20 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { CaretDown, CheckCircle } from '@phosphor-icons/react';
-import { FormikErrors } from 'formik';
+import {
+  Field,
+  FieldMetaProps,
+  FieldInputProps,
+  FormikErrors,
+  useFormikContext,
+  FormikProps,
+} from 'formik';
 import { useTranslation } from 'react-i18next';
 import { getAddress } from 'viem';
 import { CARD_SHADOW } from '../../../../constants/common';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { BigIntValuePair } from '../../../../types';
 import { formatCoin, formatUSD } from '../../../../utils';
-import { useTypesafeFormikContext } from '../../../../utils/TypesafeForm';
 import { MOCK_MORALIS_ETH_ADDRESS } from '../../../../utils/address';
 import DraggableDrawer from '../../../ui/containers/DraggableDrawer';
 import { BigIntInput } from '../../../ui/forms/BigIntInput';
@@ -38,9 +44,7 @@ function AssetsList({ formIndex }: { formIndex: number }) {
       parseFloat(asset.balance) > 0 &&
       asset.tokenAddress.toLowerCase() !== MOCK_MORALIS_ETH_ADDRESS.toLowerCase(), // Can't stream native token
   );
-  const {
-    formik: { values, setFieldValue },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, setFieldValue } = useFormikContext<RoleFormValues>();
   const selectedAsset = values.roleEditing?.payments?.[formIndex]?.asset;
 
   if (fungibleAssetsWithBalance.length === 0) {
@@ -146,10 +150,7 @@ function AssetsList({ formIndex }: { formIndex: number }) {
 
 export function AssetSelector({ formIndex, disabled }: { formIndex: number; disabled?: boolean }) {
   const { t } = useTranslation(['roles', 'treasury', 'modals']);
-  const {
-    formik: { values, setFieldValue },
-    Field,
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, setFieldValue } = useFormikContext<RoleFormValues>();
   const selectedAsset = values.roleEditing?.payments?.[formIndex]?.asset;
 
   return (
@@ -284,7 +285,15 @@ export function AssetSelector({ formIndex, disabled }: { formIndex: number; disa
         isDisabled={disabled}
       >
         <Field name={`roleEditing.payments.${formIndex}.amount`}>
-          {({ field, meta, form: { setFieldTouched } }) => {
+          {({
+            field,
+            meta,
+            form: { setFieldTouched },
+          }: {
+            field: FieldInputProps<BigIntValuePair>;
+            meta: FieldMetaProps<BigIntValuePair>;
+            form: FormikProps<RoleFormValues>;
+          }) => {
             const paymentAmountBigIntError = meta.error as FormikErrors<BigIntValuePair>;
             const paymentAmountBigIntTouched = meta.touched;
             const inputDisabled = !values?.roleEditing?.payments?.[formIndex]?.asset || disabled;

--- a/src/components/pages/Roles/forms/RoleFormCreateProposal.tsx
+++ b/src/components/pages/Roles/forms/RoleFormCreateProposal.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Flex, FormControl, Show, Text, Icon } from '@chakra-ui/react';
 import { SquaresFour, ArrowsDownUp, Trash } from '@phosphor-icons/react';
+import { Field, FieldInputProps, FormikProps, useFormikContext } from 'formik';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -9,7 +10,6 @@ import { DAO_ROUTES } from '../../../../constants/routes';
 import { useGetAccountName } from '../../../../hooks/utils/useGetAccountName';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
-import { useTypesafeFormikContext } from '../../../../utils/TypesafeForm';
 import { Card } from '../../../ui/cards/Card';
 import { CustomNonceInput } from '../../../ui/forms/CustomNonceInput';
 import { InputComponent, TextareaComponent } from '../../../ui/forms/InputComponent';
@@ -73,9 +73,11 @@ export default function RoleFormCreateProposal({ close }: { close: () => void })
   const { t } = useTranslation(['modals', 'common', 'proposal']);
 
   const {
-    formik: { values, setFieldValue: setFieldValueTopLevel, isSubmitting, submitForm },
-    Field,
-  } = useTypesafeFormikContext<RoleFormValues>();
+    values,
+    setFieldValue: setFieldValueTopLevel,
+    isSubmitting,
+    submitForm,
+  } = useFormikContext<RoleFormValues>();
 
   const editedRoles = useMemo<
     (RoleDetailsDrawerEditingRoleHatProp & {
@@ -155,7 +157,13 @@ export default function RoleFormCreateProposal({ close }: { close: () => void })
       >
         <FormControl>
           <Field name="proposalMetadata.title">
-            {({ field, form: { setFieldValue, setFieldTouched } }) => (
+            {({
+              field,
+              form: { setFieldValue, setFieldTouched },
+            }: {
+              field: FieldInputProps<string>;
+              form: FormikProps<RoleFormValues>;
+            }) => (
               <LabelWrapper label={t('proposalTitle', { ns: 'proposal' })}>
                 <InputComponent
                   value={field.value}
@@ -176,7 +184,13 @@ export default function RoleFormCreateProposal({ close }: { close: () => void })
         </FormControl>
         <FormControl>
           <Field name="proposalMetadata.description">
-            {({ field, form: { setFieldValue, setFieldTouched } }) => (
+            {({
+              field,
+              form: { setFieldValue, setFieldTouched },
+            }: {
+              field: FieldInputProps<string>;
+              form: FormikProps<RoleFormValues>;
+            }) => (
               <LabelWrapper label={t('proposalDescription', { ns: 'proposal' })}>
                 <TextareaComponent
                   value={field.value}
@@ -197,7 +211,7 @@ export default function RoleFormCreateProposal({ close }: { close: () => void })
 
         <FormControl>
           <Field name="customNonce">
-            {({ form: { setFieldValue } }) => (
+            {({ form: { setFieldValue } }: { form: FormikProps<RoleFormValues> }) => (
               <Flex
                 w="100%"
                 justifyContent="flex-end"

--- a/src/components/pages/Roles/forms/RoleFormInfo.tsx
+++ b/src/components/pages/Roles/forms/RoleFormInfo.tsx
@@ -1,10 +1,10 @@
 import { Box, FormControl } from '@chakra-ui/react';
+import { Field, FieldInputProps, FieldMetaProps, FormikProps, useFormikContext } from 'formik';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DETAILS_BOX_SHADOW } from '../../../../constants/common';
 import useAddress from '../../../../hooks/utils/useAddress';
 import { useGetAccountName } from '../../../../hooks/utils/useGetAccountName';
-import { useTypesafeFormikContext } from '../../../../utils/TypesafeForm';
 import { AddressInput } from '../../../ui/forms/EthAddressInput';
 import { InputComponent, TextareaComponent } from '../../../ui/forms/InputComponent';
 import LabelWrapper from '../../../ui/forms/LabelWrapper';
@@ -17,10 +17,7 @@ export default function RoleFormInfo() {
   const { address: resolvedWearerAddress, isValid: isValidWearerAddress } =
     useAddress(roleWearerString);
 
-  const {
-    formik: { setFieldValue, values },
-    Field,
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { setFieldValue, values } = useFormikContext<RoleFormValues>();
 
   useEffect(() => {
     if (isValidWearerAddress) {
@@ -46,7 +43,15 @@ export default function RoleFormInfo() {
     >
       <FormControl>
         <Field name="roleEditing.name">
-          {({ field, form: { setFieldTouched }, meta }) => (
+          {({
+            field,
+            form: { setFieldTouched },
+            meta,
+          }: {
+            field: FieldInputProps<string>;
+            form: FormikProps<RoleFormValues>;
+            meta: FieldMetaProps<string>;
+          }) => (
             <InputComponent
               value={field.value ?? ''}
               onChange={e => {
@@ -72,7 +77,15 @@ export default function RoleFormInfo() {
       </FormControl>
       <FormControl>
         <Field name="roleEditing.description">
-          {({ field, form: { setFieldTouched }, meta }) => (
+          {({
+            field,
+            form: { setFieldTouched },
+            meta,
+          }: {
+            field: FieldInputProps<string>;
+            form: FormikProps<RoleFormValues>;
+            meta: FieldMetaProps<string>;
+          }) => (
             <TextareaComponent
               value={field.value ?? ''}
               onChange={e => {
@@ -99,7 +112,15 @@ export default function RoleFormInfo() {
       </FormControl>
       <FormControl>
         <Field name="roleEditing.wearer">
-          {({ field, form: { setFieldTouched }, meta }) => (
+          {({
+            field,
+            form: { setFieldTouched },
+            meta,
+          }: {
+            field: FieldInputProps<string>;
+            form: FormikProps<RoleFormValues>;
+            meta: FieldMetaProps<string>;
+          }) => (
             <LabelWrapper
               label={t('member')}
               errorMessage={meta.touched && meta.error ? meta.error : undefined}

--- a/src/components/pages/Roles/forms/RoleFormPaymentStream.tsx
+++ b/src/components/pages/Roles/forms/RoleFormPaymentStream.tsx
@@ -1,12 +1,11 @@
 import { Alert, Box, Button, Flex, FormControl, Icon, Show, Text } from '@chakra-ui/react';
 import { ArrowRight, Info, Trash } from '@phosphor-icons/react';
 import { addDays, addMinutes } from 'date-fns';
-import { FormikErrors } from 'formik';
+import { FormikErrors, useFormikContext } from 'formik';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CARD_SHADOW, isDevMode } from '../../../../constants/common';
 import { useRolesStore } from '../../../../store/roles/useRolesStore';
-import { useTypesafeFormikContext } from '../../../../utils/TypesafeForm';
 import { ModalType } from '../../../ui/modals/ModalProvider';
 import { useDecentModal } from '../../../ui/modals/useDecentModal';
 import { DecentDatePicker } from '../../../ui/utils/DecentDatePicker';
@@ -16,9 +15,7 @@ import { SectionTitle } from './RoleFormSectionTitle';
 
 function FixedDate({ formIndex, disabled }: { formIndex: number; disabled: boolean }) {
   const { t } = useTranslation(['roles']);
-  const {
-    formik: { values, setFieldValue },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, setFieldValue } = useFormikContext<RoleFormValues>();
   const payment = values?.roleEditing?.payments?.[formIndex];
 
   // Show cliff date picker if both start and end dates are set and if there is at least a day between them
@@ -104,9 +101,7 @@ function FixedDate({ formIndex, disabled }: { formIndex: number; disabled: boole
 
 export default function RoleFormPaymentStream({ formIndex }: { formIndex: number }) {
   const { t } = useTranslation(['roles']);
-  const {
-    formik: { values, errors, setFieldValue },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, errors, setFieldValue } = useFormikContext<RoleFormValues>();
   const { getPayment } = useRolesStore();
   const roleEditingPaymentsErrors = (errors.roleEditing as FormikErrors<RoleHatFormValue>)
     ?.payments;

--- a/src/components/pages/Roles/forms/RoleFormPaymentStreams.tsx
+++ b/src/components/pages/Roles/forms/RoleFormPaymentStreams.tsx
@@ -1,5 +1,6 @@
 import { Box, Button } from '@chakra-ui/react';
 import { Plus } from '@phosphor-icons/react';
+import { FieldArray, useFormikContext } from 'formik';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -7,7 +8,6 @@ import {
   paymentSorterByStartDate,
   paymentSorterByWithdrawAmount,
 } from '../../../../store/roles/rolesStoreUtils';
-import { useTypesafeFormikContext } from '../../../../utils/TypesafeForm';
 import { ModalType } from '../../../ui/modals/ModalProvider';
 import { useDecentModal } from '../../../ui/modals/useDecentModal';
 import { RolePaymentDetails } from '../RolePaymentDetails';
@@ -15,10 +15,7 @@ import { RoleFormValues, SablierPaymentFormValues } from '../types';
 
 export function RoleFormPaymentStreams() {
   const { t } = useTranslation(['roles']);
-  const {
-    formik: { values, setFieldValue, validateForm },
-    FieldArray,
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, setFieldValue, validateForm } = useFormikContext<RoleFormValues>();
   const cancelModal = useDecentModal(ModalType.NONE);
   const payments = values.roleEditing?.payments;
 

--- a/src/components/pages/Roles/forms/RoleFormTabs.tsx
+++ b/src/components/pages/Roles/forms/RoleFormTabs.tsx
@@ -1,4 +1,5 @@
 import { Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
+import { useFormikContext } from 'formik';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Blocker, useNavigate } from 'react-router-dom';
@@ -7,7 +8,6 @@ import { DAO_ROUTES } from '../../../../constants/routes';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { useRolesStore } from '../../../../store/roles/useRolesStore';
-import { useTypesafeFormikContext } from '../../../../utils/TypesafeForm';
 import { EditBadgeStatus, RoleFormValues, RoleHatFormValue } from '../types';
 import RoleFormInfo from './RoleFormInfo';
 import RoleFormPaymentStream from './RoleFormPaymentStream';
@@ -31,9 +31,7 @@ export default function RoleFormTabs({
   const { addressPrefix } = useNetworkConfig();
   const { editedRoleData, isRoleUpdated, existingRoleHat } = useRoleFormEditedRole({ hatsTree });
   const { t } = useTranslation(['roles']);
-  const {
-    formik: { values, setFieldValue, errors, setTouched },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, setFieldValue, errors, setTouched } = useFormikContext<RoleFormValues>();
 
   useEffect(() => {
     if (values.hats.length && !values.roleEditing) {

--- a/src/components/pages/Roles/forms/useRoleFormEditedRole.ts
+++ b/src/components/pages/Roles/forms/useRoleFormEditedRole.ts
@@ -1,6 +1,6 @@
+import { useFormikContext } from 'formik';
 import { useMemo } from 'react';
 import { DecentTree } from '../../../../store/roles/rolesStoreUtils';
-import { useTypesafeFormikContext } from '../../../../utils/TypesafeForm';
 import { EditedRole, EditBadgeStatus, RoleFormValues } from '../types';
 
 const addRemoveField = (fieldNames: string[], fieldName: string, hasChanges: boolean) => {
@@ -13,9 +13,7 @@ const addRemoveField = (fieldNames: string[], fieldName: string, hasChanges: boo
 };
 
 export function useRoleFormEditedRole({ hatsTree }: { hatsTree: DecentTree | undefined | null }) {
-  const {
-    formik: { values },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values } = useFormikContext<RoleFormValues>();
   const existingRoleHat = useMemo(
     () =>
       hatsTree?.roleHats.find(role => !!values.roleEditing && role.id === values.roleEditing.id),

--- a/src/components/ui/utils/DecentDatePicker.tsx
+++ b/src/components/ui/utils/DecentDatePicker.tsx
@@ -11,13 +11,13 @@ import {
 } from '@chakra-ui/react';
 import { ArrowRight, CalendarBlank, CaretLeft, CaretRight } from '@phosphor-icons/react';
 import { format } from 'date-fns';
+import { Field, useFormikContext } from 'formik';
 import { ReactNode, useMemo, useState } from 'react';
 import { Calendar } from 'react-calendar';
 import { useTranslation } from 'react-i18next';
 import '../../../assets/css/Calendar.css';
 import { SEXY_BOX_SHADOW_T_T } from '../../../constants/common';
 import { DEFAULT_DATE_FORMAT } from '../../../utils';
-import { useTypesafeFormikContext } from '../../../utils/TypesafeForm';
 import { DatePickerTrigger } from '../../pages/Roles/DatePickerTrigger';
 import { RoleFormValues } from '../../pages/Roles/types';
 import DraggableDrawer from '../containers/DraggableDrawer';
@@ -99,10 +99,7 @@ function DecentDatePickerContainer({
   disabled: boolean;
 }) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const {
-    formik: { values },
-    Field,
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values } = useFormikContext<RoleFormValues>();
   const selectedDate = values.roleEditing?.payments?.[formIndex]?.[type];
   const boxShadow = useBreakpointValue({ base: 'none', md: SEXY_BOX_SHADOW_T_T });
   const maxBoxW = useBreakpointValue({ base: '100%', md: '26.875rem' });
@@ -210,9 +207,7 @@ export function DecentDatePicker({
   formIndex: number;
   disabled: boolean;
 }) {
-  const {
-    formik: { values },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values } = useFormikContext<RoleFormValues>();
 
   const selectedDate = useMemo(() => {
     if (values.roleEditing?.roleEditingPaymentIndex === undefined) return null;
@@ -270,10 +265,7 @@ export function DecentDatePickerRange({
   formIndex: number;
   disabled: boolean;
 }) {
-  const {
-    formik: { values },
-  } = useTypesafeFormikContext<RoleFormValues>();
-
+  const { values } = useFormikContext<RoleFormValues>();
   const selectedRange: [DateOrNull, DateOrNull] = useMemo(() => {
     if (values.roleEditing?.roleEditingPaymentIndex === undefined) return [null, null];
     const paymentIndex = values.roleEditing.roleEditingPaymentIndex;

--- a/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/details/index.tsx
@@ -14,6 +14,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { ArrowLeft, DotsThree, Trash } from '@phosphor-icons/react';
+import { FieldArray, useFormikContext } from 'formik';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -38,14 +39,11 @@ import { useNavigationBlocker } from '../../../../../../hooks/utils/useNavigatio
 import { useFractal } from '../../../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { useRolesStore } from '../../../../../../store/roles/useRolesStore';
-import { useTypesafeFormikContext } from '../../../../../../utils/TypesafeForm';
 import { UnsavedChangesWarningContent } from '../unsavedChangesWarningContent';
 
 function EditRoleMenu({ onRemove, hatId }: { hatId: Hex; onRemove: () => void }) {
   const { t } = useTranslation(['roles']);
-  const {
-    formik: { values, setFieldValue },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, setFieldValue } = useFormikContext<RoleFormValues>();
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const hatIndex = values.hats.findIndex(h => h.id === hatId);
@@ -138,16 +136,13 @@ export default function RoleEditDetails() {
   const { getPayment } = useRolesStore();
   const { addressPrefix } = useNetworkConfig();
   const navigate = useNavigate();
-  const {
-    formik: { values, setFieldValue, touched, setTouched },
-    FieldArray,
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values, setFieldValue, touched, setTouched } = useFormikContext<RoleFormValues>();
   const [searchParams] = useSearchParams();
   const hatEditingId = searchParams.get('hatId');
 
   const [wasRoleActuallyEdited, setWasRoleActuallyEdited] = useState(false);
 
-  const { formik: editRolesFormikContext } = useTypesafeFormikContext<RoleFormValues>();
+  const editRolesFormikContext = useFormikContext<RoleFormValues>();
   const blocker = useNavigationBlocker({
     roleEditDetailsNavigationBlockerParams: { wasRoleActuallyEdited, ...editRolesFormikContext },
   });

--- a/src/pages/daos/[daoAddress]/roles/edit/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/index.tsx
@@ -1,6 +1,7 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import { Box, Button, Flex, Hide, Show } from '@chakra-ui/react';
 import { Plus } from '@phosphor-icons/react';
+import { Formik } from 'formik';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useNavigate } from 'react-router-dom';
@@ -22,7 +23,6 @@ import { analyticsEvents } from '../../../../../insights/analyticsEvents';
 import { useFractal } from '../../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { useRolesStore } from '../../../../../store/roles/useRolesStore';
-import { makeTypesafeForm } from '../../../../../utils/TypesafeForm';
 import { UnsavedChangesWarningContent } from './unsavedChangesWarningContent';
 
 function RolesEdit() {
@@ -95,10 +95,8 @@ function RolesEdit() {
   const hatsTreeLoading = hatsTree === undefined;
   const showNoRolesCard = !hatsTreeLoading && (hatsTree === null || hatsTree.roleHats.length === 0);
 
-  const { Formik } = makeTypesafeForm<RoleFormValues>();
-
   return (
-    <Formik
+    <Formik<RoleFormValues>
       initialValues={initialValues}
       enableReinitialize
       validationSchema={rolesSchema}

--- a/src/pages/daos/[daoAddress]/roles/edit/summary/index.tsx
+++ b/src/pages/daos/[daoAddress]/roles/edit/summary/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Icon, Portal, Show, Text } from '@chakra-ui/react';
 import { ArrowLeft } from '@phosphor-icons/react';
+import { useFormikContext } from 'formik';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -10,7 +11,6 @@ import { SIDEBAR_WIDTH, useHeaderHeight } from '../../../../../../constants/comm
 import { DAO_ROUTES } from '../../../../../../constants/routes';
 import { useFractal } from '../../../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../../../providers/NetworkConfig/NetworkConfigProvider';
-import { useTypesafeFormikContext } from '../../../../../../utils/TypesafeForm';
 
 export default function EditProposalSummary() {
   const headerHeight = useHeaderHeight();
@@ -20,9 +20,7 @@ export default function EditProposalSummary() {
   } = useFractal();
   const { t } = useTranslation(['roles', 'breadcrumbs']);
   const { addressPrefix } = useNetworkConfig();
-  const {
-    formik: { values },
-  } = useTypesafeFormikContext<RoleFormValues>();
+  const { values } = useFormikContext<RoleFormValues>();
 
   // @dev redirects back to roles edit page if no roles are edited (user refresh)
   useEffect(() => {

--- a/src/utils/TypesafeForm.tsx
+++ b/src/utils/TypesafeForm.tsx
@@ -297,4 +297,4 @@ function makeTypesafeForm<Values extends Record<string, unknown>>(): {
   };
 }
 
-export { makeTypesafeForm, useTypesafeFormikContext };
+export { makeTypesafeForm as doNotUseThis, useTypesafeFormikContext as thisIsBroken };


### PR DESCRIPTION
The Typesafe Formik stuff was actually pretty broken. The `Field` and `FieldArray` props coming out of the hook were `undefined`. Oops!

Attempting to fix it started leading down a path that didn't have a clear end, so, this PR simply undoes all of the usage of `makeTypesafeForm` and `useTypesafeFormikContext`, to give me some more time to debug this while not blocking everyone else.