### PR TITLE
Remove `underlyingTokenAddress` and `loadUnderlyingERC20Token`

### DIFF
--- a/src/hooks/DAO/loaders/governance/useERC20LinearToken.ts
+++ b/src/hooks/DAO/loaders/governance/useERC20LinearToken.ts
@@ -1,5 +1,5 @@
 import { abis } from '@fractal-framework/fractal-contracts';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { getContract } from 'viem';
 import { useAccount, usePublicClient } from 'wagmi';
 import { useFractal } from '../../../../providers/App/AppProvider';
@@ -10,24 +10,12 @@ export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) =
   const tokenAccount = useRef<string>();
 
   const {
-    governanceContracts: { votesTokenAddress, underlyingTokenAddress },
+    governanceContracts: { votesTokenAddress },
     action,
   } = useFractal();
   const user = useAccount();
   const account = user.address;
   const publicClient = usePublicClient();
-
-  const underlyingTokenContract = useMemo(() => {
-    if (!underlyingTokenAddress || !publicClient) {
-      return;
-    }
-
-    return getContract({
-      abi: abis.VotesERC20,
-      address: underlyingTokenAddress,
-      client: publicClient,
-    });
-  }, [publicClient, underlyingTokenAddress]);
 
   const loadERC20Token = useCallback(async () => {
     if (!votesTokenAddress || !publicClient) {
@@ -56,26 +44,6 @@ export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) =
     isTokenLoaded.current = true;
     action.dispatch({ type: FractalGovernanceAction.SET_TOKEN_DATA, payload: tokenData });
   }, [action, publicClient, votesTokenAddress]);
-
-  const loadUnderlyingERC20Token = useCallback(async () => {
-    if (!underlyingTokenContract) {
-      return;
-    }
-
-    const [tokenName, tokenSymbol] = await Promise.all([
-      underlyingTokenContract.read.name(),
-      underlyingTokenContract.read.symbol(),
-    ]);
-    const tokenData = {
-      name: tokenName,
-      symbol: tokenSymbol,
-      address: underlyingTokenContract.address,
-    };
-    action.dispatch({
-      type: FractalGovernanceAction.SET_UNDERLYING_TOKEN_DATA,
-      payload: tokenData,
-    });
-  }, [underlyingTokenContract, action]);
 
   const loadERC20TokenAccountData = useCallback(async () => {
     if (!account || !votesTokenAddress || !publicClient) {
@@ -209,5 +177,5 @@ export const useERC20LinearToken = ({ onMount = true }: { onMount?: boolean }) =
     };
   }, [account, loadERC20TokenAccountData, onMount, publicClient, votesTokenAddress]);
 
-  return { loadERC20Token, loadUnderlyingERC20Token, loadERC20TokenAccountData };
+  return { loadERC20Token, loadERC20TokenAccountData };
 };

--- a/src/hooks/DAO/loaders/useFractalGovernance.ts
+++ b/src/hooks/DAO/loaders/useFractalGovernance.ts
@@ -31,7 +31,7 @@ export const useFractalGovernance = () => {
   const loadDAOProposals = useLoadDAOProposals();
   const loadERC20Strategy = useERC20LinearStrategy();
   const loadERC721Strategy = useERC721LinearStrategy();
-  const { loadERC20Token, loadUnderlyingERC20Token } = useERC20LinearToken({});
+  const { loadERC20Token } = useERC20LinearToken({});
   const { loadLockedVotesToken } = useLockRelease({});
   const loadERC721Tokens = useERC721Tokens();
   const ipfsClient = useIPFSClient();
@@ -117,7 +117,6 @@ export const useFractalGovernance = () => {
           });
           loadERC20Strategy();
           loadERC20Token();
-          loadUnderlyingERC20Token();
           if (lockReleaseAddress) {
             loadLockedVotesToken();
           }
