### PR TITLE
`[Bugfix | No Issue]` Add `useEffect` for when wallet is connected to different network

### DIFF
--- a/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
+++ b/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
@@ -108,6 +108,13 @@ export function EstablishEssentials(props: ICreationStepProps) {
     },
   });
 
+  useEffect(() => {
+    if (chain.id !== walletChainID) {
+      const chainId = getChainIdFromPrefix(addressPrefix);
+      switchChain({ chainId });
+    }
+  });
+
   return (
     <>
       <StepWrapper

--- a/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
+++ b/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
@@ -151,6 +151,7 @@ export function EstablishEssentials(props: ICreationStepProps) {
               selectedItem={dropdownItems.find(item => item.selected)}
               onSelect={item => {
                 setCurrentConfig(getConfigByChainId(Number(item.value)));
+                switchChain({ chainId: Number(item.value) });
               }}
               title={t('networks')}
               isDisabled={false}

--- a/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
+++ b/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
@@ -113,7 +113,7 @@ export function EstablishEssentials(props: ICreationStepProps) {
       const chainId = getChainIdFromPrefix(addressPrefix);
       switchChain({ chainId });
     }
-  });
+  }, [chain.id, walletChainID, addressPrefix, switchChain]);
 
   return (
     <>


### PR DESCRIPTION
Noticed that the wallet wouldn't switch to ethereum on page load and that switching networks via the selection wasn't causing hte network to change