### PR TITLE
Erc721 vote button

### DIFF
--- a/src/components/Proposals/ProposalActions/CastVote.tsx
+++ b/src/components/Proposals/ProposalActions/CastVote.tsx
@@ -44,12 +44,7 @@ export function CastVote({ proposal }: { proposal: FractalProposal }) {
     snapshotWeightedChoice,
   } = useCastSnapshotVote(extendedSnapshotProposal);
 
-  const { canVote, canVoteLoading, hasVoted, hasVotedLoading } = useVoteContext();
-
-  // if the user is not a signer or has no delegated tokens, don't show anything
-  if (!canVote) {
-    return null;
-  }
+  const { canVoteLoading, hasVoted, hasVotedLoading } = useVoteContext();
 
   // If user is lucky enough - he could create a proposal and proceed to vote on it
   // even before the block, in which proposal was created, was mined.

--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Address, erc721Abi, getContract } from 'viem';
+import { erc721Abi, getContract, Hex, toHex } from 'viem';
 import { useAccount, usePublicClient } from 'wagmi';
 import useSnapshotProposal from '../../../../hooks/DAO/loaders/snapshot/useSnapshotProposal';
 import useUserERC721VotingTokens from '../../../../hooks/DAO/proposal/useUserERC721VotingTokens';
@@ -116,60 +116,63 @@ export function VoteContextProvider({
     return userVotingWeight;
   }, [governance, publicClient, userAccount.address]);
 
