### PR TITLE
`BugFix` Pass SmartAddress to retrieve normal roles streams

### DIFF
--- a/src/hooks/DAO/loaders/useHatsTree.ts
+++ b/src/hooks/DAO/loaders/useHatsTree.ts
@@ -266,6 +266,7 @@ const useHatsTree = () => {
               return hat;
             }
             const payments: SablierPayment[] = [];
+            // @todo - update Datepicker to choose more precise dates (Date.now())
             if (hat.isTermed) {
               const recipients = hat.roleTerms.allTerms.map(term => term.nominee);
               const uniqueRecipients = [...new Set(recipients)];
@@ -273,7 +274,10 @@ const useHatsTree = () => {
                 payments.push(...(await getPaymentStreams(recipient)));
               }
             } else {
-              payments.push(...(await getPaymentStreams(hat.wearerAddress)));
+              if (!hat.smartAddress) {
+                throw new Error('Smart account address not found');
+              }
+              payments.push(...(await getPaymentStreams(hat.smartAddress)));
             }
 
             return { ...hat, payments };


### PR DESCRIPTION
Noticed that I was passing the `hat.wearerAddress` incorrectly to retrieve payments for normal roles.

This was while exploring a slightly annoying issue of termed payments and tying it to a single hat. But unrelated to this PR so pushed this commit up. See #2479