### PR TITLE
Refactor `useResolveAddressMultichain` to `useResolveENSName` 

### DIFF
--- a/src/hooks/DAO/useSearchDao.ts
+++ b/src/hooks/DAO/useSearchDao.ts
@@ -2,7 +2,8 @@ import SafeApiKit from '@safe-global/api-kit';
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address } from 'viem';
-import { useResolveAddressMultiChain } from '../utils/useResolveAddressMultiChain';
+import { supportedNetworks } from '../../providers/NetworkConfig/useNetworkConfigStore';
+import { useResolveENSName } from '../utils/useResolveENSName';
 
 type ResolvedAddressWithPrefix = {
   address: Address;
@@ -10,7 +11,7 @@ type ResolvedAddressWithPrefix = {
 };
 export const useSearchDao = () => {
   const { t } = useTranslation('dashboard');
-  const { resolveAddressMultiChain, isLoading: isAddressLoading } = useResolveAddressMultiChain();
+  const { resolveAddressMultiChain, isLoading: isAddressLoading } = useResolveENSName();
   const [searchString, setSearchString] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>();
 
@@ -41,9 +42,14 @@ export const useSearchDao = () => {
 
   const resolveInput = useCallback(
     async (input: string) => {
-      const { resolved, isValid } = await resolveAddressMultiChain(input);
+      const { resolvedAddress, isValid } = await resolveAddressMultiChain(input);
       if (isValid) {
-        await findSafes(resolved);
+        await findSafes(
+          supportedNetworks.map(network => ({
+            address: resolvedAddress,
+            chainId: network.chain.id,
+          })),
+        );
       } else {
         setErrorMessage('Invalid search');
       }

--- a/src/hooks/DAO/useSearchDao.ts
+++ b/src/hooks/DAO/useSearchDao.ts
@@ -11,7 +11,7 @@ type ResolvedAddressWithPrefix = {
 };
 export const useSearchDao = () => {
   const { t } = useTranslation('dashboard');
-  const { resolveAddressMultiChain, isLoading: isAddressLoading } = useResolveENSName();
+  const { resolveENSName, isLoading: isAddressLoading } = useResolveENSName();
   const [searchString, setSearchString] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>();
 
@@ -42,7 +42,7 @@ export const useSearchDao = () => {
 
   const resolveInput = useCallback(
     async (input: string) => {
-      const { resolvedAddress, isValid } = await resolveAddressMultiChain(input);
+      const { resolvedAddress, isValid } = await resolveENSName(input);
       if (isValid) {
         await findSafes(
           supportedNetworks.map(network => ({
@@ -54,7 +54,7 @@ export const useSearchDao = () => {
         setErrorMessage('Invalid search');
       }
     },
-    [findSafes, resolveAddressMultiChain],
+    [findSafes, resolveENSName],
   );
 
   useEffect(() => {

--- a/src/hooks/utils/useResolveAddressMultiChain.ts
+++ b/src/hooks/utils/useResolveAddressMultiChain.ts
@@ -45,13 +45,18 @@ export const useResolveAddressMultiChain = () => {
         setIsLoading(false);
         return returnedResult;
       }
+      const mainnet = supportedNetworks.find(network => network.chain.id === 1);
+      if (!mainnet) {
+        throw new Error('Mainnet not found');
+      }
+
+      const mainnetPublicClient = createPublicClient({
+        chain: mainnet.chain,
+        transport: http(mainnet.rpcEndpoint),
+      });
       for (const network of supportedNetworks) {
-        const client = createPublicClient({
-          chain: network.chain,
-          transport: http(network.rpcEndpoint),
-        });
         try {
-          const resolvedAddress = await client.getEnsAddress({ name: normalizedName });
+          const resolvedAddress = await mainnetPublicClient.getEnsAddress({ name: normalizedName });
           if (resolvedAddress) {
             returnedResult.resolved.push({
               address: resolvedAddress,

--- a/src/hooks/utils/useResolveENSName.ts
+++ b/src/hooks/utils/useResolveENSName.ts
@@ -10,57 +10,54 @@ type ResolveENSNameReturnType = {
 export const useResolveENSName = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const resolveAddressMultiChain = useCallback(
-    async (input: string): Promise<ResolveENSNameReturnType> => {
-      setIsLoading(true);
+  const resolveENSName = useCallback(async (input: string): Promise<ResolveENSNameReturnType> => {
+    setIsLoading(true);
 
-      const returnedResult: ResolveENSNameReturnType = {
-        resolvedAddress: zeroAddress,
-        isValid: false,
-      };
+    const returnedResult: ResolveENSNameReturnType = {
+      resolvedAddress: zeroAddress,
+      isValid: false,
+    };
 
-      if (input === '') {
-        throw new Error('ENS name is empty');
-      }
+    if (input === '') {
+      throw new Error('ENS name is empty');
+    }
 
-      if (isAddress(input)) {
-        // @dev if its a valid address, its valid on all networks
-        returnedResult.isValid = true;
-        returnedResult.resolvedAddress = getAddress(input);
-        setIsLoading(false);
-        return returnedResult;
-      }
-
-      // @dev if its not an address, try to resolve as possible ENS name on all networks
-      let normalizedName: string;
-      try {
-        normalizedName = normalize(input);
-      } catch {
-        setIsLoading(false);
-        return returnedResult;
-      }
-      const mainnet = supportedNetworks.find(network => network.chain.id === 1);
-      if (!mainnet) {
-        throw new Error('Mainnet not found');
-      }
-
-      const mainnetPublicClient = createPublicClient({
-        chain: mainnet.chain,
-        transport: http(mainnet.rpcEndpoint),
-      });
-      try {
-        const resolvedAddress = await mainnetPublicClient.getEnsAddress({ name: normalizedName });
-        if (resolvedAddress) {
-          returnedResult.resolvedAddress = resolvedAddress;
-          returnedResult.isValid = true;
-        }
-      } catch {
-        // do nothing
-      }
+    if (isAddress(input)) {
+      // @dev if its a valid address, its valid on all networks
+      returnedResult.isValid = true;
+      returnedResult.resolvedAddress = getAddress(input);
       setIsLoading(false);
       return returnedResult;
-    },
-    [],
-  );
-  return { resolveAddressMultiChain, isLoading };
+    }
+
+    // @dev if its not an address, try to resolve as possible ENS name on all networks
+    let normalizedName: string;
+    try {
+      normalizedName = normalize(input);
+    } catch {
+      setIsLoading(false);
+      return returnedResult;
+    }
+    const mainnet = supportedNetworks.find(network => network.chain.id === 1);
+    if (!mainnet) {
+      throw new Error('Mainnet not found');
+    }
+
+    const mainnetPublicClient = createPublicClient({
+      chain: mainnet.chain,
+      transport: http(mainnet.rpcEndpoint),
+    });
+    try {
+      const resolvedAddress = await mainnetPublicClient.getEnsAddress({ name: normalizedName });
+      if (resolvedAddress) {
+        returnedResult.resolvedAddress = resolvedAddress;
+        returnedResult.isValid = true;
+      }
+    } catch {
+      // do nothing
+    }
+    setIsLoading(false);
+    return returnedResult;
+  }, []);
+  return { resolveENSName, isLoading };
 };

--- a/src/hooks/utils/useResolveENSName.ts
+++ b/src/hooks/utils/useResolveENSName.ts
@@ -47,15 +47,12 @@ export const useResolveENSName = () => {
       chain: mainnet.chain,
       transport: http(mainnet.rpcEndpoint),
     });
-    try {
-      const resolvedAddress = await mainnetPublicClient.getEnsAddress({ name: normalizedName });
-      if (resolvedAddress) {
-        returnedResult.resolvedAddress = resolvedAddress;
-        returnedResult.isValid = true;
-      }
-    } catch {
-      // do nothing
+    const resolvedAddress = await mainnetPublicClient.getEnsAddress({ name: normalizedName });
+    if (resolvedAddress) {
+      returnedResult.resolvedAddress = resolvedAddress;
+      returnedResult.isValid = true;
     }
+
     setIsLoading(false);
     return returnedResult;
   }, []);


### PR DESCRIPTION
@adamgall 

Very similar to `useAddress`. 

Main difference it that the execution the lookup doesn't kickoff via `useEffect` but rather the hook spits out the function to be used as directed. 

if you prefer I just refactor this back and fit `useAddress` in I can do that. I just prefer using a `callback` function to time the execution