### PR TITLE
`Bugfix` termed role member validation

### DIFF
--- a/src/components/ui/forms/EthAddressInput.tsx
+++ b/src/components/ui/forms/EthAddressInput.tsx
@@ -15,7 +15,7 @@ export function AddressInput({ value, onChange, ...rest }: InputProps) {
     () =>
       debounce((event: ChangeEvent<HTMLInputElement>) => {
         if (onChange) onChange(event);
-      }, 500),
+      }, 300),
     [onChange],
   );
 
@@ -31,8 +31,8 @@ export function AddressInput({ value, onChange, ...rest }: InputProps) {
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      debounceValue(event);
       setLocalValue(event.target.value);
+      debounceValue(event);
     },
     [debounceValue],
   );

--- a/src/hooks/schemas/roles/useRolesSchema.ts
+++ b/src/hooks/schemas/roles/useRolesSchema.ts
@@ -158,7 +158,7 @@ export const useRolesSchema = () => {
                     test: (termEndDate, cxt) => {
                       if (!termEndDate || !cxt.from) return true;
                       const [, { value: roleForm }] = cxt.from;
-                      const { roleTerms } = roleForm.roleEditing;
+                      const roleTerms = roleForm.roleEditing?.roleTerms;
                       // remove the last element from terms and create a new array with the rest of the elements
                       if (!roleTerms || roleTerms.length === 0) return termEndDate > new Date();
                       const previousTerms = roleTerms.slice(0, -1);

--- a/src/pages/dao/roles/edit/details/SafeRoleEditDetailsPage.tsx
+++ b/src/pages/dao/roles/edit/details/SafeRoleEditDetailsPage.tsx
@@ -67,7 +67,7 @@ function EditRoleMenu({ onRemove, hatId }: { hatId: Hex; onRemove: () => void })
     }
 
     setFieldValue('roleEditing', undefined);
-    setFieldValue('addMewTerm', undefined);
+    setFieldValue('newRoleTerm', undefined);
     setTimeout(() => onRemove(), 50);
   };
 
@@ -150,6 +150,7 @@ export function SafeRoleEditDetailsPage() {
 
   const backupRoleEditing = useRef(values.roleEditing);
   const backupTouched = useRef(touched.roleEditing);
+  const backupNewRoleTerm = useRef(values.newRoleTerm);
 
   if (!isHex(hatEditingId)) return null;
   if (!safe?.address) return null;
@@ -158,13 +159,14 @@ export function SafeRoleEditDetailsPage() {
   const goBackToRolesEdit = () => {
     backupRoleEditing.current = values.roleEditing;
     backupTouched.current = touched.roleEditing;
+    backupNewRoleTerm.current = values.newRoleTerm;
 
     setWasRoleActuallyEdited(values.roleEditing !== undefined);
 
     setTimeout(() => {
       setTouched({});
       setFieldValue('roleEditing', undefined);
-      setFieldValue('addMewTerm', undefined);
+      setFieldValue('newRoleTerm', undefined);
       navigate(DAO_ROUTES.rolesEdit.relative(addressPrefix, safe.address), { replace: true });
     }, 50);
   };
@@ -187,6 +189,7 @@ export function SafeRoleEditDetailsPage() {
         values.roleEditing.payments.filter((_, index) => index !== paymentIndex),
       );
     }
+    setFieldValue('newRoleTerm', undefined);
     setFieldValue('roleEditing.roleEditingPaymentIndex', undefined);
   };
 
@@ -211,6 +214,7 @@ export function SafeRoleEditDetailsPage() {
                 onDiscard={blocker.proceed}
                 onKeepEditing={() => {
                   setFieldValue('roleEditing', backupRoleEditing.current);
+                  setFieldValue('newRoleTerm', backupNewRoleTerm.current);
                   setTouched({ roleEditing: backupTouched.current });
                   blocker.reset();
                 }}
@@ -226,6 +230,7 @@ export function SafeRoleEditDetailsPage() {
                 onDiscard={blocker.proceed}
                 onKeepEditing={() => {
                   setFieldValue('roleEditing', backupRoleEditing.current);
+                  setFieldValue('newRoleTerm', backupNewRoleTerm.current);
                   setTouched({ roleEditing: backupTouched.current });
                   blocker.reset();
                 }}


### PR DESCRIPTION
This was kinda hard to test as it was quite flaky. Sometime it was just work. I narrowed it down to the `debounce` on a paste it wasn't properly passing the value to the `onChange`. Reducing the debounce time down to `300` seems to fix this, I can no longer reproduce.

I also fixed a few other small things as they came up.

- Clearing `newRoleTerm` form property since its outside of `roleEditing`. (also fixed misnamed property)
- removes an errors that was occuring in `useRolesSchema` before deconstruction of a possible `undefined` value