### PR TITLE
Fix Shutter not loading on mainnet

### DIFF
--- a/src/hooks/utils/useAddressContractType.ts
+++ b/src/hooks/utils/useAddressContractType.ts
@@ -177,21 +177,13 @@ const contractTests: ContractFunctionTest[] = [
   },
   {
     abi: combineAbis(abis.VotesERC20, abis.VotesERC20Wrapper),
-    functionNames: ['DOMAIN_SEPARATOR', 'decimals', 'name', 'owner', 'symbol', 'totalSupply'],
+    functionNames: ['decimals', 'name', 'owner', 'symbol', 'totalSupply'],
     revertFunctionNames: ['underlying'],
     resultKey: 'isVotesErc20',
   },
   {
     abi: abis.VotesERC20Wrapper,
-    functionNames: [
-      'DOMAIN_SEPARATOR',
-      'decimals',
-      'name',
-      'owner',
-      'symbol',
-      'totalSupply',
-      'underlying',
-    ],
+    functionNames: ['decimals', 'name', 'owner', 'symbol', 'totalSupply', 'underlying'],
     resultKey: 'isVotesErc20Wrapper',
   },
 ];


### PR DESCRIPTION
Remove DOMAIN_SEPARATOR from `isVotesErc20` and `isVotesErc20Wrapper` fingerprint.

I ran this change through my test repo, and all tests on sepolia still passed. So, this `DOMAIN_SEPARATOR` part of the fingerprint that I removed wasn't required to produce a unique fingerprint.