### PR TITLE
Handicap netlify

### DIFF
--- a/src/components/ui/page/Global/index.tsx
+++ b/src/components/ui/page/Global/index.tsx
@@ -1,7 +1,10 @@
 import * as amplitude from '@amplitude/analytics-browser';
+import { Box } from '@chakra-ui/react';
 import * as Sentry from '@sentry/react';
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { useAccount } from 'wagmi';
+import { isFeatureEnabled } from '../../../../helpers/featureFlags';
 import { useAccountFavorites } from '../../../../hooks/DAO/loaders/useFavorites';
 import {
   CacheExpiry,
@@ -89,11 +92,62 @@ const useUpdateFavoritesCache = (onFavoritesUpdated: () => void) => {
   }, [favoritesList, onFavoritesUpdated]);
 };
 
+function Leave() {
+  return (
+    <Box lineHeight="1rem">
+      <Box fontWeight="bold">This domain is shutting down on 2025-01-19.</Box>
+      <Box mt="0.25rem">
+        <Box>Please use:</Box>
+        <Box>
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://develop.decent-interface.pages.dev"
+          >
+            https://develop.decent-interface.pages.dev
+          </a>
+        </Box>
+      </Box>
+      <Box mt="0.25rem">
+        <Box>Learn how to migrate your local &quot;My DAOs&quot; to the new domain:</Box>
+        <Box>
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://youtu.be/xvPrWmsBlBc"
+          >
+            https://youtu.be/xvPrWmsBlBc
+          </a>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+const useLeave = () => {
+  useEffect(() => {
+    if (!isFeatureEnabled('flag_leave')) {
+      return;
+    }
+    const leaveToast = toast.error(<Leave />, {
+      dismissible: false,
+      duration: Infinity,
+      closeButton: false,
+    });
+    return () => {
+      toast.dismiss(leaveToast);
+    };
+  }, []);
+};
+
 export function Global() {
   useUserTracking();
 
   // Initialize all modes from URL parameters
   useInitializeDemoMode();
+
+  // Can remove this after about 2025-01-19 when we shut down Netlify
+  useLeave();
 
   // Trigger a re-render when favorite names are updated
   const [favoritesUpdatedTrigger, setFavoritesUpdatedTrigger] = useState(0);

--- a/src/helpers/featureFlags.ts
+++ b/src/helpers/featureFlags.ts
@@ -1,4 +1,4 @@
-export const FEATURE_FLAGS = ['flag_dev', 'flag_yelling'] as const;
+export const FEATURE_FLAGS = ['flag_dev', 'flag_yelling', 'flag_leave'] as const;
 
 export type FeatureFlagKeys = typeof FEATURE_FLAGS;
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[number];


### PR DESCRIPTION
Closes [ENG-128](https://linear.app/decent-labs/issue/ENG-128/help-migrate-users-from-old-dev-site-to-new-dev-site)

Uses a new Feature Flag (environment variable `VITE_APP_FLAG_LEAVE="on"` set on the Netlify `decent-interface-dev` project) to trigger a persistent toast explaining to users that this domain (app.dev.decentdao.org) is being shut down, and instructions on how to migrate their "My DAOs".