### PR TITLE
Fix the logic for deleting permission

### DIFF
--- a/src/components/ui/modals/ConfirmDeleteStrategyModal.tsx
+++ b/src/components/ui/modals/ConfirmDeleteStrategyModal.tsx
@@ -28,8 +28,8 @@ export function ConfirmDeleteStrategyModal({ onClose }: { onClose: () => void })
     }
 
     if (
-      !governanceContracts.linearVotingErc20Address ||
-      !governanceContracts.linearVotingErc721Address
+      !governanceContracts.linearVotingErc20WithHatsWhitelistingAddress &&
+      !governanceContracts.linearVotingErc721WithHatsWhitelistingAddress
     ) {
       toast.error(t('cannotDeleteStrategy'));
       onClose();


### PR DESCRIPTION
There was a bug that you couldn't delete voting strategy with ERC-20 / ERC-721 token gating for proposal creation when you actually already have whitelisted role.
Fixed in this PR