### PR TITLE
`[Eng-87] | [ENG-4]` voting context updates

### DIFF
--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -79,8 +79,6 @@ export function VoteContextProvider({
     } else if (governance.isAzorius) {
       const azoriusProposal = proposal as AzoriusProposal;
       if (azoriusProposal?.votes) {
-        console.log('🚀 ~ azoriusProposal?.votes:', azoriusProposal?.votes);
-        console.log('🚀 ~ userAccount.address:', userAccount.address);
         setHasVoted(!!azoriusProposal?.votes.find(vote => vote.voter === userAccount.address));
       }
     } else {
@@ -125,7 +123,6 @@ export function VoteContextProvider({
   const getCanVote = useCallback(async () => {
     setCanVoteLoading(true);
     let newCanVote = false;
-    console.log('🚀 ~ userAccount.address:  --->', userAccount.address);
     if (userAccount.address && publicClient) {
       if (snapshotProposal) {
         const votingWeightData = await loadVotingWeight();
@@ -151,8 +148,6 @@ export function VoteContextProvider({
         newCanVote = false;
       }
     }
-    console.log('🚀 ~ newCanVote: --->', newCanVote);
-    console.log('🚀 ~ canVote: --->', canVote);
 
     if (canVote !== newCanVote) {
       setCanVote(newCanVote);

--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -184,18 +184,16 @@ export function VoteContextProvider({
     }
   }, [getHasVoted, proposal]);
 
-  return (
-    <VoteContext.Provider
-      value={{
+  const memoizedValue = useMemo(() => {
+    return {
       canVote,
       canVoteLoading,
       hasVoted,
       hasVotedLoading,
+      getCanVote,
       getHasVoted,
-        getCanVote,
-      }}
-    >
-      {children}
-    </VoteContext.Provider>
-  );
+    };
+  }, [canVote, canVoteLoading, getCanVote, getHasVoted, hasVoted, hasVotedLoading]);
+
+  return <VoteContext.Provider value={memoizedValue}>{children}</VoteContext.Provider>;
 }

--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -60,7 +61,6 @@ export function VoteContextProvider({
   const [canVoteLoading, setCanVoteLoading] = useState(false);
   const [hasVoted, setHasVoted] = useState(false);
   const [hasVotedLoading, setHasVotedLoading] = useState(false);
-  const [proposalVotesLength, setProposalVotesLength] = useState(0);
   const { governance } = useFractal();
   const userAccount = useAccount();
   const { safe } = useDaoInfoStore();
@@ -172,26 +172,26 @@ export function VoteContextProvider({
     // Prevent running this effect multiple times
     if (initialLoadRef.current) return;
     initialLoadRef.current = true;
-
     getCanVote();
-    getHasVoted();
-  }, [getCanVote, getHasVoted]);
+  }, [getCanVote]);
 
+  const loadVotingWeightRef = useRef<number>();
   useEffect(() => {
     const azoriusProposal = proposal as AzoriusProposal;
-    if (azoriusProposal.votes && proposalVotesLength !== azoriusProposal.votes.length) {
-      setProposalVotesLength(azoriusProposal.votes.length);
+    if (azoriusProposal.votes.length !== loadVotingWeightRef.current) {
+      loadVotingWeightRef.current = azoriusProposal.votes.length;
+      getHasVoted();
     }
-  }, [proposal, proposalVotesLength]);
+  }, [getHasVoted, proposal]);
 
   return (
     <VoteContext.Provider
       value={{
-        canVote,
-        canVoteLoading,
-        hasVoted,
-        hasVotedLoading,
-        getHasVoted,
+      canVote,
+      canVoteLoading,
+      hasVoted,
+      hasVotedLoading,
+      getHasVoted,
         getCanVote,
       }}
     >

--- a/src/hooks/DAO/proposal/useCastVote.ts
+++ b/src/hooks/DAO/proposal/useCastVote.ts
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Address, getContract } from 'viem';
 import { useWalletClient } from 'wagmi';
-import { useVoteContext } from '../../../components/Proposals/ProposalVotes/context/VoteContext';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { useTransaction } from '../../utils/useTransaction';
 import useUserERC721VotingTokens from './useUserERC721VotingTokens';
@@ -25,7 +24,6 @@ const useCastVote = (proposalId: string, strategy: Address) => {
     proposalId,
   );
 
-  const { getCanVote, getHasVoted } = useVoteContext();
   const { data: walletClient } = useWalletClient();
 
   const { t } = useTranslation('transaction');
@@ -50,12 +48,6 @@ const useCastVote = (proposalId: string, strategy: Address) => {
           pendingMessage: t('pendingCastVote'),
           failedMessage: t('failedCastVote'),
           successMessage: t('successCastVote'),
-          successCallback: () => {
-            setTimeout(() => {
-              getHasVoted();
-              getCanVote();
-            }, 3000);
-          },
         });
       } else if (
         strategy === linearVotingErc721Address ||
@@ -77,12 +69,6 @@ const useCastVote = (proposalId: string, strategy: Address) => {
           pendingMessage: t('pendingCastVote'),
           failedMessage: t('failedCastVote'),
           successMessage: t('successCastVote'),
-          successCallback: () => {
-            setTimeout(() => {
-              getHasVoted();
-              getCanVote();
-            }, 3000);
-          },
         });
       }
     },
@@ -90,8 +76,6 @@ const useCastVote = (proposalId: string, strategy: Address) => {
       contractCall,
       linearVotingErc721Address,
       linearVotingErc721WithHatsWhitelistingAddress,
-      getCanVote,
-      getHasVoted,
       linearVotingErc20Address,
       linearVotingErc20WithHatsWhitelistingAddress,
       proposalId,


### PR DESCRIPTION
## Description
Closes [ENG-87](https://linear.app/decent-labs/issue/ENG-87/voting-quorum-is-not-updated)
Closes [ENG-4](https://linear.app/decent-labs/issue/ENG-4/vote-button-doesnt-disappear-after-voting-and-refreshes)

## Testing
Create or use an existing Token DAO with at least 2 accounts (quicker with 3 or 4)

Account 1: Allocated, Self-Delegated
Account 2: Allocated, Self-Delegated
Account 3: Allocated, Delegated to account 4
Account 4: not-allocated, delegated power from account 3

For easy proposal creation, I used update DAO name.
For easy testing, I'd increase voting period.

Use allocated and self-delegated accounts and vote. Vote details should update on screen (quorum and vote summary)
Great ✅,
 
Next switch between other accounts, to ensure that the button acts properly
- hasVotingPower and hasn't voted -> active
- hasVotingPower and already voted -> disabled
- no allocated token -> hidden


## Screenshots

### Voting with Account 1
-Account 1 casts vote
  - quorum Updates
  - vote details update
  - button remains disabled
![pr_gif_quorom_update](https://github.com/user-attachments/assets/47981efa-3a3f-4432-80fd-440727814e51)

### Account Switching while voting
- Account 1 has voted
  - button is disabled
- Switches to account 2
  - button is active
- Switches to account 3
  - button is removed
- Switches to account 4
  - button is active
- Switches to account 2 and votes
  - quorum Updates
  - vote details update
  - button remains disabled
![pr_gif_account_changes_voting](https://github.com/user-attachments/assets/3a3bf819-9ac5-44f8-8618-50fb8dc57709)


## Link
https://linear.app/decent-labs/issue/ENG-87/voting-quorum-is-not-updated
