### PR TITLE
No more directly reading anything from FractalRegsistry

### DIFF
--- a/.graphclientrc.yml
+++ b/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: decent
     handler:
       graphql:
-        endpoint: https://api.studio.thegraph.com/query/{context.subgraphSpace:71032}/{context.subgraphSlug:fractal-mainnet}/{context.subgraphVersion:v0.1.1}
+        endpoint: https://api.studio.thegraph.com/query/{context.subgraphSpace:71032}/{context.subgraphSlug:fractal-mainnet}/{context.subgraphVersion:v0.1.2}
   - name: sablier
     handler:
       graphql:

--- a/src/components/DaoHierarchy/DaoHierarchyNode.tsx
+++ b/src/components/DaoHierarchy/DaoHierarchyNode.tsx
@@ -3,7 +3,6 @@ import { ArrowElbowDownRight } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { Address } from 'viem';
 import { useLoadDAONode } from '../../hooks/DAO/loaders/useLoadDAONode';
-import { useLoadDAOData } from '../../hooks/DAO/useDAOData';
 import { useFractal } from '../../providers/App/AppProvider';
 import { FractalNode, WithError } from '../../types';
 import { DAONodeInfoCard, NODE_HEIGHT_REM } from '../ui/cards/DAONodeInfoCard';
