### PR TITLE
Don't infinite rerender when Safe is not a DAO

### DIFF
--- a/src/hooks/DAO/loaders/useFractalNode.ts
+++ b/src/hooks/DAO/loaders/useFractalNode.ts
@@ -43,11 +43,11 @@ export const useFractalNode = ({
       } catch (e) {
         // TODO: this is the thing causing an error when
         // trying to load a DAO with a valid address which is not a Safe
-        reset({ error: true });
+        // reset({ error: true });
         return;
       }
     }
-  }, [addressPrefix, safeAddress, loadDao, setDaoInfo, reset]);
+  }, [addressPrefix, safeAddress, loadDao, setDaoInfo]);
 
   useEffect(() => {
     if (`${addressPrefix}${safeAddress}` !== currentValidSafe.current) {


### PR DESCRIPTION
Would rather not infinite rerender when trying to load a Safe which is not a DAO.

This is obviously not a good solution, because it doesn't fix the actual issue. The actual issue is that we _should_ be able to load up a Safe which is not yet a DAO. But I guess we recently merged some code which broke that ability. Currently when trying to load a Safe which is not a DAO, it results in the browser tab crashing. This PR simply stops the browser tab from crashing, but it still doesn't load the Safe.