### PR TITLE
`[ENG-5]` Fix misaligned toast loading icon

### DIFF
--- a/src/assets/css/Toast.css
+++ b/src/assets/css/Toast.css
@@ -31,6 +31,10 @@
   margin-right: 0;
 }
 
+.sonner-toast[data-type='loading'] [data-icon] {
+  margin-top: 8px;
+}
+
 .sonner-toast [data-icon] svg {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
Previous:
<img width="381" alt="Screenshot 2025-01-07 at 12 13 14" src="https://github.com/user-attachments/assets/3d25b5db-f8d8-4da3-8cdb-1f03b8491568" />

Fixed:
<img width="367" alt="Screenshot 2025-01-07 at 12 54 22" src="https://github.com/user-attachments/assets/3975a65d-b282-4ddc-86de-382bbffc4105" />

