### PR TITLE
Update fractal contracts package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@fontsource/space-mono": "^5.0.19",
         "@fractal-framework/fractal-contracts": "^1.3.1",
         "@graphprotocol/client-apollo": "^1.0.16",
+        "@hatsprotocol/modules-sdk": "^1.4.0",
         "@hatsprotocol/sdk-v1-core": "^0.9.0",
         "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
         "@hotjar/browser": "^1.0.9",
@@ -7544,6 +7545,30 @@
       "peer": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hatsprotocol/modules-sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@hatsprotocol/modules-sdk/-/modules-sdk-1.4.0.tgz",
+      "integrity": "sha512-j9taBBNSTJWGuJq/vmURHJFyvG8jb3xq0xAbs22fZV/aQlkNB/7uHJ7ZT1Q0ZWGy0fjYOxw1ATWZhY1MnIt6gA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.5.0",
+        "zod": "^3.21.4"
+      },
+      "peerDependencies": {
+        "viem": "^1.11.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@hatsprotocol/modules-sdk/node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@hatsprotocol/sdk-v1-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",
         "@fontsource/space-mono": "^5.0.19",
-        "@fractal-framework/fractal-contracts": "^1.2.17",
+        "@fractal-framework/fractal-contracts": "^1.3.1",
         "@graphprotocol/client-apollo": "^1.0.16",
         "@hatsprotocol/sdk-v1-core": "^0.9.0",
         "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
@@ -4969,9 +4969,9 @@
       "integrity": "sha512-gz9yaKtXCY+HutNvQ4APc15xwZ1f6pWXve5N55x5m/hOoGqgB9Auf3l7CitHNhNJkSKEmaM45M29b0rFeudXlg=="
     },
     "node_modules/@fractal-framework/fractal-contracts": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-1.2.17.tgz",
