### PR TITLE
Remove two GovernanceTypes from enum, doesn't seem like they were being used anywhere

### DIFF
--- a/src/components/DaoCreator/hooks/useParentSafeVotingWeight.ts
+++ b/src/components/DaoCreator/hooks/useParentSafeVotingWeight.ts
@@ -21,9 +21,7 @@ export const useParentSafeVotingWeight = () => {
 
     switch (governance.type) {
       case GovernanceType.AZORIUS_ERC20:
-      case GovernanceType.AZORIUS_ERC20_HATS_WHITELISTING:
       case GovernanceType.AZORIUS_ERC721:
-      case GovernanceType.AZORIUS_ERC721_HATS_WHITELISTING:
         const governanceAzorius = governance as AzoriusGovernance;
 
         if (dao?.isAzorius === false || !governanceAzorius.votingStrategy) {

--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -106,10 +106,7 @@ export function VoteContextProvider({
         if (snapshotProposal) {
           const votingWeightData = await loadVotingWeight();
           newCanVote = votingWeightData.votingWeight >= 1;
-        } else if (
-          type === GovernanceType.AZORIUS_ERC20 ||
-          type === GovernanceType.AZORIUS_ERC20_HATS_WHITELISTING
-        ) {
+        } else if (type === GovernanceType.AZORIUS_ERC20) {
           const azoriusProposal = proposal as AzoriusProposal;
           const ozLinearVotingContract = getContract({
             abi: abis.LinearERC20Voting,
@@ -121,10 +118,7 @@ export function VoteContextProvider({
               userAccount.address,
               Number(proposal.proposalId),
             ])) > 0n && !hasVoted;
-        } else if (
-          type === GovernanceType.AZORIUS_ERC721 ||
-          type === GovernanceType.AZORIUS_ERC721_HATS_WHITELISTING
-        ) {
+        } else if (type === GovernanceType.AZORIUS_ERC721) {
           if (refetchUserTokens) {
             await getUserERC721VotingTokens(null, null);
           }

--- a/src/hooks/utils/useCanUserSubmitProposal.ts
+++ b/src/hooks/utils/useCanUserSubmitProposal.ts
@@ -70,9 +70,7 @@ export function useCanUserCreateProposal() {
           return checkIsMultisigOwner(owners);
         } else if (
           type === GovernanceType.AZORIUS_ERC20 ||
-          type === GovernanceType.AZORIUS_ERC20_HATS_WHITELISTING ||
-          type === GovernanceType.AZORIUS_ERC721 ||
-          type === GovernanceType.AZORIUS_ERC721_HATS_WHITELISTING
+          type === GovernanceType.AZORIUS_ERC721
         ) {
           const isProposerPerStrategy = await Promise.all(
             [

--- a/src/pages/dao/settings/governance/SafeGovernanceSettingsPage.tsx
+++ b/src/pages/dao/settings/governance/SafeGovernanceSettingsPage.tsx
@@ -22,12 +22,8 @@ export function SafeGovernanceSettingsPage() {
   } = useFractal();
   const { safe } = useDaoInfoStore();
 
-  const isERC20Governance =
-    type === GovernanceType.AZORIUS_ERC20 ||
-    type === GovernanceType.AZORIUS_ERC20_HATS_WHITELISTING;
-  const isERC721Governance =
-    type === GovernanceType.AZORIUS_ERC721 ||
-    type === GovernanceType.AZORIUS_ERC721_HATS_WHITELISTING;
+  const isERC20Governance = type === GovernanceType.AZORIUS_ERC20;
+  const isERC721Governance = type === GovernanceType.AZORIUS_ERC721;
   const isMultisigGovernance = type === GovernanceType.MULTISIG;
 
   return (

--- a/src/providers/App/useReadOnlyValues.ts
+++ b/src/providers/App/useReadOnlyValues.ts
@@ -89,9 +89,7 @@ export const useReadOnlyValues = ({
         : {
             isAzorius:
               governance.type === GovernanceType.AZORIUS_ERC20 ||
-              governance.type === GovernanceType.AZORIUS_ERC721 ||
-              governance.type === GovernanceType.AZORIUS_ERC20_HATS_WHITELISTING ||
-              governance.type === GovernanceType.AZORIUS_ERC721_HATS_WHITELISTING,
+              governance.type === GovernanceType.AZORIUS_ERC721,
           },
     };
     if (!isEqual(newReadOnlyValues, readOnlyValues)) {

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -280,9 +280,7 @@ export interface VotingStrategy<Type = BIFormattedPair> {
 export enum GovernanceType {
   MULTISIG = 'labelMultisigGov',
   AZORIUS_ERC20 = 'labelAzoriusErc20Gov',
-  AZORIUS_ERC20_HATS_WHITELISTING = 'labelAzoriusErc20HatsWhitelistingGov',
   AZORIUS_ERC721 = 'labelAzoriusErc721Gov',
-  AZORIUS_ERC721_HATS_WHITELISTING = 'labelAzoriusErc721HatsWhitelistingGov',
 }
 
 export enum VotingStrategyType {


### PR DESCRIPTION
@mudrila would especially like your eyes on this one.

The reason why I think this PR is valid is because, the at only places where we're doing:

```ts
action.dispatch({
  type: FractalGovernanceAction.SET_GOVERNANCE_TYPE,
  payload: ...,
});
```

(which are in `useFractalGovernance.ts`)

the only `payload`s that are being used are
- `GovernanceType.AZORIUS_ERC20`
- `GovernanceType.AZORIUS_ERC721`
- `GovernanceType.MULTISIG`

So it seems like the `type` property on the `FractalGovernance` state is never going to be two enum values that I removed in this PR.