### PR TITLE
`[Eng 49]` Show Mint event as seperate transfer event

### DIFF
--- a/src/components/DAOTreasury/components/Transactions.tsx
+++ b/src/components/DAOTreasury/components/Transactions.tsx
@@ -1,14 +1,13 @@
 import { Box, Button, Center, Flex, HStack, Icon, Image, Text } from '@chakra-ui/react';
 import { ArrowDown, ArrowUp } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
-import { getAddress } from 'viem';
 import { useDateTimeDisplay } from '../../../helpers/dateTime';
 import { useFractal } from '../../../providers/App/AppProvider';
 import { useNetworkConfigStore } from '../../../providers/NetworkConfig/useNetworkConfigStore';
 import { useDaoInfoStore } from '../../../store/daoInfo/useDaoInfoStore';
 import { TokenEventType, TransferDisplayData, TransferType } from '../../../types';
 import { DecentTooltip } from '../../ui/DecentTooltip';
-import { DisplayAddress } from '../../ui/links/DisplayAddress';
+import DisplayTransaction from '../../ui/links/DisplayTransaction';
 import EtherscanLink from '../../ui/links/EtherscanLink';
 import { BarLoader } from '../../ui/loaders/BarLoader';
 
@@ -97,12 +96,12 @@ function TransferRow({ displayData }: { displayData: TransferDisplayData }) {
         <HStack
           w="40%"
           justifyContent="flex-end"
+          textAlign="end"
+          onClick={e => e.stopPropagation()}
         >
-          <DisplayAddress
+          <DisplayTransaction
             data-testid="link-transfer-address"
-            address={getAddress(displayData.transferAddress)}
-            textAlign="end"
-            onClick={e => e.stopPropagation()}
+            txHash={displayData.transactionHash}
           />
         </HStack>
       </HStack>

--- a/src/components/DAOTreasury/components/Transactions.tsx
+++ b/src/components/DAOTreasury/components/Transactions.tsx
@@ -30,7 +30,7 @@ function TransferRow({ displayData }: { displayData: TransferDisplayData }) {
           gap="0.5rem"
         >
           <Icon
-            as={displayData.eventType == TokenEventType.WITHDRAW ? ArrowUp : ArrowDown}
+            as={displayData.eventType === TokenEventType.WITHDRAW ? ArrowUp : ArrowDown}
             w="1.25rem"
             h="1.25rem"
             color="neutral-7"
@@ -40,7 +40,7 @@ function TransferRow({ displayData }: { displayData: TransferDisplayData }) {
               textStyle="labels-small"
               color="neutral-7"
             >
-              {t(displayData.eventType == TokenEventType.WITHDRAW ? 'labelSent' : 'labelReceived')}
+              {t(displayData.eventType === TokenEventType.WITHDRAW ? 'labelSent' : 'labelReceived')}
             </Text>
             <Text>{useDateTimeDisplay(new Date(displayData.executionDate))}</Text>
           </Box>
@@ -76,7 +76,7 @@ function TransferRow({ displayData }: { displayData: TransferDisplayData }) {
                   : 'link-token-amount'
               }
             >
-              {(displayData.eventType == TokenEventType.WITHDRAW ? '- ' : '+ ') +
+              {(displayData.eventType === TokenEventType.WITHDRAW ? '- ' : '+ ') +
                 displayData.assetDisplay}
             </Text>
           </DecentTooltip>

--- a/src/components/DAOTreasury/components/Transactions.tsx
+++ b/src/components/DAOTreasury/components/Transactions.tsx
@@ -12,6 +12,19 @@ import { DisplayAddress } from '../../ui/links/DisplayAddress';
 import EtherscanLink from '../../ui/links/EtherscanLink';
 import { BarLoader } from '../../ui/loaders/BarLoader';
 
+function getTransferEventLabel(eventType: TokenEventType) {
+  switch (eventType) {
+    case TokenEventType.WITHDRAW:
+      return 'labelSent';
+    case TokenEventType.DEPOSIT:
+      return 'labelReceived';
+    case TokenEventType.MINT:
+      return 'labelMinted';
+    default:
+      throw new Error('Unknown event type');
+  }
+}
+
 function TransferRow({ displayData }: { displayData: TransferDisplayData }) {
   const { t } = useTranslation(['treasury', 'common']);
   const { etherscanBaseURL } = useNetworkConfigStore();
@@ -40,7 +53,7 @@ function TransferRow({ displayData }: { displayData: TransferDisplayData }) {
               textStyle="labels-small"
               color="neutral-7"
             >
-              {t(displayData.eventType === TokenEventType.WITHDRAW ? 'labelSent' : 'labelReceived')}
+              {t(getTransferEventLabel(displayData.eventType))}
             </Text>
             <Text>{useDateTimeDisplay(new Date(displayData.executionDate))}</Text>
           </Box>

--- a/src/i18n/locales/en/treasury.json
+++ b/src/i18n/locales/en/treasury.json
@@ -13,6 +13,7 @@
   "columnProtocols": "Protocols",
   "labelSent": "Sent",
   "labelReceived": "Received",
+  "labelMinted": "Mint",
   "textEmptyTransactions": "No transfers",
   "textMoreTransactions": "Load More",
   "transactionsShownCount": "Latest {{count}} from a total of",

--- a/src/types/daoTreasury.ts
+++ b/src/types/daoTreasury.ts
@@ -3,6 +3,7 @@ import { Address } from 'viem';
 export enum TokenEventType {
   DEPOSIT = 'DEPOSIT',
   WITHDRAW = 'WITHDRAW',
+  MINT = 'MINT',
 }
 
 export interface TokenEvent {


### PR DESCRIPTION
Closes [ENG-49](https://linear.app/decent-labs/issue/ENG-49/dev-when-i-created-a-new-dao-in-treasury-transactions-shows-the-mint)

## Testing
- Create Token DAO and Don't allocate all the token (or go to a newer existing Token DAO). You should now see mint transaction.

- Click on any transaction, should direct you to the transaction details

## Screenshots
![image](https://github.com/user-attachments/assets/a1b52235-0e07-4eb0-a227-08d7bc12a6f0)
