### PR TITLE
Fix ugly line under search box

### DIFF
--- a/src/components/ui/menus/DAOSearch/index.tsx
+++ b/src/components/ui/menus/DAOSearch/index.tsx
@@ -143,7 +143,7 @@ export function DAOSearch() {
             marginTop="0.25rem"
             rounded="0.5rem"
             bg="neutral-2"
-            boxShadow={SEXY_BOX_SHADOW_T_T}
+            boxShadow={resolvedAddressesWithPrefix.length ? SEXY_BOX_SHADOW_T_T : 'none'}
             hidden={!showResults}
             w="full"
             position="absolute"


### PR DESCRIPTION
Before
<img width="1041" alt="Screenshot 2025-01-10 at 15 36 39" src="https://github.com/user-attachments/assets/cf84e972-e25a-4246-9532-8bc2533db0eb" />
<img width="1066" alt="Screenshot 2025-01-10 at 15 37 02" src="https://github.com/user-attachments/assets/36a0861c-3ff0-4793-99ef-ec39474c1bba" />

After:
<img width="1133" alt="Screenshot 2025-01-10 at 15 36 07" src="https://github.com/user-attachments/assets/1ad77e4f-2a35-498f-846c-0130cabec5ef" />
<img width="1071" alt="Screenshot 2025-01-10 at 15 37 17" src="https://github.com/user-attachments/assets/f509170d-8af4-4558-b77a-55b71279685c" />
