### PR TITLE
`[ENG-116]` Support empty array as param value

### DIFF
--- a/src/hooks/DAO/proposal/usePrepareProposal.ts
+++ b/src/hooks/DAO/proposal/usePrepareProposal.ts
@@ -21,8 +21,6 @@ export function usePrepareProposal() {
           const signature = tx.parameters.map(parameter => parameter.signature.trim()).join(', ');
           const parameters = tx.parameters
             .map(parameter =>
-              parameter.value !== '[]' &&
-              parameter.value !== '[ ]' &&
               isValidUrl(parameter.value!.trim())
                 ? encodeURIComponent(parameter.value!.trim()) // If parameter.value is valid URL with special symbols like ":" or "?" - decoding might fail, thus we need to encode URL
                 : parameter.value!.trim(),

--- a/src/hooks/DAO/proposal/usePrepareProposal.ts
+++ b/src/hooks/DAO/proposal/usePrepareProposal.ts
@@ -21,6 +21,8 @@ export function usePrepareProposal() {
           const signature = tx.parameters.map(parameter => parameter.signature.trim()).join(', ');
           const parameters = tx.parameters
             .map(parameter =>
+              parameter.value !== '[]' &&
+              parameter.value !== '[ ]' &&
               isValidUrl(parameter.value!.trim())
                 ? encodeURIComponent(parameter.value!.trim()) // If parameter.value is valid URL with special symbols like ":" or "?" - decoding might fail, thus we need to encode URL
                 : parameter.value!.trim(),

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -28,7 +28,10 @@ export const encodeFunction = (
   const parametersFixed: Array<string | string[]> | undefined = parameters ? [] : undefined;
   let tupleIndex: number | undefined = undefined;
   parameters?.forEach((param, i) => {
-    if (param.startsWith('[') && param.endsWith(']')) {
+    if (param === '[]' || param === '[ ]') {
+      // Handle empty array explicitly
+      parametersFixed!!.push([]);
+    } else if (param.startsWith('[') && param.endsWith(']')) {
       parametersFixed!!.push(
         param
           .substring(1, param.length - 1)

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -28,7 +28,7 @@ export const encodeFunction = (
   const parametersFixed: Array<string | string[]> | undefined = parameters ? [] : undefined;
   let tupleIndex: number | undefined = undefined;
   parameters?.forEach((param, i) => {
-    if (param === '[]' || param === '[ ]') {
+    if (param.replaceAll(' ', '') === '[]') {
       // Handle empty array explicitly
       parametersFixed!!.push([]);
     } else if (param.startsWith('[') && param.endsWith(']')) {


### PR DESCRIPTION
Closes [ENG-116](https://linear.app/decent-labs/issue/ENG-116/from-cannot-use-%5B%5D-or-%5B-%5D-as-param-value)

## Testing

For testing use this address for the target address `0xB2586A28840dD03Ca3EF402FDeEd835620A2F00B`

You can check [on etherscan](https://sepolia.etherscan.io/address/0xB2586A28840dD03Ca3EF402FDeEd835620A2F00B#code). First create a proposal to add a address to the array using `updateAddresses`. Then create a proposal with an empty array `[]` or `[ ]`. You will see that the length return 0. 
