### PR TITLE
`[ENG-84]` Toast not closing

### DIFF
--- a/src/pages/create/SafeCreatePage.tsx
+++ b/src/pages/create/SafeCreatePage.tsx
@@ -37,9 +37,7 @@ export function SafeCreatePage() {
       if (daoFound) {
         navigate(DAO_ROUTES.dao.relative(addressPrefix, safeAddress));
       } else {
-        toast.loading(t('failedIndexSafe'), {
-          duration: Infinity,
-        });
+        toast.loading(t('failedIndexSafe'));
         navigate(BASE_ROUTES.landing);
       }
     },


### PR DESCRIPTION
## Description
Looks like this was set to `infinity`, removed that.

Closes [ENG-84](https://linear.app/decent-labs/issue/ENG-84/cannot-close-toast)

## Testing
As this particular toast is part of a failure workflow, might take a few tries to reproduce. I have this happen more often when creating Token DAOs, so I'd recommend that, if you are itching to test, otherwise, pretty straight forward fix.

## Screenshots
No Screenshots

