### PR TITLE
Explicitly enable default tracking to silence browser console warning

### DIFF
--- a/src/insights/amplitude.ts
+++ b/src/insights/amplitude.ts
@@ -7,5 +7,7 @@ export const initAmplitude = () => {
     return;
   }
 
-  amplitude.init(amplitudeApiKey);
+  amplitude.init(amplitudeApiKey, {
+    defaultTracking: true,
+  });
 };


### PR DESCRIPTION
On prod, get this warning in the console:

<img width="1430" alt="Screenshot 2024-11-12 at 9 08 25 AM" src="https://github.com/user-attachments/assets/f3615c7a-8965-474b-a95a-2d62f0b3168c">

This PR exists to silence that warning.