### PR TITLE
`[Eng 50]` | Dao creation network switch

### DIFF
--- a/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
+++ b/src/components/DaoCreator/formComponents/EstablishEssentials.tsx
@@ -108,13 +108,6 @@ export function EstablishEssentials(props: ICreationStepProps) {
     },
   });
 
-  useEffect(() => {
-    if (chain.id !== walletChainID) {
-      const chainId = getChainIdFromPrefix(addressPrefix);
-      switchChain({ chainId });
-    }
-  }, [chain.id, walletChainID, addressPrefix, switchChain]);
-
   return (
     <>
       <StepWrapper

--- a/src/components/DaoCreator/index.tsx
+++ b/src/components/DaoCreator/index.tsx
@@ -1,6 +1,9 @@
 import { Box } from '@chakra-ui/react';
 import { Formik } from 'formik';
+import { useEffect } from 'react';
+import { useChainId, useSwitchChain } from 'wagmi';
 import { useDAOCreateSchema } from '../../hooks/schemas/DAOCreate/useDAOCreateSchema';
+import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
 import {
   AzoriusERC20DAO,
   AzoriusERC721DAO,
@@ -28,6 +31,8 @@ function DaoCreator({
   mode: DAOCreateMode;
 }) {
   const { totalParentVotingWeight } = useParentSafeVotingWeight();
+  const walletChainID = useChainId();
+  const { chain } = useNetworkConfigStore();
 
   const { createDAOValidation } = useDAOCreateSchema({
     isSubDAO: !!isSubDAO,
@@ -36,6 +41,21 @@ function DaoCreator({
 
   const { prepareMultisigFormData, prepareAzoriusERC20FormData, prepareAzoriusERC721FormData } =
     usePrepareFormData();
+
+  const { switchChain } = useSwitchChain({
+    mutation: {
+      onError: () => {
+        if (chain.id !== walletChainID && !isSubDAO) {
+          switchChain({ chainId: chain.id });
+        }
+      },
+    },
+  });
+  useEffect(() => {
+    if (chain.id !== walletChainID && !isSubDAO) {
+      switchChain({ chainId: chain.id });
+    }
+  }, [chain.id, walletChainID, switchChain, isSubDAO]);
 
   return (
     <Box>


### PR DESCRIPTION
Closes https://linear.app/decent-labs/issue/ENG-50/dev-error-creating-an-nft-dao

So the problem is that I placed the useEffect within the EstablishEssentials form rather than higher up. 

This move makes it if the User switches there network at some point later in the process, the app switches it back keeping the user on the selected network. 

I did attempt to move this selection and network check to the button, but with the current setup within `useBuildDAOTx` where it pulls contracts from `useNetworkConfigStore` in which is set to the current network. 

A future refactor will be needed to confirm to a new pattern of more fine control over what network the DAO is deployed on. 

## Testing: 
- Enter Create DAO workflow
- Select Different network from etherem
- Go to end of which DAO creation workflow you are on.
- Before deploying, open wallet and manually switch wallet network
- Go back to page (focus on page), go back to wallet and network should be back to the originally selected network. 

Basically our now app now prevents the user from manually switching thier network via wallet during this workflow. Not ideal to be so connected to that network. but without some refactoring how the contracts for deployment are chosen this is the most effective method to ensure proper deployment