### PR TITLE
`Bugfix` Edit Role Link missing

### DIFF
--- a/src/hooks/utils/useCanUserSubmitProposal.ts
+++ b/src/hooks/utils/useCanUserSubmitProposal.ts
@@ -115,7 +115,7 @@ export function useCanUserCreateProposal() {
 
   useEffect(() => {
     const loadCanUserCreateProposal = async () => {
-      const newCanCreateProposal = isDemoMode() ?? (await getCanUserCreateProposal());
+      const newCanCreateProposal = isDemoMode() || (await getCanUserCreateProposal());
       if (newCanCreateProposal !== canUserCreateProposal) {
         setCanUserCreateProposal(newCanCreateProposal);
       }


### PR DESCRIPTION
Noticed that the Edit Role Button link was missing from the RolesPage. Noticed that we were using `??` here. For this case we would want `||` to capture the boolean `false`. 