### PR TITLE
`[BUGFIX]` rename getStreamsWithFundsToClaimFromFromHat -> getStreamsWithFundsToClaimNotCancelling

### DIFF
--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -411,7 +411,7 @@ export default function useCreateRoles() {
     [prepareBatchLinearStreamCreation],
   );
 
-  const getStreamsWithFundsToClaimFromFromHat = useCallback((formHat: RoleHatFormValueEdited) => {
+  const getStreamsWithFundsToClaimNotCancelling = useCallback((formHat: RoleHatFormValueEdited) => {
     return (formHat.payments ?? []).filter(
       payment => (payment?.withdrawableAmount ?? 0n) > 0n && !payment.isCancelling,
     );
@@ -596,7 +596,7 @@ export default function useCreateRoles() {
               throw new Error('Cannot find original hat');
             }
 
-            const streamsWithFundsToClaim = getStreamsWithFundsToClaimFromFromHat(formHat);
+            const streamsWithFundsToClaim = getStreamsWithFundsToClaimNotCancelling(formHat);
 
             if (streamsWithFundsToClaim.length) {
               // If there are unclaimed funds on any streams on the hat, we need to flush them to the original wearer.
@@ -744,7 +744,7 @@ export default function useCreateRoles() {
       prepareCancelStreamTxs,
       uploadHatDescription,
       hatsDetailsBuilder,
-      getStreamsWithFundsToClaimFromFromHat,
+      getStreamsWithFundsToClaimNotCancelling,
       getCancelledStreamsFromFormHat,
       getNewStreamsFromFormHat,
       predictSmartAccount,

--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -411,7 +411,7 @@ export default function useCreateRoles() {
     [prepareBatchLinearStreamCreation],
   );
 
-  const getStreamsWithFundsToClaimNotCancelling = useCallback((formHat: RoleHatFormValueEdited) => {
+  const getMemberChangedStreamsWithFundsToClaim = useCallback((formHat: RoleHatFormValueEdited) => {
     return (formHat.payments ?? []).filter(
       payment => (payment?.withdrawableAmount ?? 0n) > 0n && !payment.isCancelling,
     );
@@ -425,7 +425,7 @@ export default function useCreateRoles() {
     return (formHat.payments ?? []).filter(payment => payment.isCancelling && !!payment.streamId);
   }, []);
 
-  const getStreamsWithFundsToClaimFromFormHat = useCallback((formHat: RoleHatFormValueEdited) => {
+  const getRoleRemovedStreamsWithFundsToClaim = useCallback((formHat: RoleHatFormValueEdited) => {
     return (formHat.payments ?? []).filter(payment => (payment?.withdrawableAmount ?? 0n) > 0n);
   }, []);
 
@@ -511,7 +511,7 @@ export default function useCreateRoles() {
             targetAddress: hatsProtocol,
           });
 
-          const streamsWithFundsToClaim = getStreamsWithFundsToClaimFromFormHat(formHat);
+          const streamsWithFundsToClaim = getRoleRemovedStreamsWithFundsToClaim(formHat);
 
           if (streamsWithFundsToClaim.length) {
             // This role is being removed.
@@ -596,7 +596,7 @@ export default function useCreateRoles() {
               throw new Error('Cannot find original hat');
             }
 
-            const streamsWithFundsToClaim = getStreamsWithFundsToClaimNotCancelling(formHat);
+            const streamsWithFundsToClaim = getMemberChangedStreamsWithFundsToClaim(formHat);
 
             if (streamsWithFundsToClaim.length) {
               // If there are unclaimed funds on any streams on the hat, we need to flush them to the original wearer.
@@ -738,13 +738,13 @@ export default function useCreateRoles() {
       prepareNewHatTxs,
       getHat,
       hatsProtocol,
-      getStreamsWithFundsToClaimFromFormHat,
+      getRoleRemovedStreamsWithFundsToClaim,
       getActiveStreamsFromFormHat,
       prepareFlushStreamTxs,
       prepareCancelStreamTxs,
       uploadHatDescription,
       hatsDetailsBuilder,
-      getStreamsWithFundsToClaimNotCancelling,
+      getMemberChangedStreamsWithFundsToClaim,
       getCancelledStreamsFromFormHat,
       getNewStreamsFromFormHat,
       predictSmartAccount,


### PR DESCRIPTION
Closes #2446 

So looking into it. 

- `getStreamsWithFundsToClaimFromFromHat`: 
  - is used during `member change` action. 
  - filters for `withdrawableAmount` and `isCancelling` (which indicates the user has set this payment to be cancelled)

- `getStreamsWithFundsToClaimFromFormHat`:
  - is used during `role removed` action
  
  Looking into it. When the role is removed. all streams are cancelled and flushed. so the user can't add in additionally to cancel individual streams. In the case of `member change` we track that if a stream is marked for cancelling that it is ignored  when looking at what streams to flush during that section and handled in the `payments` section
  
  