### PR TITLE
Fix proposal load bug

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -56,7 +56,6 @@ export const MAX_CONTENT_WIDTH = '80rem';
 
 const features = {
   developmentMode: 'DEVELOPMENT_MODE',
-  termedRoles: 'TERMED_ROLES',
   demoMode: 'DEMO_MODE',
 } as const;
 
@@ -72,7 +71,6 @@ export const isFeatureEnabled = (feature: FeatureFlag) => {
 };
 
 export const isDevMode = () => isFeatureEnabled(features.developmentMode);
-export const isTermedRolesEnabled = () => isFeatureEnabled(features.termedRoles);
 export const isDemoMode = () => isFeatureEnabled(features.demoMode);
 
 /**

--- a/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
+++ b/src/hooks/DAO/loaders/governance/useAzoriusProposals.ts
@@ -234,6 +234,13 @@ export const useAzoriusProposals = () => {
 
         let proposalData;
 
+        if (
+          proposalCreatedEvent.args.proposer === undefined ||
+          proposalCreatedEvent.args.strategy === undefined
+        ) {
+          continue;
+        }
+
         if (proposalCreatedEvent.args.metadata && proposalCreatedEvent.args.transactions) {
           const metadataEvent = parseProposalMetadata(proposalCreatedEvent.args.metadata);
 
@@ -271,13 +278,6 @@ export const useAzoriusProposals = () => {
               proposalCreatedEvent.args.transactions,
             );
           }
-        }
-
-        if (
-          proposalCreatedEvent.args.proposer === undefined ||
-          proposalCreatedEvent.args.strategy === undefined
-        ) {
-          continue;
         }
 
         let strategyType: VotingStrategyType | undefined;

--- a/src/utils/azorius.ts
+++ b/src/utils/azorius.ts
@@ -198,11 +198,20 @@ export const mapProposalCreatedEventToProposal = async (
     abstainVotes: 0n,
   };
 
-  const strategyContract = getContract({
-    address: strategyAddress,
-    abi: abis.LinearERC20Voting,
-    client: publicClient,
-  });
+  const strategyContract =
+    strategyType === VotingStrategyType.LINEAR_ERC20 ||
+    strategyType === VotingStrategyType.LINEAR_ERC20_HATS_WHITELISTING
+      ? getContract({
+          address: strategyAddress,
+          abi: abis.LinearERC20Voting,
+          client: publicClient,
+        })
+      : getContract({
+          address: strategyAddress,
+          abi: abis.LinearERC721Voting,
+          client: publicClient,
+        });
+
   const stratProposalVotes = await strategyContract.read.getProposalVotes([proposalId]);
   proposalVotes.noVotes = stratProposalVotes[0];
   proposalVotes.yesVotes = stratProposalVotes[1];


### PR DESCRIPTION
This PR fixes a bug that was preventing VantaDAO from loading. The fix is in `src/utils/azorius.ts`, where the wrong strategy contract appears to have been used to call `getProposalVotes`.

Need confirmation on the true type of VantaDAO. If it's an ERC-721 type and has just one proposal, all is good.

If not, well. We have a problem on our hands here.

### Testing
- Using a new Incognito Window on Chrome, go to https://app.decentdao.org/home?dao=eth:0xB14AC30AA97057e2A934c47BDc45171335B91Bd8
- Verify that proposals do not load
- Now go to https://DEPLOY-PREVIEW-URL-PENDING/home?dao=eth:0xB14AC30AA97057e2A934c47BDc45171335B91Bd8
- Verify that proposals load