### PR TITLE
`[ENG-101]` Fix conditional logic preventing switch chain from working properly

### DIFF
--- a/src/hooks/utils/useAutomaticSwitchChain.ts
+++ b/src/hooks/utils/useAutomaticSwitchChain.ts
@@ -27,11 +27,7 @@ export const useAutomaticSwitchChain = ({
       return;
     }
     const chainId = getChainIdFromPrefix(urlAddressPrefix);
-    if (
-      (addressPrefix !== urlAddressPrefix || chainId !== walletChainId) &&
-      urlAddressPrefix !== undefined &&
-      isFetchedAfterMount
-    ) {
+    if ((addressPrefix !== urlAddressPrefix || chainId !== walletChainId) && isFetchedAfterMount) {
       switchChain({ chainId });
     }
     setTimeout(() => setCurrentConfig(getConfigByChainId(chainId)), 300);

--- a/src/hooks/utils/useAutomaticSwitchChain.ts
+++ b/src/hooks/utils/useAutomaticSwitchChain.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSwitchChain, useWalletClient } from 'wagmi';
+import { useChainId, useSwitchChain, useWalletClient } from 'wagmi';
 import { useNetworkConfigStore } from '../../providers/NetworkConfig/useNetworkConfigStore';
 import { getChainIdFromPrefix } from '../../utils/url';
 
@@ -10,6 +10,7 @@ export const useAutomaticSwitchChain = ({
 }) => {
   const { setCurrentConfig, getConfigByChainId, addressPrefix } = useNetworkConfigStore();
   const { isFetchedAfterMount } = useWalletClient();
+  const walletChainId = useChainId();
   const { switchChain } = useSwitchChain({
     mutation: {
       onError: () => {
@@ -22,12 +23,12 @@ export const useAutomaticSwitchChain = ({
   });
 
   useEffect(() => {
-    if (urlAddressPrefix === undefined || addressPrefix === urlAddressPrefix) {
+    if (urlAddressPrefix === undefined) {
       return;
     }
     const chainId = getChainIdFromPrefix(urlAddressPrefix);
     if (
-      addressPrefix !== urlAddressPrefix &&
+      (addressPrefix !== urlAddressPrefix || chainId !== walletChainId) &&
       urlAddressPrefix !== undefined &&
       isFetchedAfterMount
     ) {
@@ -39,6 +40,7 @@ export const useAutomaticSwitchChain = ({
     setCurrentConfig,
     getConfigByChainId,
     urlAddressPrefix,
+    walletChainId,
     switchChain,
     isFetchedAfterMount,
   ]);


### PR DESCRIPTION
Closes [ENG-101](https://linear.app/decent-labs/issue/ENG-101/dao-does-not-load-properly-when-on-wrong-network)

While I believe this setup isn't long (hopefully) for this codebase as discussed in @adamgall 's comments in #2658. it should still work. and was not taking in account the fact that mainnet is the default network for our network config. 

This would cause app to think everything was good to go and not switch the wallet's network...

Soooo this will fix that thanks for flagging @DarksightKellar 

## Testing
- Visit any sepolia DAO. (or be on home page of app and manually switch network to sepolia. and close the tab.

- Then in new tab visit `/home?dao=eth:0xB14AC30AA97057e2A934c47BDc45171335B91Bd8`.
- or just be on Home page and search and visit the above address while connected to sepolia. 

Everything should load correctly