@@ -138,7 +137,6 @@ export const useFractalGovernance = () => {
     }
   }, [
     governanceContracts,
-    loadUnderlyingERC20Token,
     loadERC20Strategy,
     loadERC20Token,
     loadLockedVotesToken,

--- a/src/hooks/DAO/loaders/useGovernanceContracts.ts
+++ b/src/hooks/DAO/loaders/useGovernanceContracts.ts
@@ -45,7 +45,6 @@ export const useGovernanceContracts = () => {
     let linearVotingErc20WithHatsWhitelistingAddress: Address | undefined;
     let linearVotingErc721WithHatsWhitelistingAddress: Address | undefined;
     let votesTokenAddress: Address | undefined;
-    let underlyingTokenAddress: Address | undefined;
     let lockReleaseAddress: Address | undefined;
 
     const setGovTokenAddress = async (erc20VotingStrategyAddress: Address) => {
@@ -122,7 +121,6 @@ export const useGovernanceContracts = () => {
           linearVotingErc721Address,
           linearVotingErc721WithHatsWhitelistingAddress,
           votesTokenAddress,
-          underlyingTokenAddress,
           lockReleaseAddress,
           moduleAzoriusAddress: azoriusModule.moduleAddress,
         },

--- a/src/providers/App/governance/action.ts
+++ b/src/providers/App/governance/action.ts
@@ -6,7 +6,6 @@ import {
   FractalProposalState,
   VotesData,
   VotingStrategy,
-  UnderlyingTokenData,
   GovernanceType,
   ERC721TokenData,
 } from '../../../types';
@@ -30,7 +29,6 @@ export enum FractalGovernanceAction {
   SET_TOKEN_ACCOUNT_DATA = 'SET_TOKEN_ACCOUNT_DATA',
   SET_CLAIMING_CONTRACT = 'SET_CLAIMING_CONTRACT',
   RESET_TOKEN_ACCOUNT_DATA = 'RESET_TOKEN_ACCOUNT_DATA',
-  SET_UNDERLYING_TOKEN_DATA = 'SET_UNDERLYING_TOKEN_DATA',
   PENDING_PROPOSAL_ADD = 'PENDING_PROPOSAL_ADD',
 }
 
@@ -87,10 +85,6 @@ export type FractalGovernanceActions =
   | {
       type: FractalGovernanceAction.SET_TOKEN_DATA;
       payload: ERC20TokenData;
-    }
-  | {
-      type: FractalGovernanceAction.SET_UNDERLYING_TOKEN_DATA;
-      payload: UnderlyingTokenData;
     }
   | {
       type: FractalGovernanceAction.SET_TOKEN_ACCOUNT_DATA;

--- a/src/providers/App/governance/reducer.ts
+++ b/src/providers/App/governance/reducer.ts
@@ -185,10 +185,6 @@ export const governanceReducer = (state: FractalGovernance, action: FractalGover
     case FractalGovernanceAction.SET_ERC721_TOKENS_DATA: {
       return { ...state, erc721Tokens: action.payload };
     }
-    case FractalGovernanceAction.SET_UNDERLYING_TOKEN_DATA: {
-      const { votesToken } = state as AzoriusGovernance;
-      return { ...state, votesToken: { ...votesToken, underlyingTokenData: action.payload } };
-    }
     case FractalGovernanceAction.SET_TOKEN_ACCOUNT_DATA: {
       const { votesToken } = state as AzoriusGovernance;
       return { ...state, votesToken: { ...votesToken, ...action.payload } };

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -6,10 +6,6 @@ export interface VotesData {
   delegatee: Address | null;
   votingWeight: bigint | null;
 }
-export type UnderlyingTokenData = Omit<
-  ERC20TokenData,
-  'totalSupply' | 'decimals' | 'underlyingTokenData'
->;
 
 export interface BaseTokenData {
   name: string;
@@ -19,7 +15,6 @@ export interface BaseTokenData {
 export interface ERC20TokenData extends BaseTokenData {
   decimals: number;
   totalSupply: bigint;
-  underlyingTokenData?: UnderlyingTokenData;
 }
 
 export interface ERC721TokenData extends BaseTokenData {

--- a/src/types/fractal.ts
+++ b/src/types/fractal.ts
@@ -216,7 +216,6 @@ export interface FractalGovernanceContracts {
   moduleAzoriusAddress?: Address;
   votesTokenAddress?: Address;
   lockReleaseAddress?: Address;
-  underlyingTokenAddress?: Address;
   isLoaded: boolean;
 }
 


### PR DESCRIPTION
Closes #2614

`underlyingTokenAddress` was left unused after wrap functionality rip. Removed