### PR TITLE
Implement tooltip design update

### DIFF
--- a/src/assets/theme/components/tooltip/index.ts
+++ b/src/assets/theme/components/tooltip/index.ts
@@ -4,10 +4,11 @@ const $arrowBg = cssVar('popper-arrow-bg');
 
 export default {
   baseStyle: {
+    maxW: '20rem',
     borderRadius: '4px',
-    backgroundColor: 'black-0',
+    backgroundColor: 'neutral-9',
     padding: '0.25rem 0.5rem',
-    color: 'white-0',
+    color: 'black-0',
     [$arrowBg.variable]: 'black-0',
   },
 };

--- a/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
+++ b/src/components/Proposals/MultisigProposalDetails/TxActions.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text, Flex, Tooltip } from '@chakra-ui/react';
+import { Box, Button, Text, Flex } from '@chakra-ui/react';
 import { abis } from '@fractal-framework/fractal-contracts';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,6 +16,7 @@ import { useFractal } from '../../../providers/App/AppProvider';
 import { useSafeAPI } from '../../../providers/App/hooks/useSafeAPI';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
 import { MultisigProposal, FractalProposalState } from '../../../types';
+import { DecentTooltip } from '../../ui/DecentTooltip';
 import ContentBox from '../../ui/containers/ContentBox';
 import { ProposalCountdown } from '../../ui/proposal/ProposalCountdown';
 
@@ -296,7 +297,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
         <ProposalCountdown proposal={proposal} />
       </Flex>
       <Box marginTop={4}>
-        <Tooltip
+        <DecentTooltip
           placement="top-start"
           label={t('notActiveNonceTooltip')}
           isDisabled={isActiveNonce}
@@ -309,7 +310,7 @@ export function TxActions({ proposal }: { proposal: MultisigProposal }) {
           >
             {t(buttonProps[proposal.state!].text, { ns: 'common' })}
           </Button>
-        </Tooltip>
+        </DecentTooltip>
       </Box>
     </ContentBox>
   );

--- a/src/components/Proposals/ProposalActions/CastVote.tsx
+++ b/src/components/Proposals/ProposalActions/CastVote.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip, Box, Text, Image, Flex, Radio, RadioGroup, Icon } from '@chakra-ui/react';
+import { Button, Box, Text, Image, Flex, Radio, RadioGroup, Icon } from '@chakra-ui/react';
 import { Check, CheckCircle } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +13,7 @@ import {
   FractalProposalState,
   VOTE_CHOICES,
 } from '../../../types';
+import { DecentTooltip } from '../../ui/DecentTooltip';
 import WeightedInput from '../../ui/forms/WeightedInput';
 import { useVoteContext } from '../ProposalVotes/context/VoteContext';
 
