### PR TITLE
Whitelisting voting strategy setup

### DIFF
--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -1,12 +1,12 @@
 import { abis } from '@fractal-framework/fractal-contracts';
 import {
-  useContext,
-  useCallback,
-  useEffect,
-  useState,
   createContext,
   ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
   useRef,
+  useState,
 } from 'react';
 import { getContract } from 'viem';
 import { usePublicClient } from 'wagmi';
@@ -14,12 +14,12 @@ import useSnapshotProposal from '../../../../hooks/DAO/loaders/snapshot/useSnaps
 import useUserERC721VotingTokens from '../../../../hooks/DAO/proposal/useUserERC721VotingTokens';
 import { useFractal } from '../../../../providers/App/AppProvider';
 import {
-  FractalProposal,
-  SnapshotProposal,
   AzoriusProposal,
-  MultisigProposal,
-  GovernanceType,
   ExtendedSnapshotProposal,
+  FractalProposal,
+  GovernanceType,
+  MultisigProposal,
+  SnapshotProposal,
 } from '../../../../types';
 
 interface IVoteContext {
@@ -63,7 +63,6 @@ export function VoteContextProvider({
     readOnly: { user, dao },
     node: { safe },
     governance: { type },
-    governanceContracts: { linearVotingErc20Address },
   } = useFractal();
 
   const { loadVotingWeight } = useSnapshotProposal(proposal as SnapshotProposal);
@@ -104,10 +103,14 @@ export function VoteContextProvider({
         if (snapshotProposal) {
           const votingWeightData = await loadVotingWeight();
           newCanVote = votingWeightData.votingWeight >= 1;
-        } else if (type === GovernanceType.AZORIUS_ERC20 && linearVotingErc20Address) {
+        } else if (
+          type === GovernanceType.AZORIUS_ERC20 ||
+          type === GovernanceType.AZORIUS_ERC20_HATS_WHITELISTING
+        ) {
+          const azoriusProposal = proposal as AzoriusProposal;
           const ozLinearVotingContract = getContract({
             abi: abis.LinearERC20Voting,
-            address: linearVotingErc20Address,
+            address: azoriusProposal.votingStrategy,
             client: publicClient,
           });
           newCanVote =
@@ -115,7 +118,10 @@ export function VoteContextProvider({
               user.address,
               Number(proposal.proposalId),
             ])) > 0n && !hasVoted;
-        } else if (type === GovernanceType.AZORIUS_ERC721) {
+        } else if (
+          type === GovernanceType.AZORIUS_ERC721 ||
+          type === GovernanceType.AZORIUS_ERC721_HATS_WHITELISTING
+        ) {
           if (refetchUserTokens) {
             await getUserERC721VotingTokens(null, null);
           }
@@ -139,13 +145,12 @@ export function VoteContextProvider({
       canVote,
       snapshotProposal,
       type,
-      linearVotingErc20Address,
       loadVotingWeight,
-      proposal.proposalId,
       hasVoted,
       remainingTokenIds.length,
       getUserERC721VotingTokens,
       safe?.owners,
+      proposal,
     ],
   );
 

--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -136,6 +136,8 @@ export default function useCreateRoles() {
 
         const quorumDenominator =
           await linearERC20VotingMasterCopyContract.read.QUORUM_DENOMINATOR();
+
+        console.log(votingStrategy.votingPeriod.value, Number(votingStrategy.votingPeriod.value));
         const encodedStrategyInitParams = encodeAbiParameters(
           parseAbiParameters(
             'address, address, address, uint32, uint256, uint256, address, uint256[]',

--- a/src/hooks/utils/useCreateRoles.ts
+++ b/src/hooks/utils/useCreateRoles.ts
@@ -79,7 +79,9 @@ export default function useCreateRoles() {
     node: { safe, daoName },
     governance,
     governanceContracts: {
+      linearVotingErc20Address,
       linearVotingErc20WithHatsWhitelistingAddress,
+      linearVotingErc721Address,
       linearVotingErc721WithHatsWhitelistingAddress,
       moduleAzoriusAddress,
     },
@@ -123,7 +125,7 @@ export default function useCreateRoles() {
       const azoriusGovernance = governance as AzoriusGovernance;
       const { votingStrategy, votesToken, erc721Tokens } = azoriusGovernance;
       if (azoriusGovernance.type === GovernanceType.AZORIUS_ERC20) {
-        if (!votesToken || !votingStrategy?.votingPeriod || !votingStrategy.quorumPercentage) {
+        if (!votesToken || !votingStrategy?.quorumPercentage || !linearVotingErc20Address) {
           return;
         }
 
@@ -137,7 +139,12 @@ export default function useCreateRoles() {
         const quorumDenominator =
           await linearERC20VotingMasterCopyContract.read.QUORUM_DENOMINATOR();
 
-        console.log(votingStrategy.votingPeriod.value, Number(votingStrategy.votingPeriod.value));
+        const votingStrategyContract = getContract({
+          abi: abis.LinearERC20Voting,
+          address: linearVotingErc20Address,
+          client: publicClient,
+        });
+        const existingVotingPeriod = await votingStrategyContract.read.votingPeriod();
         const encodedStrategyInitParams = encodeAbiParameters(
           parseAbiParameters(
             'address, address, address, uint32, uint256, uint256, address, uint256[]',
@@ -146,7 +153,7 @@ export default function useCreateRoles() {
             safeAddress, // owner
             votesToken.address, // governance token
             moduleAzoriusAddress, // Azorius module
-            Number(votingStrategy.votingPeriod.value),
+            existingVotingPeriod,
             (votingStrategy.quorumPercentage.value * quorumDenominator) / 100n, // quorom numerator, denominator is 1,000,000, so quorum percentage is quorumNumerator * 100 / quorumDenominator
             500000n, // basis numerator, denominator is 1,000,000, so basis percentage is 50% (simple majority)
             hatsProtocol,
@@ -201,7 +208,7 @@ export default function useCreateRoles() {
 
         return [deployWhitelistingVotingStrategyTx, enableDeployedVotingStrategyTx];
       } else if (azoriusGovernance.type === GovernanceType.AZORIUS_ERC721) {
-        if (!erc721Tokens || !votingStrategy?.votingPeriod || !votingStrategy.quorumThreshold) {
+        if (!erc721Tokens || !votingStrategy?.quorumThreshold || !linearVotingErc721Address) {
           return;
         }
 
@@ -211,6 +218,12 @@ export default function useCreateRoles() {
           address: linearVotingErc721HatsWhitelistingMasterCopy,
           client: publicClient,
         });
+        const votingStrategyContract = getContract({
+          abi: abis.LinearERC20Voting,
+          address: linearVotingErc721Address,
+          client: publicClient,
+        });
+        const existingVotingPeriod = await votingStrategyContract.read.votingPeriod();
 
         const quorumDenominator =
           await linearERC721VotingMasterCopyContract.read.QUORUM_DENOMINATOR();
@@ -223,7 +236,7 @@ export default function useCreateRoles() {
             erc721Tokens.map(token => token.address), // governance tokens addresses
             erc721Tokens.map(token => token.votingWeight), // governance tokens weights
             moduleAzoriusAddress, // Azorius module
-            Number(votingStrategy.votingPeriod.value),
+            existingVotingPeriod,
             (votingStrategy.quorumThreshold.value * quorumDenominator) / 100n, // quorom numerator, denominator is 1,000,000, so quorum percentage is quorumNumerator * 100 / quorumDenominator
             500000n, // basis numerator, denominator is 1,000,000, so basis percentage is 50% (simple majority)
             hatsProtocol,
@@ -292,6 +305,8 @@ export default function useCreateRoles() {
       moduleAzoriusAddress,
       publicClient,
       zodiacModuleProxyFactory,
+      linearVotingErc20Address,
+      linearVotingErc721Address,
     ],
   );
 

--- a/src/providers/App/governance/action.ts
+++ b/src/providers/App/governance/action.ts
@@ -25,10 +25,6 @@ export enum FractalGovernanceAction {
   UPDATE_NEW_AZORIUS_ERC20_VOTE = 'UPDATE_NEW_AZORIUS_ERC20_VOTE',
   UPDATE_NEW_AZORIUS_ERC721_VOTE = 'UPDATE_NEW_AZORIUS_ERC721_VOTE',
   UPDATE_PROPOSAL_STATE = 'UPDATE_PROPOSAL_STATE',
-  UPDATE_VOTING_PERIOD = 'UPDATE_VOTING_PERIOD',
-  UPDATE_VOTING_QUORUM = 'UPDATE_VOTING_QUORUM',
-  UPDATE_VOTING_QUORUM_THRESHOLD = 'UPDATE_VOTING_QUORUM_THRESHOLD',
-  UPDATE_TIMELOCK_PERIOD = 'UPDATE_TIMELOCK_PERIOD',
   SET_ERC721_TOKENS_DATA = 'SET_ERC721_TOKENS_DATA',
   SET_TOKEN_DATA = 'SET_TOKEN_DATA',
   SET_TOKEN_ACCOUNT_DATA = 'SET_TOKEN_ACCOUNT_DATA',
@@ -86,22 +82,6 @@ export type FractalGovernanceActions =
   | {
       type: FractalGovernanceAction.UPDATE_PROPOSAL_STATE;
       payload: { state: FractalProposalState; proposalId: string };
-    }
-  | {
-      type: FractalGovernanceAction.UPDATE_VOTING_PERIOD;
-      payload: bigint;
-    }
-  | {
-      type: FractalGovernanceAction.UPDATE_VOTING_QUORUM;
-      payload: bigint;
-    }
-  | {
-      type: FractalGovernanceAction.UPDATE_VOTING_QUORUM_THRESHOLD;
-      payload: bigint;
-    }
-  | {
-      type: FractalGovernanceAction.UPDATE_TIMELOCK_PERIOD;
-      payload: bigint;
     }
   | { type: FractalGovernanceAction.SET_ERC721_TOKENS_DATA; payload: ERC721TokenData[] }
   | {

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -170,22 +170,6 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
       });
       return { ...state, proposals: updatedProposals };
     }
-    case FractalGovernanceAction.UPDATE_VOTING_PERIOD: {
-      const { votingStrategy } = state as AzoriusGovernance;
-      return { ...state, votingStrategy: { ...votingStrategy, votingPeriod: action.payload } };
-    }
-    case FractalGovernanceAction.UPDATE_VOTING_QUORUM_THRESHOLD: {
-      const { votingStrategy } = state as AzoriusGovernance;
-      return { ...state, votingStrategy: { ...votingStrategy, quorumThreshold: action.payload } };
-    }
-    case FractalGovernanceAction.UPDATE_VOTING_QUORUM: {
-      const { votingStrategy } = state as AzoriusGovernance;
-      return { ...state, votingStrategy: { ...votingStrategy, votingQuorum: action.payload } };
-    }
-    case FractalGovernanceAction.UPDATE_TIMELOCK_PERIOD: {
-      const { votingStrategy } = state as AzoriusGovernance;
-      return { ...state, votingStrategy: { ...votingStrategy, timelockPeriod: action.payload } };
-    }
     case FractalGovernanceAction.SET_TOKEN_DATA: {
       const { votesToken } = state as AzoriusGovernance;
       return { ...state, votesToken: { ...votesToken, ...action.payload } };


### PR DESCRIPTION
- Fix reading user's voting weight on the proposal details page for the given proposal based on proposal's voting strategy
- Fix `canVote` identification - read it from proposal's voting strategy instead of global voting strategy contract
- Read `votingPeriod` from existing voting strategy on-chain instead of reading global value - since it is formatted from blocks to seconds, while we want to have same exact blocks number