### PR TITLE
`[ENG-86]` Try decoding transactions with `viem`'s `decodeFunctionData` when Safe Decoder fails

### DIFF
--- a/src/components/ui/forms/ABISelector.tsx
+++ b/src/components/ui/forms/ABISelector.tsx
@@ -38,10 +38,10 @@ export default function ABISelector({ target, onChange }: IABISelector) {
           const requestFunc = ({ method, params }: { method: any; params: any }) =>
             client.request({ method, params });
 
-          const proxy = await detectProxyTarget(ensAddress || target, requestFunc);
+          const implementationAddress = await detectProxyTarget(ensAddress || target, requestFunc);
 
           const response = await axios.get(
-            `${etherscanAPIUrl}&module=contract&action=getabi&address=${proxy || ensAddress || target}`,
+            `${etherscanAPIUrl}&module=contract&action=getabi&address=${implementationAddress || ensAddress || target}`,
           );
           const responseData = response.data;
 

--- a/src/hooks/utils/useSafeDecoder.tsx
+++ b/src/hooks/utils/useSafeDecoder.tsx
@@ -68,9 +68,9 @@ export const useSafeDecoder = () => {
           }
           const requestFunc = ({ method, params }: { method: any; params: any }) =>
             client.request({ method, params });
-          const proxy = await detectProxyTarget(to, requestFunc);
+          const implementationAddress = await detectProxyTarget(to, requestFunc);
           const response = await axios.get(
-            `${etherscanAPIUrl}&module=contract&action=getabi&address=${proxy || to}`,
+            `${etherscanAPIUrl}&module=contract&action=getabi&address=${implementationAddress || to}`,
           );
           const responseData = response.data;
           const abi = JSON.parse(responseData.result);


### PR DESCRIPTION
## Changes

This PR introduces alternative way of decoding transaction data as a fallback for Safe Decoder. 
It detects whether target address is proxy or not, then tries to fetch smart contract's ABI from Etherscan and parse it. 

<details>

<summary> Some DRYing might be done, though not sure it's worthy</summary>

Note: This part pretty much replicates what we have in `ABISelector` - so maybe some DRYing could be done, not sure it's worth that for ~5 lines of code though. The only replicated logic would be detecting proxy and fetching ABI, but we can't leverage storing ABI since ABI selector needs state storage and `useSafeDecoder` doesn't. Some further improvements, as caching ABI, also might be done - but seems like that's not an issue right now, so maybe we can list that as a further enhancement in the backlog.

</details>

Then it composes parsed ABI and decoded function data into decoded transaction data.
With this approach - we were able to successfully decode data on Shutter's proposal, that Safe's Decoder was failing to parse. See the screenshot below.

## Testing
1. Visit production and try to open transaction details for the Shutter's proposal (or any other proposal where Safe Decoder is failing to decode data). I.e. https://app.decentdao.org/proposals/46?dao=eth:0x36bD3044ab68f600f6d3e081056F34f2a58432c4
2. Visit preview deployment and verify that the very same proposal now properly displays executable code details. I.e. https://deploy-preview-2649.app.dev.decentdao.org/proposals/46?dao=eth:0x36bD3044ab68f600f6d3e081056F34f2a58432c4
3. Enjoy how sweet and simple that actually was

## Screenshots

<img width="1728" alt="Screenshot 2025-01-06 at 18 01 35" src="https://github.com/user-attachments/assets/2c15afd5-5b3b-4d1d-8ede-1f78caea6415" />