@@ -160,7 +161,7 @@ export function CastVote({ proposal }: { proposal: FractalProposal }) {
   }
 
   return (
-    <Tooltip
+    <DecentTooltip
       placement="left"
       maxW={TOOLTIP_MAXW}
       title={
@@ -209,6 +210,6 @@ export function CastVote({ proposal }: { proposal: FractalProposal }) {
           {t('vote')}
         </Button>
       </RadioGroup>
-    </Tooltip>
+    </DecentTooltip>
   );
 }

--- a/src/components/Proposals/ProposalSummary.tsx
+++ b/src/components/Proposals/ProposalSummary.tsx
@@ -1,4 +1,4 @@
-import { Text, Box, Button, Flex, Tooltip, Icon } from '@chakra-ui/react';
+import { Text, Box, Button, Flex, Icon } from '@chakra-ui/react';
 import { abis } from '@fractal-framework/fractal-contracts';
 import { ArrowUpRight } from '@phosphor-icons/react';
 import { format } from 'date-fns';
@@ -12,6 +12,7 @@ import useBlockTimestamp from '../../hooks/utils/useBlockTimestamp';
 import { useFractal } from '../../providers/App/AppProvider';
 import { AzoriusGovernance, AzoriusProposal, GovernanceType } from '../../types';
 import { DEFAULT_DATE_TIME_FORMAT, formatCoin } from '../../utils/numberFormats';
+import { DecentTooltip } from '../ui/DecentTooltip';
 import ContentBox from '../ui/containers/ContentBox';
 import DisplayTransaction from '../ui/links/DisplayTransaction';
 import EtherscanLink from '../ui/links/EtherscanLink';
@@ -227,13 +228,13 @@ export function AzoriusProposalSummary({ proposal }: { proposal: AzoriusProposal
             {t('votingPower')}
           </Text>
           {showVotingPower ? (
-            <Tooltip
+            <DecentTooltip
               label={t('votingPowerTooltip')}
               placement="left"
               maxW={TOOLTIP_MAXW}
             >
               {ShowVotingPowerButton}
-            </Tooltip>
+            </DecentTooltip>
           ) : (
             ShowVotingPowerButton
           )}

--- a/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
+++ b/src/components/Proposals/SnapshotProposalDetails/SnapshotProposalSummary.tsx
@@ -1,4 +1,4 @@
-import { Text, Box, Button, Flex, Tooltip } from '@chakra-ui/react';
+import { Text, Box, Button, Flex } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { useState } from 'react';
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { TOOLTIP_MAXW } from '../../../constants/common';
 import { ExtendedSnapshotProposal } from '../../../types';
 import { DEFAULT_DATE_TIME_FORMAT } from '../../../utils/numberFormats';
+import { DecentTooltip } from '../../ui/DecentTooltip';
 import ContentBox from '../../ui/containers/ContentBox';
 import ExternalLink from '../../ui/links/ExternalLink';
 import { InfoBoxLoader } from '../../ui/loaders/InfoBoxLoader';
@@ -117,13 +118,13 @@ export default function SnapshotProposalSummary({ proposal }: ISnapshotProposalS
             {t('votingPower')}
           </Text>
           {showVotingPower ? (
-            <Tooltip
+            <DecentTooltip
               label={t('votingPowerTooltip')}
               placement="left"
               maxW={TOOLTIP_MAXW}
             >
               {ShowVotingPowerButton}
-            </Tooltip>
+            </DecentTooltip>
           ) : (
             ShowVotingPowerButton
           )}

--- a/src/components/pages/DAOTreasury/components/AssetCoin.tsx
+++ b/src/components/pages/DAOTreasury/components/AssetCoin.tsx
@@ -1,9 +1,10 @@
-import { Divider, HStack, Flex, Tooltip, Text, Image, Box } from '@chakra-ui/react';
+import { Divider, HStack, Flex, Text, Image, Box } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { TokenBalance } from '../../../../types';
 import { MOCK_MORALIS_ETH_ADDRESS } from '../../../../utils/address';
 import { formatPercentage, formatUSD, formatCoin } from '../../../../utils/numberFormats';
+import { DecentTooltip } from '../../../ui/DecentTooltip';
 import EtherscanLink from '../../../ui/links/EtherscanLink';
 
 export function CoinHeader() {
@@ -96,12 +97,12 @@ export function CoinRow({ asset }: { asset: TokenBalance }) {
           width="100%"
           isTruncated
         >
-          <Tooltip
+          <DecentTooltip
             label={formatCoin(asset.balance, false, asset.decimals, asset.symbol)}
             placement="top-start"
           >
             {formatCoin(asset.balance, true, asset.decimals, asset.symbol, false)}
-          </Tooltip>
+          </DecentTooltip>
         </Text>
         {asset.usdPrice && asset.usdValue && (
           <Text
@@ -109,12 +110,12 @@ export function CoinRow({ asset }: { asset: TokenBalance }) {
             color="neutral-7"
             width="100%"
           >
-            <Tooltip
+            <DecentTooltip
               label={`1 ${asset.symbol} = ${formatUSD(asset.usdPrice)}`}
               placement="top-start"
             >
               {formatUSD(asset.usdValue)}
-            </Tooltip>
+            </DecentTooltip>
           </Text>
         )}
       </Flex>

--- a/src/components/pages/DAOTreasury/components/AssetDeFi.tsx
+++ b/src/components/pages/DAOTreasury/components/AssetDeFi.tsx
@@ -1,9 +1,10 @@
-import { Divider, HStack, Flex, Tooltip, Text, Image, Box } from '@chakra-ui/react';
+import { Divider, HStack, Flex, Text, Image, Box } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { DefiBalance } from '../../../../types';
 import { MOCK_MORALIS_ETH_ADDRESS } from '../../../../utils/address';
 import { formatPercentage, formatUSD, formatCoin } from '../../../../utils/numberFormats';
+import { DecentTooltip } from '../../../ui/DecentTooltip';
 import EtherscanLink from '../../../ui/links/EtherscanLink';
 
 export function DeFiHeader() {
@@ -72,7 +73,7 @@ export function DeFiRow({ asset }: { asset: DefiBalance }) {
         alignItems="center"
         gap="0.5rem"
       >
-        <Tooltip
+        <DecentTooltip
           label={tooltipLabel}
           placement="top-start"
         >
@@ -84,7 +85,7 @@ export function DeFiRow({ asset }: { asset: DefiBalance }) {
             w="1rem"
             h="1rem"
           />
-        </Tooltip>
+        </DecentTooltip>
         <EtherscanLink
           color="white-0"
           _hover={{ bg: 'transparent' }}
@@ -104,12 +105,12 @@ export function DeFiRow({ asset }: { asset: DefiBalance }) {
         flexWrap="wrap"
       >
         {asset.position?.balanceUsd && (
-          <Tooltip
+          <DecentTooltip
             label={tooltipLabel}
             placement="top-start"
           >
             <Text width="100%">{formatUSD(asset.position.balanceUsd)}</Text>
-          </Tooltip>
+          </DecentTooltip>
         )}
       </Flex>
 

--- a/src/components/pages/DAOTreasury/components/LidoButtons.tsx
+++ b/src/components/pages/DAOTreasury/components/LidoButtons.tsx
@@ -1,5 +1,6 @@
-import { Button, HStack, Text, Tooltip, Show, Divider } from '@chakra-ui/react';
+import { Button, HStack, Text, Show, Divider } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
+import { DecentTooltip } from '../../../ui/DecentTooltip';
 import useTreasuryLidoInteractions from '../hooks/useTreasuryLidoInteractions';
 
 export default function LidoButtons() {
@@ -49,7 +50,7 @@ export default function LidoButtons() {
               </Button>
             )}
             {showClaimETHButton && (
-              <Tooltip label={!isLidoClaimable ? t('nonClaimableYet') : ''}>
+              <DecentTooltip label={!isLidoClaimable ? t('nonClaimableYet') : ''}>
                 <Button
                   size="sm"
                   isDisabled={!isLidoClaimable}
@@ -57,7 +58,7 @@ export default function LidoButtons() {
                 >
                   {t('claimUnstakedETH')}
                 </Button>
-              </Tooltip>
+              </DecentTooltip>
             )}
           </HStack>
         </Show>

--- a/src/components/pages/DAOTreasury/components/Transactions.tsx
+++ b/src/components/pages/DAOTreasury/components/Transactions.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Center, Flex, HStack, Icon, Image, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Button, Center, Flex, HStack, Icon, Image, Text } from '@chakra-ui/react';
 import { ArrowDown, ArrowUp } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 import { getAddress } from 'viem';
@@ -6,6 +6,7 @@ import { useDateTimeDisplay } from '../../../../helpers/dateTime';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../../providers/NetworkConfig/NetworkConfigProvider';
 import { TokenEventType, TransferDisplayData, TransferType } from '../../../../types';
+import { DecentTooltip } from '../../../ui/DecentTooltip';
 import { DisplayAddress } from '../../../ui/links/DisplayAddress';
 import EtherscanLink from '../../../ui/links/EtherscanLink';
 import { BarLoader } from '../../../ui/loaders/BarLoader';
@@ -58,7 +59,7 @@ function TransferRow({ displayData }: { displayData: TransferDisplayData }) {
             w="1.25rem"
             h="1.25rem"
           />
-          <Tooltip
+          <DecentTooltip
             label={
               displayData.transferType === TransferType.ERC721_TRANSFER
                 ? undefined
@@ -77,7 +78,7 @@ function TransferRow({ displayData }: { displayData: TransferDisplayData }) {
               {(displayData.eventType == TokenEventType.WITHDRAW ? '- ' : '+ ') +
                 displayData.assetDisplay}
             </Text>
-          </Tooltip>
+          </DecentTooltip>
         </HStack>
         <HStack
           w="40%"

--- a/src/components/pages/DaoDashboard/Activities/ActivityFreeze.tsx
+++ b/src/components/pages/DaoDashboard/Activities/ActivityFreeze.tsx
@@ -1,10 +1,11 @@
-import { Flex, Text, Tooltip } from '@chakra-ui/react';
+import { Flex, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useDateTimeDisplay } from '../../../../helpers/dateTime';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { DAOState } from '../../../../types';
 import { ActivityCard } from '../../../Activity/ActivityCard';
 import { FreezeButton } from '../../../Activity/FreezeButton';
+import { DecentTooltip } from '../../../ui/DecentTooltip';
 import { Badge } from '../../../ui/badges/Badge';
 
 export function FreezeDescription({ isFrozen }: { isFrozen: boolean }) {
@@ -69,12 +70,12 @@ export function ActivityFreeze() {
         >
           <Text textStyle="text-base-sans-regular">
             {!isFrozen && freezeVotesThreshold !== null && freezeVotesThreshold > 0n && (
-              <Tooltip
+              <DecentTooltip
                 label={t('tipFreeze', { amount: voteToThreshold })}
                 placement="bottom"
               >
                 {voteToThreshold}
-              </Tooltip>
+              </DecentTooltip>
             )}
           </Text>
           {!isFreezeProposalDeadlinePassed && !isFreezeDeadlinePassed && (

--- a/src/components/ui/DecentTooltip.tsx
+++ b/src/components/ui/DecentTooltip.tsx
@@ -1,0 +1,13 @@
+import { Tooltip, TooltipProps } from '@chakra-ui/react';
+
+export function DecentTooltip(props: TooltipProps) {
+  return (
+    <Tooltip
+      hasArrow
+      placement="top-start"
+      backgroundColor="neutral-9"
+      color="black-0"
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/badges/Badge.tsx
+++ b/src/components/ui/badges/Badge.tsx
@@ -1,8 +1,9 @@
-import { Box, Flex, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Flex, Text } from '@chakra-ui/react';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TOOLTIP_MAXW } from '../../../constants/common';
 import { FractalProposalState, DAOState } from '../../../types';
+import { DecentTooltip } from '../DecentTooltip';
 
 type BadgeType = {
   tooltipKey?: string;
@@ -116,7 +117,7 @@ export function Badge({ labelKey, children, size }: IBadge) {
 
   const { t } = useTranslation('proposal');
   return (
-    <Tooltip
+    <DecentTooltip
       label={tooltipKey ? t(tooltipKey) : undefined}
       maxW={TOOLTIP_MAXW}
       placement="top"
@@ -146,6 +147,6 @@ export function Badge({ labelKey, children, size }: IBadge) {
           {children || t(labelKey)}
         </Text>
       </Flex>
-    </Tooltip>
+    </DecentTooltip>
   );
 }

--- a/src/components/ui/badges/SupportTooltip.tsx
+++ b/src/components/ui/badges/SupportTooltip.tsx
@@ -1,7 +1,8 @@
-import { Tooltip, TooltipProps, Icon } from '@chakra-ui/react';
+import { TooltipProps, Icon } from '@chakra-ui/react';
 import { Icon as PhosphorIcon, Question } from '@phosphor-icons/react';
 import { RefObject } from 'react';
 import { TOOLTIP_MAXW } from '../../../constants/common';
+import { DecentTooltip } from '../DecentTooltip';
 import ModalTooltip from '../modals/ModalTooltip';
 
 interface Props extends Omit<TooltipProps, 'children'> {
@@ -37,13 +38,13 @@ export default function SupportTooltip({ containerRef, IconComponent, ...rest }:
   }
 
   return (
-    <Tooltip
+    <DecentTooltip
       maxW={TOOLTIP_MAXW}
       placement="top"
       {...rest}
       color="white"
     >
       {icon}
-    </Tooltip>
+    </DecentTooltip>
   );
 }

--- a/src/components/ui/forms/LabelWrapper.tsx
+++ b/src/components/ui/forms/LabelWrapper.tsx
@@ -1,5 +1,6 @@
-import { Box, Flex, FormLabel, Text, Tooltip, Image } from '@chakra-ui/react';
+import { Box, Flex, FormLabel, Text, Image } from '@chakra-ui/react';
 import { Info } from '@phosphor-icons/react';
+import { DecentTooltip } from '../DecentTooltip';
 
 // @todo there is some type cleanup needed here
 export interface LabelWrapperProps {
@@ -36,13 +37,13 @@ function LabelWrapper({
           <Text>{label}</Text>
           {isRequired && <Text color="lilac-0">*</Text>}
           {!!tooltipContent && (
-            <Tooltip
+            <DecentTooltip
               hasArrow
               label={tooltipContent}
               closeDelay={500}
             >
               <Info />
-            </Tooltip>
+            </DecentTooltip>
           )}
         </Flex>
         {children}

--- a/src/components/ui/icons/FavoriteIcon.tsx
+++ b/src/components/ui/icons/FavoriteIcon.tsx
@@ -1,10 +1,11 @@
-import { Box, BoxProps, Button, Tooltip, Icon, IconButton } from '@chakra-ui/react';
+import { Box, BoxProps, Button, Icon, IconButton } from '@chakra-ui/react';
 import { Star } from '@phosphor-icons/react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address } from 'viem';
 import { useAccountFavorites } from '../../../hooks/DAO/loaders/useFavorites';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
+import { DecentTooltip } from '../DecentTooltip';
 
 interface Props extends BoxProps {
   safeAddress: Address;
@@ -20,7 +21,7 @@ export function FavoriteIcon({ safeAddress, ...rest }: Props) {
   const { t } = useTranslation();
   return (
     <Box {...rest}>
-      <Tooltip label={t('favoriteTooltip')}>
+      <DecentTooltip label={t('favoriteTooltip')}>
         <Button
           variant="tertiary"
           size="icon-md"
@@ -39,7 +40,7 @@ export function FavoriteIcon({ safeAddress, ...rest }: Props) {
           }}
           aria-label={t('favoriteTooltip')}
         />
-      </Tooltip>
+      </DecentTooltip>
     </Box>
   );
 }

--- a/src/components/ui/menus/OptionMenu/index.tsx
+++ b/src/components/ui/menus/OptionMenu/index.tsx
@@ -1,7 +1,8 @@
-import { Menu, MenuButton, MenuList, As, MenuProps, Tooltip, Portal, Box } from '@chakra-ui/react';
+import { Menu, MenuButton, MenuList, As, MenuProps, Portal, Box } from '@chakra-ui/react';
 import { MouseEvent, ReactNode, RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NEUTRAL_2_82_TRANSPARENT } from '../../../../constants/common';
+import { DecentTooltip } from '../../DecentTooltip';
 import { EaseOutComponent } from '../../utils/EaseOutComponent';
 import { OptionsList } from './OptionsList';
 import { IOption, IOptionsList } from './types';
@@ -69,7 +70,7 @@ export function OptionMenu({
       isLazy
       {...rest}
     >
-      <Tooltip
+      <DecentTooltip
         closeDelay={0}
         hasArrow
         label={tooltipKey ? t(tooltipKey) : undefined}
@@ -84,7 +85,7 @@ export function OptionMenu({
         >
           {trigger}
         </MenuButton>
-      </Tooltip>
+      </DecentTooltip>
       {containerRef !== undefined ? (
         <Portal containerRef={containerRef}>{menuList}</Portal>
       ) : (

--- a/src/components/ui/modals/ModalTooltip.tsx
+++ b/src/components/ui/modals/ModalTooltip.tsx
@@ -1,5 +1,6 @@
-import { Portal, Tooltip, TooltipProps } from '@chakra-ui/react';
+import { Portal, TooltipProps } from '@chakra-ui/react';
 import { ReactNode, RefObject } from 'react';
+import { DecentTooltip } from '../DecentTooltip';
 
 interface Props extends TooltipProps {
   containerRef: RefObject<HTMLElement | null>;
@@ -19,7 +20,7 @@ interface Props extends TooltipProps {
 export default function ModalTooltip({ containerRef, children, ...rest }: Props) {
   return (
     <Portal containerRef={containerRef}>
-      <Tooltip {...rest}>{children}</Tooltip>
+      <DecentTooltip {...rest}>{children}</DecentTooltip>
     </Portal>
   );
 }

--- a/src/components/ui/page/Navigation/NavigationTooltip.tsx
+++ b/src/components/ui/page/Navigation/NavigationTooltip.tsx
@@ -1,9 +1,10 @@
-import { Center, Tooltip } from '@chakra-ui/react';
+import { Center } from '@chakra-ui/react';
+import { DecentTooltip } from '../../DecentTooltip';
 
 export function NavigationTooltip({ label, children }: { label: string; children: JSX.Element }) {
   return (
     <Center>
-      <Tooltip
+      <DecentTooltip
         closeDelay={250}
         gutter={10}
         hasArrow
@@ -11,7 +12,7 @@ export function NavigationTooltip({ label, children }: { label: string; children
         placement="right"
       >
         {children}
-      </Tooltip>
+      </DecentTooltip>
     </Center>
   );
 }

--- a/src/components/ui/proposal/InfoRow.tsx
+++ b/src/components/ui/proposal/InfoRow.tsx
@@ -1,5 +1,6 @@
-import { Box, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Text } from '@chakra-ui/react';
 import DisplayTransaction from '../../ui/links/DisplayTransaction';
+import { DecentTooltip } from '../DecentTooltip';
 
 export default function InfoRow({
   property,
@@ -31,7 +32,7 @@ export default function InfoRow({
           <Text>{value}</Text>
         )
       ) : (
-        <Tooltip label={tooltip}>
+        <DecentTooltip label={tooltip}>
           {txHash ? (
             <DisplayTransaction
               isTextLink
@@ -40,7 +41,7 @@ export default function InfoRow({
           ) : (
             <Text color="white-0">{value}</Text>
           )}
-        </Tooltip>
+        </DecentTooltip>
       )}
     </Box>
   );

--- a/src/components/ui/proposal/ProposalCountdown.tsx
+++ b/src/components/ui/proposal/ProposalCountdown.tsx
@@ -1,4 +1,4 @@
-import { ComponentWithAs, Flex, IconProps, Text, Tooltip } from '@chakra-ui/react';
+import { ComponentWithAs, Flex, IconProps, Text } from '@chakra-ui/react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Execute } from '../../../assets/theme/custom/icons/Execute';
@@ -6,6 +6,7 @@ import { Lock } from '../../../assets/theme/custom/icons/Lock';
 import { Vote } from '../../../assets/theme/custom/icons/Vote';
 import useSnapshotProposal from '../../../hooks/DAO/loaders/snapshot/useSnapshotProposal';
 import { FractalProposal, FractalProposalState } from '../../../types';
+import { DecentTooltip } from '../DecentTooltip';
 import { useProposalCountdown } from './useProposalCountdown';
 
 /** pads a zero to the start of a number so that it is always 2 characters, e.g. '03' */
@@ -76,7 +77,7 @@ export function ProposalCountdown({
   const showSeconds = secondsLeft >= 0;
 
   return (
-    <Tooltip
+    <DecentTooltip
       label={tooltipLabel}
       placement="top"
     >
@@ -100,6 +101,6 @@ export function ProposalCountdown({
           </Text>
         </Flex>
       </Flex>
-    </Tooltip>
+    </DecentTooltip>
   );
 }

--- a/src/i18n/locales/en/proposal.json
+++ b/src/i18n/locales/en/proposal.json
@@ -112,7 +112,7 @@
   "customNonce": "Custom Nonce (advanced)",
   "customNonceTrimmed": "Custom Nonce",
   "customNonceTooltip": "Optionally set a custom proposal nonce to avoid collisions.",
-  "notActiveNonceTooltip": "There is a proposal with a lower nonce that must be executed first. If you have recently executed all lower nonce proposals, please reload in a few minutes.",
+  "notActiveNonceTooltip": "A proposal with a lower nonce must be executed first. If you've already executed all lower nonce proposals, please reload in a few minutes.",
   "nonce": "Nonce",
   "votingTooltip": "Time remaining to cast your vote.",
   "timeLockedTooltip": "This proposal can be executed once its timelock period has passed.",


### PR DESCRIPTION
All tooltips across the app should now look like this:

<img width="468" alt="Screenshot 2024-11-01 at 17 33 46" src="https://github.com/user-attachments/assets/ed0ae1e9-7b56-48dc-a574-6ec5b0649572">

@decentdao/engineering 
I couldn't use the tooltip theme to add the tooltip arrow to all the tooltips -- it simply refused to work. Also, even when I manually set `hasArrow`, for some reason I _also_ have to set `backgroundColor` _inline_ for the arrow to show. Using `backgroundColor` on the theme alone caused the arrow NOT to show.

So I've elected to create a custom `DecentTooltip` component and have all files import from it instead.

I don't like it, so hoping there's a much less invasive way to do this.