-      "integrity": "sha512-+FWJJ2jsx2GMLQ0wumV6s3oX+pJUKf9pBO20qc9Cz4YgqXbIDlqyk6svhc+DuRKzHjGYib2xSd6q7kC0WsIUng==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/fractal-contracts/-/fractal-contracts-1.3.1.tgz",
+      "integrity": "sha512-S/Vrpk8cUn85qo4tomP/ddcXLaAoDmC052QZVyKgGm3BWHgwUCozQ/W5FmolxI4aYdj/rjcvAX26bNlOnf4e6w==",
       "license": "MIT",
       "dependencies": {
         "@gnosis.pm/zodiac": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@ethersproject/abstract-signer": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
     "@fontsource/space-mono": "^5.0.19",
-    "@fractal-framework/fractal-contracts": "^1.2.17",
+    "@fractal-framework/fractal-contracts": "^1.3.1",
     "@graphprotocol/client-apollo": "^1.0.16",
     "@hatsprotocol/sdk-v1-core": "^0.9.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fontsource/space-mono": "^5.0.19",
     "@fractal-framework/fractal-contracts": "^1.3.1",
     "@graphprotocol/client-apollo": "^1.0.16",
+    "@hatsprotocol/modules-sdk": "^1.4.0",
     "@hatsprotocol/sdk-v1-core": "^0.9.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
     "@hotjar/browser": "^1.0.9",

--- a/src/assets/abi/ZodiacModuleProxyFactoryAbi.ts
+++ b/src/assets/abi/ZodiacModuleProxyFactoryAbi.ts
@@ -1,0 +1,38 @@
+export const ZodiacModuleProxyFactoryAbi = [
+  { inputs: [], name: 'FailedInitialization', type: 'error' },
+  {
+    inputs: [{ internalType: 'address', name: 'address_', type: 'address' }],
+    name: 'TakenAddress',
+    type: 'error',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'target', type: 'address' }],
+    name: 'TargetHasNoCode',
+    type: 'error',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'target', type: 'address' }],
+    name: 'ZeroAddress',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'proxy', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'masterCopy', type: 'address' },
+    ],
+    name: 'ModuleProxyCreation',
+    type: 'event',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'masterCopy', type: 'address' },
+      { internalType: 'bytes', name: 'initializer', type: 'bytes' },
+      { internalType: 'uint256', name: 'saltNonce', type: 'uint256' },
+    ],
+    name: 'deployModule',
+    outputs: [{ internalType: 'address', name: 'proxy', type: 'address' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;

--- a/src/components/pages/Roles/types.tsx
+++ b/src/components/pages/Roles/types.tsx
@@ -80,10 +80,11 @@ export interface HatStruct {
   imageURI: string;
   isMutable: boolean; // true
   wearer: Address;
+  termEndDateTs: 0n;
 }
 
 export interface HatStructWithPayments extends HatStruct {
-  sablierParams: {
+  sablierStreamsParams: {
     sablier: Address;
     sender: Address;
     totalAmount: bigint;

--- a/src/hooks/DAO/loaders/useHatsTree.ts
+++ b/src/hooks/DAO/loaders/useHatsTree.ts
@@ -34,7 +34,6 @@ const useHatsTree = () => {
       hatsProtocol,
       erc6551Registry,
       hatsAccount1ofNMasterCopy: hatsAccountImplementation,
-      decentHatsMasterCopy,
     },
   } = useNetworkConfig();
   const publicClient = usePublicClient();
@@ -46,7 +45,6 @@ const useHatsTree = () => {
         hatsTreeId === undefined ||
         hatsTreeId === null ||
         publicClient === undefined ||
-        decentHatsMasterCopy === undefined ||
         contextChainId === null
       ) {
         return;
@@ -141,7 +139,6 @@ const useHatsTree = () => {
     getHatsTree();
   }, [
     contextChainId,
-    decentHatsMasterCopy,
     erc6551Registry,
     hatsAccountImplementation,
     hatsProtocol,

--- a/src/hooks/streams/useCreateSablierStream.ts
+++ b/src/hooks/streams/useCreateSablierStream.ts
@@ -18,7 +18,7 @@ export function convertStreamIdToBigInt(streamId: string) {
 
 export default function useCreateSablierStream() {
   const {
-    contracts: { sablierV2LockupLinear, sablierV2Batch, decentSablierMasterCopy },
+    contracts: { sablierV2LockupLinear, sablierV2Batch, decentSablierStreamManagementModule },
   } = useNetworkConfig();
   const {
     node: { daoAddress },
@@ -89,17 +89,17 @@ export default function useCreateSablierStream() {
       const enableModuleData = encodeFunctionData({
         abi: GnosisSafeL2,
         functionName: 'enableModule',
-        args: [decentSablierMasterCopy],
+        args: [decentSablierStreamManagementModule],
       });
 
       const disableModuleData = encodeFunctionData({
         abi: GnosisSafeL2,
         functionName: 'disableModule',
-        args: [SENTINEL_MODULE, decentSablierMasterCopy],
+        args: [SENTINEL_MODULE, decentSablierStreamManagementModule],
       });
 
       const withdrawMaxFromStreamData = encodeFunctionData({
-        abi: abis.DecentSablierStreamManagement,
+        abi: abis.DecentSablierStreamManagementModule,
         functionName: 'withdrawMaxFromStream',
         args: [sablierV2LockupLinear, smartAccount, convertStreamIdToBigInt(streamId), to],
       });
@@ -110,7 +110,7 @@ export default function useCreateSablierStream() {
           calldata: enableModuleData,
         },
         {
-          targetAddress: decentSablierMasterCopy,
+          targetAddress: decentSablierStreamManagementModule,
           calldata: withdrawMaxFromStreamData,
         },
         {
@@ -119,7 +119,7 @@ export default function useCreateSablierStream() {
         },
       ];
     },
-    [daoAddress, decentSablierMasterCopy, sablierV2LockupLinear],
+    [daoAddress, decentSablierStreamManagementModule, sablierV2LockupLinear],
   );
 
   const prepareCancelStreamTxs = useCallback(
@@ -131,17 +131,17 @@ export default function useCreateSablierStream() {
       const enableModuleData = encodeFunctionData({
         abi: GnosisSafeL2,
         functionName: 'enableModule',
-        args: [decentSablierMasterCopy],
+        args: [decentSablierStreamManagementModule],
       });
 
       const disableModuleData = encodeFunctionData({
         abi: GnosisSafeL2,
         functionName: 'disableModule',
-        args: [SENTINEL_MODULE, decentSablierMasterCopy],
+        args: [SENTINEL_MODULE, decentSablierStreamManagementModule],
       });
 
       const cancelStreamData = encodeFunctionData({
-        abi: abis.DecentSablierStreamManagement,
+        abi: abis.DecentSablierStreamManagementModule,
         functionName: 'cancelStream',
         args: [sablierV2LockupLinear, convertStreamIdToBigInt(streamId)],
       });
@@ -152,7 +152,7 @@ export default function useCreateSablierStream() {
           calldata: enableModuleData,
         },
         {
-          targetAddress: decentSablierMasterCopy,
+          targetAddress: decentSablierStreamManagementModule,
           calldata: cancelStreamData,
         },
         {
@@ -161,7 +161,7 @@ export default function useCreateSablierStream() {
         },
       ];
     },
-    [daoAddress, decentSablierMasterCopy, sablierV2LockupLinear],
+    [daoAddress, decentSablierStreamManagementModule, sablierV2LockupLinear],
   );
 
   const prepareBatchLinearStreamCreation = useCallback(

--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -1,4 +1,5 @@
 import { abis } from '@fractal-framework/fractal-contracts';
+import { HATS_MODULES_FACTORY_ADDRESS } from '@hatsprotocol/modules-sdk';
 import { FormikHelpers } from 'formik';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +18,6 @@ import {
   RoleHatFormValueEdited,
   SablierPaymentFormValues,
 } from '../../components/pages/Roles/types';
-import { ERC6551_REGISTRY_SALT } from '../../constants/common';
 import { DAO_ROUTES } from '../../constants/routes';
 import { useFractal } from '../../providers/App/AppProvider';
 import useIPFSClient from '../../providers/App/hooks/useIPFSClient';
@@ -40,11 +40,15 @@ export default function useCreateRoles() {
     chain,
     contracts: {
       hatsProtocol,
-      decentHatsMasterCopy,
+      decentHatsCreationModule,
+      decentHatsModificationModule,
       hatsAccount1ofNMasterCopy,
       erc6551Registry,
       keyValuePairs,
       sablierV2LockupLinear,
+      zodiacModuleProxyFactory,
+      decentAutonomousAdminV1MasterCopy,
+      hatsElectionsEligibilityMasterCopy,
     },
   } = useNetworkConfig();
 
@@ -87,6 +91,7 @@ export default function useCreateRoles() {
         imageURI: '',
         isMutable: true,
         wearer: wearer,
+        termEndDateTs: 0n,
       };
 
       return newHat;
@@ -115,7 +120,7 @@ export default function useCreateRoles() {
 
       const newHatWithPayments: HatStructWithPayments = {
         ...newHat,
-        sablierParams: payments.map(payment => ({
+        sablierStreamsParams: payments.map(payment => ({
           sablier: sablierV2LockupLinear,
           sender: daoAddress,
           totalAmount: payment.totalAmount,
@@ -203,21 +208,21 @@ export default function useCreateRoles() {
     [publicClient, hatsAccount1ofNMasterCopy, chain.id, hatsProtocol, erc6551Registry],
   );
 
-  const getEnableDisableDecentHatsModuleData = useCallback(() => {
+  const getEnableDisableDecentHatsModuleData = useCallback((moduleAddress: Address) => {
     const enableDecentHatsModuleData = encodeFunctionData({
       abi: GnosisSafeL2,
       functionName: 'enableModule',
-      args: [decentHatsMasterCopy],
+      args: [moduleAddress],
     });
 
     const disableDecentHatsModuleData = encodeFunctionData({
       abi: GnosisSafeL2,
       functionName: 'disableModule',
-      args: [SENTINEL_MODULE, decentHatsMasterCopy],
+      args: [SENTINEL_MODULE, moduleAddress],
     });
 
     return { enableDecentHatsModuleData, disableDecentHatsModuleData };
-  }, [decentHatsMasterCopy]);
+  }, []);
 
   const prepareCreateTopHatProposalData = useCallback(
     async (proposalMetadata: CreateProposalMetadata, modifiedHats: RoleHatFormValueEdited[]) => {
@@ -226,7 +231,7 @@ export default function useCreateRoles() {
       }
 
       const { enableDecentHatsModuleData, disableDecentHatsModuleData } =
-        getEnableDisableDecentHatsModuleData();
+        getEnableDisableDecentHatsModuleData(decentHatsCreationModule);
 
       const topHatDetails = await uploadHatDescription(
         hatsDetailsBuilder({
@@ -241,36 +246,37 @@ export default function useCreateRoles() {
         }),
       );
 
-      const adminHat: HatStructWithPayments = {
-        maxSupply: 1,
-        details: adminHatDetails,
-        imageURI: '',
-        isMutable: true,
-        wearer: zeroAddress,
-        sablierParams: [],
-      };
-
       const addedHats = await createHatStructsForNewTreeFromRolesFormValues(modifiedHats);
 
       const createAndDeclareTreeData = encodeFunctionData({
-        abi: abis.DecentHats_0_1_0,
+        abi: abis.DecentHatsCreationModule,
         functionName: 'createAndDeclareTree',
         args: [
           {
             hatsProtocol,
+            erc6551Registry,
+            hatsModuleFactory: HATS_MODULES_FACTORY_ADDRESS,
+            moduleProxyFactory: zodiacModuleProxyFactory,
+            keyValuePairs,
+            decentAutonomousAdminImplementation: decentAutonomousAdminV1MasterCopy,
             hatsAccountImplementation: hatsAccount1ofNMasterCopy,
-            registry: erc6551Registry,
-            keyValuePairs: getAddress(keyValuePairs),
-            topHatDetails,
-            topHatImageURI: '',
-            adminHat,
+            hatsElectionsEligibilityImplementation: hatsElectionsEligibilityMasterCopy,
+            topHat: {
+              details: topHatDetails,
+              imageURI: '',
+            },
+            adminHat: {
+              details: adminHatDetails,
+              imageURI: '',
+              isMutable: true,
+            },
             hats: addedHats,
           },
         ],
       });
 
       return {
-        targets: [daoAddress, decentHatsMasterCopy, daoAddress],
+        targets: [daoAddress, decentHatsCreationModule, daoAddress],
         calldatas: [
           enableDecentHatsModuleData,
           createAndDeclareTreeData,
@@ -291,7 +297,10 @@ export default function useCreateRoles() {
       hatsAccount1ofNMasterCopy,
       erc6551Registry,
       keyValuePairs,
-      decentHatsMasterCopy,
+      decentHatsCreationModule,
+      decentAutonomousAdminV1MasterCopy,
+      hatsElectionsEligibilityMasterCopy,
+      zodiacModuleProxyFactory,
     ],
   );
 
@@ -325,41 +334,33 @@ export default function useCreateRoles() {
       );
 
       const { enableDecentHatsModuleData, disableDecentHatsModuleData } =
-        getEnableDisableDecentHatsModuleData();
+        getEnableDisableDecentHatsModuleData(decentHatsModificationModule);
 
       const createNewRoleData = encodeFunctionData({
-        abi: abis.DecentHats_0_1_0,
-        functionName: 'createRoleHat',
+        abi: abis.DecentHatsModificationModule,
+        functionName: 'createRoleHats',
         args: [
-          hatsProtocol,
-          BigInt(hatsTree.adminHat.id),
-          hatStruct,
-          BigInt(hatsTree.topHat.id),
-          hatsTree.topHat.smartAddress,
-          erc6551Registry,
-          hatsAccount1ofNMasterCopy,
-          ERC6551_REGISTRY_SALT,
+          {
+            hatsProtocol,
+            erc6551Registry,
+            hatsAccountImplementation: hatsAccount1ofNMasterCopy,
+            topHatId: BigInt(hatsTree.topHat.id),
+            topHatAccount: hatsTree.topHat.smartAddress,
+            hatsModuleFactory: HATS_MODULES_FACTORY_ADDRESS,
+            hatsElectionsEligibilityImplementation: hatsElectionsEligibilityMasterCopy,
+            adminHatId: BigInt(hatsTree.adminHat.id),
+            hats: [hatStruct],
+          },
         ],
       });
 
-      // Transfer top hat to the DecentHats module so it is authorised to create hats on the tree
-      const transferTopHatToDecentHatsData = encodeFunctionData({
-        abi: HatsAbi,
-        functionName: 'transferHat',
-        args: [BigInt(hatsTree.topHat.id), daoAddress, decentHatsMasterCopy],
-      });
-
       return [
-        {
-          targetAddress: hatsProtocol,
-          calldata: transferTopHatToDecentHatsData,
-        },
         {
           targetAddress: daoAddress,
           calldata: enableDecentHatsModuleData,
         },
         {
-          targetAddress: decentHatsMasterCopy,
+          targetAddress: decentHatsModificationModule,
           calldata: createNewRoleData,
         },
         {
@@ -369,15 +370,16 @@ export default function useCreateRoles() {
       ];
     },
     [
-      hatsTree,
-      daoAddress,
       createHatStructWithPayments,
-      parseSablierPaymentsFromFormRolePayments,
-      getEnableDisableDecentHatsModuleData,
-      hatsProtocol,
+      daoAddress,
+      decentHatsModificationModule,
       erc6551Registry,
+      getEnableDisableDecentHatsModuleData,
       hatsAccount1ofNMasterCopy,
-      decentHatsMasterCopy,
+      hatsElectionsEligibilityMasterCopy,
+      hatsProtocol,
+      hatsTree,
+      parseSablierPaymentsFromFormRolePayments,
     ],
   );
 

--- a/src/models/AzoriusTxBuilder.ts
+++ b/src/models/AzoriusTxBuilder.ts
@@ -14,6 +14,7 @@ import {
   getAddress,
 } from 'viem';
 import GnosisSafeL2Abi from '../assets/abi/GnosisSafeL2';
+import { ZodiacModuleProxyFactoryAbi } from '../assets/abi/ZodiacModuleProxyFactoryAbi';
 import { buildContractCall, getRandomBytes } from '../helpers';
 import {
   SafeTransaction,
@@ -213,7 +214,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
 
   public buildCreateTokenTx(): SafeTransaction {
     return buildContractCall(
-      abis.ModuleProxyFactory,
+      ZodiacModuleProxyFactoryAbi,
       this.zodiacModuleProxyFactory,
       'deployModule',
       [this.votesErc20MasterCopy, this.encodedSetupTokenData, this.tokenNonce],
@@ -226,7 +227,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
     const daoData = this.daoData as AzoriusGovernanceDAO;
 
     return buildContractCall(
-      abis.ModuleProxyFactory,
+      ZodiacModuleProxyFactoryAbi,
       this.zodiacModuleProxyFactory,
       'deployModule',
       [
@@ -243,7 +244,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
 
   public buildDeployAzoriusTx(): SafeTransaction {
     return buildContractCall(
-      abis.ModuleProxyFactory,
+      ZodiacModuleProxyFactoryAbi,
       this.zodiacModuleProxyFactory,
       'deployModule',
       [this.moduleAzoriusMasterCopy, this.encodedSetupAzoriusData, this.azoriusNonce],
@@ -254,7 +255,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
 
   public buildDeployTokenClaim() {
     return buildContractCall(
-      abis.ModuleProxyFactory,
+      ZodiacModuleProxyFactoryAbi,
       this.zodiacModuleProxyFactory,
       'deployModule',
       [this.claimErc20MasterCopy, this.encodedSetupTokenClaimData, this.claimNonce],
@@ -281,7 +282,7 @@ export class AzoriusTxBuilder extends BaseTxBuilder {
 
   public buildCreateTokenWrapperTx(): SafeTransaction {
     return buildContractCall(
-      abis.ModuleProxyFactory,
+      ZodiacModuleProxyFactoryAbi,
       this.zodiacModuleProxyFactory,
       'deployModule',
       [this.votesErc20WrapperMasterCopy, this.encodedSetupERC20WrapperData, this.tokenNonce],

--- a/src/models/FreezeGuardTxBuilder.ts
+++ b/src/models/FreezeGuardTxBuilder.ts
@@ -12,6 +12,7 @@ import {
   encodeFunctionData,
 } from 'viem';
 import GnosisSafeL2Abi from '../assets/abi/GnosisSafeL2';
+import { ZodiacModuleProxyFactoryAbi } from '../assets/abi/ZodiacModuleProxyFactoryAbi';
 import { buildContractCall } from '../helpers';
 import { SafeTransaction, SubDAO, VotingStrategyType } from '../types';
 import { BaseTxBuilder } from './BaseTxBuilder';
@@ -95,7 +96,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
 
   public buildDeployZodiacModuleTx(): SafeTransaction {
     return buildContractCall(
-      abis.ModuleProxyFactory,
+      ZodiacModuleProxyFactoryAbi,
       this.zodiacModuleProxyFactory,
       'deployModule',
       [
@@ -172,7 +173,7 @@ export class FreezeGuardTxBuilder extends BaseTxBuilder {
 
   public buildDeployFreezeGuardTx() {
     return buildContractCall(
-      abis.ModuleProxyFactory,
+      ZodiacModuleProxyFactoryAbi,
       this.zodiacModuleProxyFactory,
       'deployModule',
       [this.getGuardMasterCopyAddress(), this.freezeGuardCallData!, this.saltNum],

--- a/src/models/helpers/fractalModuleData.ts
+++ b/src/models/helpers/fractalModuleData.ts
@@ -9,6 +9,7 @@ import {
   encodeFunctionData,
 } from 'viem';
 import GnosisSafeL2Abi from '../../assets/abi/GnosisSafeL2';
+import { ZodiacModuleProxyFactoryAbi } from '../../assets/abi/ZodiacModuleProxyFactoryAbi';
 import { buildContractCall } from '../../helpers/crypto';
 import { SafeTransaction } from '../../types';
 import { generateContractByteCodeLinear, generateSalt } from './utils';
@@ -44,7 +45,7 @@ export const fractalModuleData = (
   const fractalSalt = generateSalt(fractalModuleCalldata, saltNum);
 
   const deployFractalModuleTx = buildContractCall(
-    abis.ModuleProxyFactory,
+    ZodiacModuleProxyFactoryAbi,
     moduleProxyFactoryAddress,
     'deployModule',
     [fractalModuleMasterCopyAddress, fractalModuleCalldata, saltNum],

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -76,16 +76,22 @@ export const baseConfig: NetworkConfig = {
 
     votesErc20MasterCopy: getAddress(a.VotesERC20),
     votesErc20WrapperMasterCopy: getAddress(a.VotesERC20Wrapper),
+
     claimErc20MasterCopy: getAddress(a.ERC20Claim),
+
+    decentAutonomousAdminV1MasterCopy: getAddress(a.DecentAutonomousAdminV1),
 
     fractalRegistry: getAddress(a.FractalRegistry),
     keyValuePairs: getAddress(a.KeyValuePairs),
-    decentHatsMasterCopy: getAddress(a.DecentHats_0_1_0),
-    decentSablierMasterCopy: getAddress(a.DecentSablierStreamManagement),
+
+    decentHatsCreationModule: getAddress(a.DecentHatsCreationModule),
+    decentHatsModificationModule: getAddress(a.DecentHatsModificationModule),
+    decentSablierStreamManagementModule: getAddress(a.DecentSablierStreamManagementModule),
 
     hatsProtocol: '0x3bc1A0Ad72417f2d411118085256fC53CBdDd137',
     erc6551Registry: '0x000000006551c19487814612e58FE06813775758',
     hatsAccount1ofNMasterCopy: '0xfEf83A660b7C10a3EdaFdCF62DEee1fD8a875D29',
+    hatsElectionsEligibilityMasterCopy: '0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E',
     sablierV2Batch: '0xc1c548F980669615772dadcBfEBC29937c29481A',
     sablierV2LockupDynamic: '0xF9E9eD67DD2Fab3b3ca024A2d66Fcf0764d36742',
     sablierV2LockupTranched: '0xf4937657Ed8B3f3cB379Eed47b8818eE947BEb1e',

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -59,7 +59,6 @@ export const baseConfig: NetworkConfig = {
     ),
 
     zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
-    zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
     linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -78,14 +78,19 @@ export const mainnetConfig: NetworkConfig = {
 
     claimErc20MasterCopy: getAddress(a.ERC20Claim),
 
+    decentAutonomousAdminV1MasterCopy: getAddress(a.DecentAutonomousAdminV1),
+
     fractalRegistry: getAddress(a.FractalRegistry),
     keyValuePairs: getAddress(a.KeyValuePairs),
-    decentHatsMasterCopy: getAddress(a.DecentHats_0_1_0),
-    decentSablierMasterCopy: getAddress(a.DecentSablierStreamManagement),
+
+    decentHatsCreationModule: getAddress(a.DecentHatsCreationModule),
+    decentHatsModificationModule: getAddress(a.DecentHatsModificationModule),
+    decentSablierStreamManagementModule: getAddress(a.DecentSablierStreamManagementModule),
 
     hatsProtocol: '0x3bc1A0Ad72417f2d411118085256fC53CBdDd137',
     erc6551Registry: '0x000000006551c19487814612e58FE06813775758',
     hatsAccount1ofNMasterCopy: '0xfEf83A660b7C10a3EdaFdCF62DEee1fD8a875D29',
+    hatsElectionsEligibilityMasterCopy: '0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E',
     sablierV2Batch: '0xB5Ec9706C3Be9d22326D208f491E5DEef7C8d9f0',
     sablierV2LockupDynamic: '0x9DeaBf7815b42Bf4E9a03EEc35a486fF74ee7459',
     sablierV2LockupTranched: '0xf86B359035208e4529686A1825F2D5BeE38c28A8',

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -58,7 +58,6 @@ export const mainnetConfig: NetworkConfig = {
     ),
 
     zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
-    zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
     linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -78,14 +78,19 @@ export const optimismConfig: NetworkConfig = {
 
     claimErc20MasterCopy: getAddress(a.ERC20Claim),
 
+    decentAutonomousAdminV1MasterCopy: getAddress(a.DecentAutonomousAdminV1),
+
     fractalRegistry: getAddress(a.FractalRegistry),
     keyValuePairs: getAddress(a.KeyValuePairs),
-    decentHatsMasterCopy: getAddress(a.DecentHats_0_1_0),
-    decentSablierMasterCopy: getAddress(a.DecentSablierStreamManagement),
+
+    decentHatsCreationModule: getAddress(a.DecentHatsCreationModule),
+    decentHatsModificationModule: getAddress(a.DecentHatsModificationModule),
+    decentSablierStreamManagementModule: getAddress(a.DecentSablierStreamManagementModule),
 
     hatsProtocol: '0x3bc1A0Ad72417f2d411118085256fC53CBdDd137',
     erc6551Registry: '0x000000006551c19487814612e58FE06813775758',
     hatsAccount1ofNMasterCopy: '0xfEf83A660b7C10a3EdaFdCF62DEee1fD8a875D29',
+    hatsElectionsEligibilityMasterCopy: '0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E',
     sablierV2Batch: '0x6cd7bB0f63aFCc9F6CeDd1Bf1E3Bd4ED078CD019',
     sablierV2LockupDynamic: '0x4994325F8D4B4A36Bd643128BEb3EC3e582192C0',
     sablierV2LockupTranched: '0x90952912a50079bef00D5F49c975058d6573aCdC',

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -58,7 +58,6 @@ export const optimismConfig: NetworkConfig = {
     ),
 
     zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
-    zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
     linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -78,14 +78,19 @@ export const polygonConfig: NetworkConfig = {
 
     claimErc20MasterCopy: getAddress(a.ERC20Claim),
 
+    decentAutonomousAdminV1MasterCopy: getAddress(a.DecentAutonomousAdminV1),
+
     fractalRegistry: getAddress(a.FractalRegistry),
     keyValuePairs: getAddress(a.KeyValuePairs),
-    decentHatsMasterCopy: getAddress(a.DecentHats_0_1_0),
-    decentSablierMasterCopy: getAddress(a.DecentSablierStreamManagement),
+
+    decentHatsCreationModule: getAddress(a.DecentHatsCreationModule),
+    decentHatsModificationModule: getAddress(a.DecentHatsModificationModule),
+    decentSablierStreamManagementModule: getAddress(a.DecentSablierStreamManagementModule),
 
     hatsProtocol: '0x3bc1A0Ad72417f2d411118085256fC53CBdDd137',
     erc6551Registry: '0x000000006551c19487814612e58FE06813775758',
     hatsAccount1ofNMasterCopy: '0xfEf83A660b7C10a3EdaFdCF62DEee1fD8a875D29',
+    hatsElectionsEligibilityMasterCopy: '0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E',
     sablierV2Batch: '0x6cd7bB0f63aFCc9F6CeDd1Bf1E3Bd4ED078CD019',
     sablierV2LockupDynamic: '0x4994325F8D4B4A36Bd643128BEb3EC3e582192C0',
     sablierV2LockupTranched: '0xBF67f0A1E847564D0eFAD475782236D3Fa7e9Ec2',

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -58,7 +58,6 @@ export const polygonConfig: NetworkConfig = {
     ),
 
     zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
-    zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
     linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -58,7 +58,6 @@ export const sepoliaConfig: NetworkConfig = {
     ),
 
     zodiacModuleProxyFactory: '0x000000000000aDdB49795b0f9bA5BC298cDda236',
-    zodiacModuleProxyFactoryOld: getAddress(a.ModuleProxyFactory),
 
     linearVotingErc20MasterCopy: getAddress(a.LinearERC20Voting),
     linearVotingErc20WrappedMasterCopy: getAddress(a.LinearERC20WrappedVoting),

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -78,14 +78,19 @@ export const sepoliaConfig: NetworkConfig = {
 
     claimErc20MasterCopy: getAddress(a.ERC20Claim),
 
+    decentAutonomousAdminV1MasterCopy: getAddress(a.DecentAutonomousAdminV1),
+
     fractalRegistry: getAddress(a.FractalRegistry),
     keyValuePairs: getAddress(a.KeyValuePairs),
-    decentHatsMasterCopy: getAddress(a.DecentHats_0_1_0),
-    decentSablierMasterCopy: getAddress(a.DecentSablierStreamManagement),
+
+    decentHatsCreationModule: getAddress(a.DecentHatsCreationModule),
+    decentHatsModificationModule: getAddress(a.DecentHatsModificationModule),
+    decentSablierStreamManagementModule: getAddress(a.DecentSablierStreamManagementModule),
 
     hatsProtocol: '0x3bc1A0Ad72417f2d411118085256fC53CBdDd137',
     erc6551Registry: '0x000000006551c19487814612e58FE06813775758',
     hatsAccount1ofNMasterCopy: '0xfEf83A660b7C10a3EdaFdCF62DEee1fD8a875D29',
+    hatsElectionsEligibilityMasterCopy: '0xd3b916a8F0C4f9D1d5B6Af29c3C012dbd4f3149E',
     sablierV2Batch: '0x04A9c14b7a000640419aD5515Db4eF4172C00E31',
     sablierV2LockupDynamic: '0x73BB6dD3f5828d60F8b3dBc8798EB10fbA2c5636',
     sablierV2LockupTranched: '0x3a1beA13A8C24c0EA2b8fAE91E4b2762A59D7aF5',

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -52,15 +52,19 @@ export type NetworkConfig = {
 
     claimErc20MasterCopy: Address;
 
+    decentAutonomousAdminV1MasterCopy: Address;
+
     fractalRegistry: Address;
     keyValuePairs: Address;
 
-    decentHatsMasterCopy: Address;
-    decentSablierMasterCopy: Address;
+    decentHatsCreationModule: Address;
+    decentHatsModificationModule: Address;
+    decentSablierStreamManagementModule: Address;
 
     hatsProtocol: Address;
     erc6551Registry: Address;
     hatsAccount1ofNMasterCopy: Address;
+    hatsElectionsEligibilityMasterCopy: Address;
     sablierV2Batch: Address;
     sablierV2LockupDynamic: Address;
     sablierV2LockupTranched: Address;

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -32,7 +32,6 @@ export type NetworkConfig = {
     multiSendCallOnly: Address;
 
     zodiacModuleProxyFactory: Address;
-    zodiacModuleProxyFactoryOld: Address;
 
     linearVotingErc20MasterCopy: Address;
     linearVotingErc20WrappedMasterCopy: Address;


### PR DESCRIPTION
Brings in the new version of `@fractal-framework/fractal-contracts`, which includes a number of breaking changes, which are fixed in this PR:

- ZodiacModuleProxyFactory (neither address nor ABI) is no longer exported from `fractal-contracts`
  - This PR adds the ABI as an import in `src/assets/abis`, and removes the `zodiacModuleProxyFactoryOld` property from Network Config
- Cleanup: removes an unused reference from a `useEffect` dependency
- Adds the `@hatsprotocol/modules-sdk` package, to get access to the "module factory" deployment address
- Updates names of some existing contract addresses in NetworkConfig, and add a few more
  - `decentHatsMasterCopy` variable has been broken up into `decentHatsCreationModule` and `decentHatsModificationModule` variables
    - !!! It's not a "Master Copy". "MasterCopy" nomenclature is reserved for contracts which we create proxy copies of !!!
  - `decentSablierMasterCopy` variable has been renamed to `decentSablierStreamManagementModule`
    - !!! It's not a "Master Copy". "MasterCopy" nomenclature is reserved for contracts which we create proxy copies of !!!
  - New contract addresses: `decentAutonomousAdminV1MasterCopy`, `hatsElectionsEligibilityMasterCopy`