### PR TITLE
Revert global bigint serialization

### DIFF
--- a/src/hooks/utils/cache/migrations/2.ts
+++ b/src/hooks/utils/cache/migrations/2.ts
@@ -1,0 +1,13 @@
+const deleteProposalCache = (proposalKeys: string[]) => {
+  proposalKeys.forEach(key => {
+    localStorage.removeItem(key);
+  });
+};
+
+//@dev for testing seperated the function from the hook and export
+export default function migration2() {
+  const allV0ProposalKeys = Object.keys(localStorage).filter(key =>
+    key.startsWith('{"cacheName":"Proposal"'),
+  );
+  deleteProposalCache(allV0ProposalKeys);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,6 @@ import './insights';
 import { useNetworkConfig } from './providers/NetworkConfig/NetworkConfigProvider';
 import Providers from './providers/Providers';
 import { router } from './router';
-import './utils/polyfills';
 
 function DecentRouterProvider() {
   const { addressPrefix } = useNetworkConfig();

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,8 +1,0 @@
-declare global {
-  interface BigInt {
-    /** Convert BigInt to string form in JSON.stringify */
-    toJSON: () => string;
-  }
-}
-
-export {};

--- a/src/utils/polyfills.ts
+++ b/src/utils/polyfills.ts
@@ -1,3 +1,0 @@
-BigInt.prototype.toJSON = function () {
-  return this.toString();
-};


### PR DESCRIPTION
This was causing bad proposal data to get cached in local storage, resulting in crashes on prod.

Also need to delete cached proposal data because yeah, it was cached and it was bad.