### PR TITLE
Master copy erc20claim

### DIFF
--- a/src/hooks/DAO/loaders/governance/useERC20Claim.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20Claim.ts
@@ -4,10 +4,7 @@ import { getContract } from 'viem';
 import { usePublicClient } from 'wagmi';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import { FractalGovernanceAction } from '../../../../providers/App/governance/action';
-// get list of approvals; approval [0] should be token claim
-// query using attach = masterTokenClaim.attach(approval[0]).queryFilter()
-// check if module is tokenClaim;
-// set token claim;
+import { useMasterCopy } from '../../../utils/useMasterCopy';
 
 export function useERC20Claim() {
   const {
@@ -16,6 +13,8 @@ export function useERC20Claim() {
     action,
   } = useFractal();
   const publicClient = usePublicClient();
+
+  const { getZodiacModuleProxyMasterCopyData } = useMasterCopy();
 
   const loadTokenClaimContract = useCallback(async () => {
     if (!votesTokenAddress || !publicClient) {
@@ -36,21 +35,8 @@ export function useERC20Claim() {
       return;
     }
 
-    const possibleTokenClaimContract = getContract({
-      abi: abis.ERC20Claim,
-      address: approvals[0].args.spender,
-      client: publicClient,
-    });
-
-    const tokenClaimArray = await possibleTokenClaimContract.getEvents
-      .ERC20ClaimCreated({ fromBlock: 0n })
-      .catch(() => []);
-
-    if (!tokenClaimArray.length) return;
-
-    const childToken = tokenClaimArray[0].args.childToken;
-
-    if (!childToken || childToken === votesTokenAddress) {
+    const { isClaimErc20 } = await getZodiacModuleProxyMasterCopyData(approvals[0].args.spender);
+    if (!isClaimErc20) {
       return;
     }
 
@@ -59,7 +45,7 @@ export function useERC20Claim() {
       type: FractalGovernanceAction.SET_CLAIMING_CONTRACT,
       payload: approvals[0].args.spender,
     });
-  }, [action, publicClient, votesTokenAddress]);
+  }, [action, getZodiacModuleProxyMasterCopyData, publicClient, votesTokenAddress]);
 
   const loadKey = useRef<string>();
 

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -202,7 +202,7 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
       return { ...state, votesToken: { ...votesToken, ...action.payload } };
     }
     case FractalGovernanceAction.SET_CLAIMING_CONTRACT: {
-      return { ...state, tokenClaimContract: action.payload };
+      return { ...state, tokenClaimContractAddress: action.payload };
     }
     case FractalGovernanceAction.RESET_TOKEN_ACCOUNT_DATA: {
       const { votesToken } = state as AzoriusGovernance;


### PR DESCRIPTION
Review and merge #2442 first

- Fix a typo in the governance reducer -- seems like we were not correctly setting the `tokenClaimContractAddress` in state, very likely leading to bugs on DAOs that had tokens for their users to claim!
- utilize the new `isClaimErc20` boolean from `useMasterCopy` to confirm that the fetched address is in fact an instance of the ERC20Claim contract
  - We were checking it before, but it was a kind of wild method and this new pattern is an improvement and more standardized.

Asks:

- Would appreciate others to poke around in the codebase and make sure I didn't miss any more places where we should be verifying that _some address that we grabbed from the blockchain_ is indeed this `ERC20Claim` contract instead of just assuming it is for some reason.