-  const getCanVote = useCallback(async () => {
-    setCanVoteLoading(true);
-    let newCanVote = false;
-    if (userAccount.address && publicClient) {
-      if (snapshotProposal) {
-        const votingWeightData = await loadVotingWeight();
-        newCanVote = votingWeightData.votingWeight >= 1;
-      } else if (governance.type === GovernanceType.AZORIUS_ERC20) {
-        const azoriusProposal = proposal as AzoriusProposal;
-        const ozLinearVotingContract = getContract({
-          abi: abis.LinearERC20Voting,
-          address: azoriusProposal.votingStrategy,
-          client: publicClient,
-        });
-        newCanVote =
-          (await ozLinearVotingContract.read.getVotingWeight([
-            userAccount.address,
-            Number(proposal.proposalId),
-          ])) > 0n;
-      } else if (governance.type === GovernanceType.AZORIUS_ERC721) {
-        const votingWeight = await erc721VotingWeight();
-        newCanVote = votingWeight > 0n && remainingTokenIds.length > 0;
-      } else if (governance.type === GovernanceType.MULTISIG) {
-        newCanVote = !!safe?.owners.includes(userAccount.address);
-      } else {
-        newCanVote = false;
+  const getCanVote = useCallback(
+    async (remainingTokenIdsLength: number) => {
+      setCanVoteLoading(true);
+      let newCanVote = false;
+      if (userAccount.address && publicClient) {
+        if (snapshotProposal) {
+          const votingWeightData = await loadVotingWeight();
+          newCanVote = votingWeightData.votingWeight >= 1;
+        } else if (governance.type === GovernanceType.AZORIUS_ERC20) {
+          const azoriusProposal = proposal as AzoriusProposal;
+          const ozLinearVotingContract = getContract({
+            abi: abis.LinearERC20Voting,
+            address: azoriusProposal.votingStrategy,
+            client: publicClient,
+          });
+          newCanVote =
+            (await ozLinearVotingContract.read.getVotingWeight([
+              userAccount.address,
+              Number(proposal.proposalId),
+            ])) > 0n;
+        } else if (governance.type === GovernanceType.AZORIUS_ERC721) {
+          const votingWeight = await erc721VotingWeight();
+          newCanVote = votingWeight > 0n && remainingTokenIdsLength > 0;
+        } else if (governance.type === GovernanceType.MULTISIG) {
+          newCanVote = !!safe?.owners.includes(userAccount.address);
+        } else {
+          newCanVote = false;
+        }
       }
-    }
 
-    if (canVote !== newCanVote) {
-      setCanVote(newCanVote);
-    }
-    setCanVoteLoading(false);
-  }, [
-    userAccount.address,
-    publicClient,
-    canVote,
-    snapshotProposal,
-    governance.type,
-    loadVotingWeight,
-    remainingTokenIds.length,
-    safe?.owners,
-    proposal,
-    erc721VotingWeight,
-  ]);
+      if (canVote !== newCanVote) {
+        setCanVote(newCanVote);
+      }
+      setCanVoteLoading(false);
+    },
+    [
+      userAccount.address,
+      publicClient,
+      canVote,
+      snapshotProposal,
+      governance.type,
+      loadVotingWeight,
+      safe?.owners,
+      proposal,
+      erc721VotingWeight,
+    ],
+  );
 
-  const connectedUserRef = useRef<Address>();
+  const connectedUserRef = useRef<Hex>();
   useEffect(() => {
-    const isUserRefCurrent = connectedUserRef.current === userAccount.address;
+    const refValue = toHex(`${userAccount.address}-${remainingTokenIds.length}`);
+    const isUserRefCurrent = connectedUserRef.current === refValue;
     if (!isUserRefCurrent) {
-      connectedUserRef.current = userAccount.address;
-      getCanVote();
+      connectedUserRef.current = refValue;
+      getCanVote(remainingTokenIds.length);
     }
-  }, [getCanVote, userAccount.address]);
+  }, [getCanVote, userAccount.address, remainingTokenIds.length]);
 
   const connectedUserVotingWeightRef = useRef<string>();
   useEffect(() => {

--- a/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
+++ b/src/components/Proposals/ProposalVotes/context/VoteContext.tsx
@@ -30,8 +30,6 @@ interface IVoteContext {
   canVoteLoading: boolean;
   hasVoted: boolean;
   hasVotedLoading: boolean;
-  getCanVote: () => Promise<void>;
-  getHasVoted: () => void;
 }
 
 const VoteContext = createContext<IVoteContext>({
@@ -39,8 +37,6 @@ const VoteContext = createContext<IVoteContext>({
   canVoteLoading: false,
   hasVoted: false,
   hasVotedLoading: false,
-  getCanVote: async () => {},
-  getHasVoted: () => {},
 });
 
 export const useVoteContext = () => {
@@ -191,10 +187,8 @@ export function VoteContextProvider({
       canVoteLoading,
       hasVoted,
       hasVotedLoading,
-      getCanVote,
-      getHasVoted,
     };
-  }, [canVote, canVoteLoading, getCanVote, getHasVoted, hasVoted, hasVotedLoading]);
+  }, [canVote, canVoteLoading, hasVoted, hasVotedLoading]);
 
   return <VoteContext.Provider value={memoizedValue}>{children}</VoteContext.Provider>;
 }

--- a/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
+++ b/src/hooks/DAO/proposal/useUserERC721VotingTokens.ts
@@ -153,8 +153,8 @@ export default function useUserERC721VotingTokens(
 
             const ownedTokenIds = new Set<string>();
             allTokenTransferEvents.forEach(({ args: { to, from, tokenId } }) => {
-              if (!to || !from || !tokenId) {
-                throw new Error('An ERC721 event has undefiend data');
+              if (!to || !from || tokenId === undefined) {
+                throw new Error('An ERC721 event has undefined data');
               }
               if (to.toLowerCase() === userAddress.toLowerCase()) {
                 ownedTokenIds.add(tokenId.toString());


### PR DESCRIPTION
Closes https://linear.app/decent-labs/issue/ENG-136/contango-couldnt-vote

Currently, users are unable to vote on ERC 721 Token proposals. The "Vote" button does not appear when loading the app with a wallet connected that DOES have voting power on a proposal that already exists is and open for voting.

This PR addresses that bug.

Fixed two bugs, and do some cleanup.

Bugs fixed:
1. "zero is not undefined". When the `tokenId` of an owned NFT by the connected address is `0`, that was returning truthy in a place where we actually want to check if it's `undefined`.
2. Refactor VoteContext to improve voting eligibility checks and update user reference handling
  a. Modified getCanVote function to accept remainingTokenIdsLength as a parameter for better clarity and efficiency.
  b. Updated user reference management to use a hex representation of the user's address combined with the length of remaining token IDs.
  c. Ensured that the voting eligibility logic remains intact while enhancing readability and maintainability.

Cleanup:
1. Don't need to check a boolean twice in order to render one thing
2. Remove unused functions from VoteContext value

Testing:
1. Use Rabby
2. Add Josh's address as a "read only" address in Rabby: `0xda38c543596b7E1b79ad0aC2C7797ADb914Ea3C5`
3. Load up the VANTA DAO: `eth:0xB14AC30AA97057e2A934c47BDc45171335B91Bd8`
4. Connect to the Decent app with Rabby using Josh's address
5. Load up a current active proposal.
  a. Before this PR: no Vote button
  b. In this PR: Vote button