### PR TITLE
Add all contract tests to `useMasterCopy`

### DIFF
--- a/src/hooks/utils/useMasterCopy.ts
+++ b/src/hooks/utils/useMasterCopy.ts
@@ -133,7 +133,6 @@ export function useMasterCopy() {
       }
 
       return {
-        address: masterCopyAddress,
         isLinearVotingErc20: isLinearVotingErc20(masterCopyAddress),
         isLinearVotingErc721: isLinearVotingErc721(masterCopyAddress),
         isFreezeGuardMultisig: isFreezeGuardMultisig(masterCopyAddress),

--- a/src/hooks/utils/useMasterCopy.ts
+++ b/src/hooks/utils/useMasterCopy.ts
@@ -3,12 +3,12 @@ import { useCallback } from 'react';
 import { Address, getContract, zeroAddress } from 'viem';
 import { usePublicClient } from 'wagmi';
 import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
-// import { CacheExpiry, CacheKeys } from './cache/cacheDefaults';
-// import { getValue, setValue } from './cache/useLocalStorage';
+import { CacheExpiry, CacheKeys } from './cache/cacheDefaults';
+import { getValue, setValue } from './cache/useLocalStorage';
 
 export function useMasterCopy() {
   const {
-    // chain,
+    chain,
     contracts: {
       zodiacModuleProxyFactory,
       zodiacModuleProxyFactoryOld,
@@ -61,12 +61,12 @@ export function useMasterCopy() {
         return [zeroAddress, null] as const;
       }
 
-      // const cachedValue = getValue({
-      //   cacheName: CacheKeys.MASTER_COPY,
-      //   chainId: chain.id,
-      //   proxyAddress,
-      // });
-      // if (cachedValue) return [cachedValue, null] as const;
+      const cachedValue = getValue({
+        cacheName: CacheKeys.MASTER_COPY,
+        chainId: chain.id,
+        proxyAddress,
+      });
+      if (cachedValue) return [cachedValue, null] as const;
 
       const moduleProxyFactoryContract = getContract({
         abi: abis.ModuleProxyFactory,
@@ -79,15 +79,15 @@ export function useMasterCopy() {
         .then(proxiesCreated => {
           // @dev to prevent redundant queries, cache the master copy address as AddressZero if no proxies were created
           if (proxiesCreated.length === 0) {
-            // setValue(
-            //   {
-            //     cacheName: CacheKeys.MASTER_COPY,
-            //     chainId: chain.id,
-            //     proxyAddress,
-            //   },
-            //   zeroAddress,
-            //   CacheExpiry.ONE_WEEK,
-            // );
+            setValue(
+              {
+                cacheName: CacheKeys.MASTER_COPY,
+                chainId: chain.id,
+                proxyAddress,
+              },
+              zeroAddress,
+              CacheExpiry.ONE_WEEK,
+            );
             return [zeroAddress, 'No proxies created'] as const;
           }
 
@@ -96,21 +96,21 @@ export function useMasterCopy() {
             return [zeroAddress, 'No master copy address'] as const;
           }
 
-          // setValue(
-          //   {
-          //     cacheName: CacheKeys.MASTER_COPY,
-          //     chainId: chain.id,
-          //     proxyAddress,
-          //   },
-          //   masterCopyAddress,
-          // );
+          setValue(
+            {
+              cacheName: CacheKeys.MASTER_COPY,
+              chainId: chain.id,
+              proxyAddress,
+            },
+            masterCopyAddress,
+          );
           return [masterCopyAddress, null] as const;
         })
         .catch(() => {
           return [zeroAddress, 'error'] as const;
         });
     },
-    [publicClient],
+    [chain.id, publicClient],
   );
 
   const getZodiacModuleProxyMasterCopyData = useCallback(

--- a/src/hooks/utils/useMasterCopy.ts
+++ b/src/hooks/utils/useMasterCopy.ts
@@ -12,37 +12,47 @@ export function useMasterCopy() {
     contracts: {
       zodiacModuleProxyFactory,
       zodiacModuleProxyFactoryOld,
+
+      claimErc20MasterCopy,
+
       linearVotingErc20MasterCopy,
+      linearVotingErc20WrappedMasterCopy,
       linearVotingErc721MasterCopy,
+
       moduleFractalMasterCopy,
       moduleAzoriusMasterCopy,
+
       freezeGuardMultisigMasterCopy,
-      freezeVotingErc721MasterCopy,
+      freezeGuardAzoriusMasterCopy,
+
       freezeVotingMultisigMasterCopy,
+      freezeVotingErc20MasterCopy,
+      freezeVotingErc721MasterCopy,
+
+      votesErc20MasterCopy,
+      votesErc20WrapperMasterCopy,
     },
   } = useNetworkConfig();
   const publicClient = usePublicClient();
+
+  const isClaimErc20 = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === claimErc20MasterCopy,
+    [claimErc20MasterCopy],
+  );
 
   const isLinearVotingErc20 = useCallback(
     (masterCopyAddress: Address) => masterCopyAddress === linearVotingErc20MasterCopy,
     [linearVotingErc20MasterCopy],
   );
+  const isLinearVotingErc20Wrapped = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === linearVotingErc20WrappedMasterCopy,
+    [linearVotingErc20WrappedMasterCopy],
+  );
   const isLinearVotingErc721 = useCallback(
     (masterCopyAddress: Address) => masterCopyAddress === linearVotingErc721MasterCopy,
     [linearVotingErc721MasterCopy],
   );
-  const isFreezeGuardMultisig = useCallback(
-    (masterCopyAddress: Address) => masterCopyAddress === freezeGuardMultisigMasterCopy,
-    [freezeGuardMultisigMasterCopy],
-  );
-  const isFreezeVotingMultisig = useCallback(
-    (masterCopyAddress: Address) => masterCopyAddress === freezeVotingMultisigMasterCopy,
-    [freezeVotingMultisigMasterCopy],
-  );
-  const isFreezeVotingErc721 = useCallback(
-    (masterCopyAddress: Address) => masterCopyAddress === freezeVotingErc721MasterCopy,
-    [freezeVotingErc721MasterCopy],
-  );
+
   const isModuleAzorius = useCallback(
     (masterCopyAddress: Address) => masterCopyAddress === moduleAzoriusMasterCopy,
     [moduleAzoriusMasterCopy],
@@ -50,6 +60,37 @@ export function useMasterCopy() {
   const isModuleFractal = useCallback(
     (masterCopyAddress: Address) => masterCopyAddress === moduleFractalMasterCopy,
     [moduleFractalMasterCopy],
+  );
+
+  const isFreezeGuardMultisig = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === freezeGuardMultisigMasterCopy,
+    [freezeGuardMultisigMasterCopy],
+  );
+  const isFreezeGuardAzorius = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === freezeGuardAzoriusMasterCopy,
+    [freezeGuardAzoriusMasterCopy],
+  );
+
+  const isFreezeVotingMultisig = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === freezeVotingMultisigMasterCopy,
+    [freezeVotingMultisigMasterCopy],
+  );
+  const isFreezeVotingErc20 = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === freezeVotingErc20MasterCopy,
+    [freezeVotingErc20MasterCopy],
+  );
+  const isFreezeVotingErc721 = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === freezeVotingErc721MasterCopy,
+    [freezeVotingErc721MasterCopy],
+  );
+
+  const isVotesErc20 = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === votesErc20MasterCopy,
+    [votesErc20MasterCopy],
+  );
+  const isVotesErc20Wrapper = useCallback(
+    (masterCopyAddress: Address) => masterCopyAddress === votesErc20WrapperMasterCopy,
+    [votesErc20WrapperMasterCopy],
   );
 
   const getMasterCopyAddress = useCallback(
@@ -133,24 +174,41 @@ export function useMasterCopy() {
       }
 
       return {
+        isClaimErc20: isClaimErc20(masterCopyAddress),
+
         isLinearVotingErc20: isLinearVotingErc20(masterCopyAddress),
+        isLinearVotingErc20Wrapped: isLinearVotingErc20Wrapped(masterCopyAddress),
         isLinearVotingErc721: isLinearVotingErc721(masterCopyAddress),
-        isFreezeGuardMultisig: isFreezeGuardMultisig(masterCopyAddress),
-        isFreezeVotingMultisig: isFreezeVotingMultisig(masterCopyAddress),
-        isFreezeVotingErc721: isFreezeVotingErc721(masterCopyAddress),
+
         isModuleAzorius: isModuleAzorius(masterCopyAddress),
         isModuleFractal: isModuleFractal(masterCopyAddress),
+
+        isFreezeGuardMultisig: isFreezeGuardMultisig(masterCopyAddress),
+        isFreezeGuardAzorius: isFreezeGuardAzorius(masterCopyAddress),
+
+        isFreezeVotingMultisig: isFreezeVotingMultisig(masterCopyAddress),
+        isFreezeVotingErc20: isFreezeVotingErc20(masterCopyAddress),
+        isFreezeVotingErc721: isFreezeVotingErc721(masterCopyAddress),
+
+        isVotesErc20: isVotesErc20(masterCopyAddress),
+        isVotesErc20Wrapper: isVotesErc20Wrapper(masterCopyAddress),
       };
     },
     [
       getMasterCopyAddress,
+      isClaimErc20,
+      isFreezeGuardAzorius,
       isFreezeGuardMultisig,
+      isFreezeVotingErc20,
       isFreezeVotingErc721,
       isFreezeVotingMultisig,
       isLinearVotingErc20,
+      isLinearVotingErc20Wrapped,
       isLinearVotingErc721,
       isModuleAzorius,
       isModuleFractal,
+      isVotesErc20,
+      isVotesErc20Wrapper,
       zodiacModuleProxyFactory,
       zodiacModuleProxyFactoryOld,
     ],

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -62,6 +62,7 @@ export const baseConfig: NetworkConfig = {
     zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
+    linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),
     linearVotingErc721MasterCopy: getAddress(a.LinearERC721Voting),
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -61,6 +61,7 @@ export const mainnetConfig: NetworkConfig = {
     zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
+    linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),
     linearVotingErc721MasterCopy: getAddress(a.LinearERC721Voting),
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -61,6 +61,7 @@ export const optimismConfig: NetworkConfig = {
     zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
+    linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),
     linearVotingErc721MasterCopy: getAddress(a.LinearERC721Voting),
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -61,6 +61,7 @@ export const polygonConfig: NetworkConfig = {
     zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
+    linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),
     linearVotingErc721MasterCopy: getAddress(a.LinearERC721Voting),
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -61,6 +61,7 @@ export const sepoliaConfig: NetworkConfig = {
     zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
+    linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),
     linearVotingErc721MasterCopy: getAddress(a.LinearERC721Voting),
 
     moduleAzoriusMasterCopy: getAddress(a.Azorius),

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -35,6 +35,7 @@ export type NetworkConfig = {
     zodiacModuleProxyFactoryOld: Address;
 
     linearVotingErc20MasterCopy: Address;
+    linearVotingErc20WrappedMasterCopy: Address;
     linearVotingErc721MasterCopy: Address;
 
     moduleAzoriusMasterCopy: Address;


### PR DESCRIPTION
- Includes the COMPLETELY UNUSED (which is probably a bug) `linearVotingErc20WrappedMasterCopy` contract into our network config.
  - Still not actually using this anywhere, but we probably should. I bet this should be deployed as the strategy when we wrap a user's existing ERC20 token.
- Re-adds the caching back into `useMasterCopy` (it's been well over a week since it was disabled, which is the time after which those caches went stale, so it's safe to re-enable them).
- Remove an unused `address` property from object returned from `getZodiacModuleProxyMasterCopyData` function which comes from `useMasterCopy` hook
- Add _all_ of the non-singleton contracts to `useMasterCopy`.
  - Some are already there, but not all. Why, you ask? Probably because there are lots of places in the app where we simply assume that addresses are the contracts that we think they are.
  - This PR doesn't address the above assumptions, but plenty of new PRs are coming which do explicitly check that. We don't ever want to just assume that an address holds the code we expect it to.