@@ -18,11 +17,9 @@ import { DAONodeInfoCard, NODE_HEIGHT_REM } from '../ui/cards/DAONodeInfoCard';
  * and display another DaoNode for each child, and so on for their children.
  */
 export function DaoHierarchyNode({
-  parentAddress,
   safeAddress,
   depth,
 }: {
-  parentAddress: Address | null;
   safeAddress: Address | null;
   depth: number;
 }) {
@@ -31,7 +28,6 @@ export function DaoHierarchyNode({
   } = useFractal();
   const [fractalNode, setNode] = useState<FractalNode>();
   const { loadDao } = useLoadDAONode();
-  const { daoData } = useLoadDAOData(parentAddress, fractalNode);
 
   useEffect(() => {
     if (safeAddress) {
@@ -63,11 +59,7 @@ export function DaoHierarchyNode({
       gap="1.25rem"
       width="100%"
     >
-      <DAONodeInfoCard
-        node={fractalNode}
-        freezeGuard={daoData?.freezeGuard}
-        guardContracts={daoData?.freezeGuardContracts}
-      />
+      <DAONodeInfoCard node={fractalNode} />
 
       {/* CHILD NODES */}
       {fractalNode?.nodeHierarchy.childNodes.map(childNode => (
@@ -85,7 +77,6 @@ export function DaoHierarchyNode({
           />
 
           <DaoHierarchyNode
-            parentAddress={safeAddress}
             safeAddress={childNode.address}
             depth={depth + 1}
           />

--- a/src/components/ui/cards/DAONodeInfoCard.tsx
+++ b/src/components/ui/cards/DAONodeInfoCard.tsx
@@ -4,7 +4,7 @@ import { DAO_ROUTES } from '../../../constants/routes';
 import { useGetAccountName } from '../../../hooks/utils/useGetAccountName';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { useNetworkConfig } from '../../../providers/NetworkConfig/NetworkConfigProvider';
-import { FractalGuardContracts, FractalNode, FreezeGuard } from '../../../types';
+import { FractalNode } from '../../../types';
 import { SnapshotButton } from '../badges/Snapshot';
 import { FavoriteIcon } from '../icons/FavoriteIcon';
 import AddressCopier from '../links/AddressCopier';
@@ -15,8 +15,6 @@ export const NODE_MARGIN_TOP_REM = 1.25;
 
 export interface InfoProps extends FlexProps {
   node?: FractalNode;
-  freezeGuard?: FreezeGuard;
-  guardContracts?: FractalGuardContracts;
 }
 
 /**
@@ -29,7 +27,7 @@ export interface InfoProps extends FlexProps {
  * Simply using the useFractal() hook to get info will end up with the current DAO's
  * context being displayed in ALL the node cards in a hierarchy, which is incorrect.
  */
-export function DAONodeInfoCard({ node, freezeGuard, guardContracts, ...rest }: InfoProps) {
+export function DAONodeInfoCard({ node, ...rest }: InfoProps) {
   const {
     node: { safe: currentSafe }, // used ONLY to determine if we're on the current DAO
   } = useFractal();

--- a/src/hooks/utils/useGetSafeName.ts
+++ b/src/hooks/utils/useGetSafeName.ts
@@ -1,16 +1,11 @@
-import { abis } from '@fractal-framework/fractal-contracts';
 import { useCallback } from 'react';
-import { Address, getContract } from 'viem';
+import { Address } from 'viem';
 import { usePublicClient } from 'wagmi';
-import { useNetworkConfig } from '../../providers/NetworkConfig/NetworkConfigProvider';
 import { demoData } from '../DAO/loaders/loadDemoData';
 import { createAccountSubstring } from './useGetAccountName';
 
 export const useGetSafeName = (chainId?: number) => {
   const publicClient = usePublicClient({ chainId });
-  const {
-    contracts: { fractalRegistry },
-  } = useNetworkConfig(chainId);
 
   const getSafeName = useCallback(
     async (address: Address) => {
@@ -31,22 +26,7 @@ export const useGetSafeName = (chainId?: number) => {
         return ensName;
       }
 
-      const fractalRegistryContract = getContract({
-        abi: abis.FractalRegistry,
-        address: fractalRegistry,
-        client: publicClient,
-      });
-
-      const events = await fractalRegistryContract.getEvents.FractalNameUpdated(
-        { daoAddress: address },
-        { fromBlock: 0n },
-      );
-
-      const latestEvent = events.pop();
-
-      if (latestEvent?.args.daoName) {
-        return latestEvent.args.daoName;
-      } else if (publicClient.chain && demoData[publicClient.chain.id]) {
+      if (publicClient.chain && demoData[publicClient.chain.id]) {
         const demo = demoData[publicClient.chain.id][address];
         if (demo && demo.name) {
           return demo.name;
@@ -55,7 +35,7 @@ export const useGetSafeName = (chainId?: number) => {
 
       return createAccountSubstring(address);
     },
-    [fractalRegistry, publicClient],
+    [publicClient],
   );
 
   return { getSafeName };

--- a/src/pages/dao/hierarchy/SafeHierarchyPage.tsx
+++ b/src/pages/dao/hierarchy/SafeHierarchyPage.tsx
@@ -51,7 +51,6 @@ export function SafeHierarchyPage() {
         ]}
       />
       <DaoHierarchyNode
-        parentAddress={null}
         safeAddress={parentAddress || safeAddress}
         depth={0}
       />

--- a/src/providers/NetworkConfig/networks/base.ts
+++ b/src/providers/NetworkConfig/networks/base.ts
@@ -28,7 +28,7 @@ export const baseConfig: NetworkConfig = {
   subgraph: {
     space: 71032,
     slug: 'fractal-base',
-    version: 'v0.1.1',
+    version: 'v0.1.2',
   },
   sablierSubgraph: {
     space: 57079,

--- a/src/providers/NetworkConfig/networks/mainnet.ts
+++ b/src/providers/NetworkConfig/networks/mainnet.ts
@@ -28,7 +28,7 @@ export const mainnetConfig: NetworkConfig = {
   subgraph: {
     space: 71032,
     slug: 'fractal-mainnet',
-    version: 'v0.1.1',
+    version: 'v0.1.2',
   },
   sablierSubgraph: {
     space: 57079,

--- a/src/providers/NetworkConfig/networks/optimism.ts
+++ b/src/providers/NetworkConfig/networks/optimism.ts
@@ -28,7 +28,7 @@ export const optimismConfig: NetworkConfig = {
   subgraph: {
     space: 71032,
     slug: 'fractal-optimism',
-    version: 'v0.1.1',
+    version: 'v0.1.2',
   },
   sablierSubgraph: {
     space: 57079,

--- a/src/providers/NetworkConfig/networks/polygon.ts
+++ b/src/providers/NetworkConfig/networks/polygon.ts
@@ -28,7 +28,7 @@ export const polygonConfig: NetworkConfig = {
   subgraph: {
     space: 71032,
     slug: 'fractal-base-polygon',
-    version: 'v0.1.1',
+    version: 'v0.1.2',
   },
   sablierSubgraph: {
     space: 57079,

--- a/src/providers/NetworkConfig/networks/sepolia.ts
+++ b/src/providers/NetworkConfig/networks/sepolia.ts
@@ -28,7 +28,7 @@ export const sepoliaConfig: NetworkConfig = {
   subgraph: {
     space: 71032,
     slug: 'fractal-sepolia',
-    version: 'v0.1.1',
+    version: 'v0.1.2',
   },
   sablierSubgraph: {
     space: 57079,


### PR DESCRIPTION
Closes #2440 

This PR does two things:

1. Removes unused props (and unused data loaders) from a couple of components.
2. Removes all (only one) direct log reads from FractalRegistry contract.
3. Bumps subgraph version to [v0.1.2](https://github.com/decentdao/decent-subgraph/tree/v0.1.2)