### PR TITLE
Don't get stuck in a loop when loading voting components

### DIFF
--- a/src/components/Proposals/ProposalActions/CastVote.tsx
+++ b/src/components/Proposals/ProposalActions/CastVote.tsx
@@ -64,6 +64,7 @@ export function CastVote({ proposal }: { proposal: FractalProposal }) {
     azoriusProposal.state !== FractalProposalState.ACTIVE ||
     proposalStartBlockNotFinalized ||
     canVoteLoading ||
+    hasVoted ||
     hasVotedLoading;
 
   if (snapshotProposal && extendedSnapshotProposal) {

--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -1,5 +1,13 @@
 import { abis } from '@fractal-framework/fractal-contracts';
-import { useContext, useCallback, useEffect, useState, createContext, ReactNode } from 'react';
+import {
+  useContext,
+  useCallback,
+  useEffect,
+  useState,
+  createContext,
+  ReactNode,
+  useRef,
+} from 'react';
 import { getContract } from 'viem';
 import { usePublicClient } from 'wagmi';
 import useSnapshotProposal from '../../../../hooks/DAO/loaders/snapshot/useSnapshotProposal';
@@ -140,10 +148,16 @@ export function VoteContextProvider({
       safe?.owners,
     ],
   );
+
+  const initialLoadRef = useRef(false);
   useEffect(() => {
+    // Prevent running this effect multiple times
+    if (initialLoadRef.current) return;
+    initialLoadRef.current = true;
+
     getCanVote();
     getHasVoted();
-  }, [getCanVote, getHasVoted, proposalVotesLength]);
+  }, [getCanVote, getHasVoted]);
 
   useEffect(() => {
     const azoriusProposal = proposal as AzoriusProposal;


### PR DESCRIPTION
(Mostly) fixes #2471

Still some weirdness around not automatically disabling the voting components after a successful vote, but whatever. It's much more important to actually let people vote, than signal to them they they've already voted _immediately after they just voted_