### PR TITLE
refactor: simplify proposal builder step management

### DIFF
--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -227,7 +227,13 @@ export function ProposalBuilder({
                           {...formikProps}
                         />
                       ) : (
-                        mainContent(formikProps, pendingCreateTx, nonce, currentStep)
+                        <>
+                          {mainContent(formikProps, pendingCreateTx, nonce, currentStep)}
+                          <ShowNonceInputOnMultisig
+                            nonce={nonce}
+                            nonceOnChange={newNonce => formikProps.setFieldValue('nonce', newNonce)}
+                          />
+                        </>
                       )}
                     </Box>
                     {actionsExperience}

--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -234,6 +234,7 @@ export function ProposalBuilder({
                     <StepButtons
                       renderButtons={renderButtons}
                       currentStep={currentStep}
+                      onStepChange={setCurrentStep}
                     />
                   </Flex>
                 </GridItem>

--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -162,6 +162,7 @@ export function ProposalBuilder({
             transactions,
             nonce,
           },
+          errors,
         } = formikProps;
 
         if (!safeAddress) {
@@ -176,11 +177,17 @@ export function ProposalBuilder({
           !!formikProps.errors.nonce ||
           pendingCreateTx;
 
-        const { metadataStepButtons, transactionsStepButtons } = stepButtons({
-          formErrors: !!formikProps.errors.proposalMetadata,
-          createProposalBlocked: createProposalButtonDisabled,
-          onStepChange: setCurrentStep,
-        });
+        const renderButtons = (step: CreateProposalSteps) => {
+          const { metadataStepButtons, transactionsStepButtons } = stepButtons({
+            formErrors: !!errors.proposalMetadata,
+            createProposalBlocked: createProposalButtonDisabled,
+            onStepChange: setCurrentStep,
+          });
+
+          return step === CreateProposalSteps.METADATA
+            ? metadataStepButtons
+            : transactionsStepButtons;
+        };
 
         return (
           <form onSubmit={handleSubmit}>
@@ -225,8 +232,7 @@ export function ProposalBuilder({
                     </Box>
                     {actionsExperience}
                     <StepButtons
-                      metadataStepButtons={metadataStepButtons}
-                      transactionsStepButtons={transactionsStepButtons}
+                      renderButtons={renderButtons}
                       currentStep={currentStep}
                     />
                   </Flex>

--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -75,10 +75,7 @@ interface ProposalBuilderProps {
     formErrors: boolean;
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
-  }) => {
-    metadataStepButtons: React.ReactNode;
-    transactionsStepButtons: React.ReactNode;
-  };
+  }) => React.ReactNode;
   transactionsDetails:
     | ((transactions: CreateProposalTransaction<BigIntValuePair>[]) => React.ReactNode)
     | null;
@@ -178,15 +175,13 @@ export function ProposalBuilder({
           pendingCreateTx;
 
         const renderButtons = (step: CreateProposalSteps) => {
-          const { metadataStepButtons, transactionsStepButtons } = stepButtons({
+          const buttons = stepButtons({
             formErrors: !!errors.proposalMetadata,
             createProposalBlocked: createProposalButtonDisabled,
             onStepChange: setCurrentStep,
           });
 
-          return step === CreateProposalSteps.METADATA
-            ? metadataStepButtons
-            : transactionsStepButtons;
+          return step === CreateProposalSteps.METADATA ? buttons : null;
         };
 
         return (
@@ -241,6 +236,7 @@ export function ProposalBuilder({
                       renderButtons={renderButtons}
                       currentStep={currentStep}
                       onStepChange={setCurrentStep}
+                      createProposalBlocked={createProposalButtonDisabled}
                     />
                   </Flex>
                 </GridItem>

--- a/src/components/ProposalBuilder/ProposalBuilder.tsx
+++ b/src/components/ProposalBuilder/ProposalBuilder.tsx
@@ -214,14 +214,14 @@ export function ProposalBuilder({
                       rounded="lg"
                       bg="neutral-2"
                     >
-                      {currentStep === CreateProposalSteps.METADATA && (
+                      {currentStep === CreateProposalSteps.METADATA ? (
                         <ProposalMetadata
                           typeProps={proposalMetadataTypeProps}
                           {...formikProps}
                         />
+                      ) : (
+                        mainContent(formikProps, pendingCreateTx, nonce, currentStep)
                       )}
-                      {currentStep !== CreateProposalSteps.METADATA &&
-                        mainContent(formikProps, pendingCreateTx, nonce, currentStep)}
                     </Box>
                     {actionsExperience}
                     <StepButtons

--- a/src/components/ProposalBuilder/StepButtons.tsx
+++ b/src/components/ProposalBuilder/StepButtons.tsx
@@ -16,7 +16,7 @@ interface StepButtonBaseProps {
   onStepChange: (step: CreateProposalSteps) => void;
 }
 
-export function NextButton({ isDisabled, onStepChange }: StepButtonBaseProps) {
+export function GoToTransactionsStepButton({ isDisabled, onStepChange }: StepButtonBaseProps) {
   const { t } = useTranslation('common');
 
   return (
@@ -30,7 +30,7 @@ export function NextButton({ isDisabled, onStepChange }: StepButtonBaseProps) {
   );
 }
 
-export function PreviousButton({ onStepChange }: StepButtonBaseProps) {
+function GoToMetadataStepButton({ onStepChange }: StepButtonBaseProps) {
   const { t } = useTranslation('common');
 
   return (
@@ -86,7 +86,7 @@ export default function StepButtons({
       width="100%"
     >
       {currentStep === CreateProposalSteps.TRANSACTIONS && (
-        <PreviousButton onStepChange={onStepChange} />
+        <GoToMetadataStepButton onStepChange={onStepChange} />
       )}
       {renderButtons(currentStep)}
       {currentStep === CreateProposalSteps.TRANSACTIONS && (

--- a/src/components/ProposalBuilder/StepButtons.tsx
+++ b/src/components/ProposalBuilder/StepButtons.tsx
@@ -1,25 +1,43 @@
 import { Button, Flex, Icon } from '@chakra-ui/react';
-import { CaretLeft, CaretRight } from '@phosphor-icons/react';
+import { CaretLeft } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
-import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useDaoInfoStore } from '../../store/daoInfo/useDaoInfoStore';
 import { CreateProposalSteps } from '../../types';
 
 interface StepButtonsProps {
   metadataStepButtons: React.ReactNode;
   transactionsStepButtons: React.ReactNode;
+  currentStep: CreateProposalSteps;
 }
 
-export function PreviousButton({ prevStepUrl }: { prevStepUrl: string }) {
-  const navigate = useNavigate();
-  const { t } = useTranslation(['common', 'proposal']);
+interface StepButtonBaseProps {
+  isDisabled?: boolean;
+  onStepChange: (step: CreateProposalSteps) => void;
+}
+
+export function NextButton({ isDisabled, onStepChange }: StepButtonBaseProps) {
+  const { t } = useTranslation('common');
 
   return (
     <Button
       px="2rem"
+      isDisabled={isDisabled}
+      onClick={() => onStepChange(CreateProposalSteps.TRANSACTIONS)}
+    >
+      {t('next')}
+    </Button>
+  );
+}
+
+export function PreviousButton({ onStepChange }: StepButtonBaseProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <Button
       variant="text"
+      px="2rem"
       color="lilac-0"
-      onClick={() => navigate(prevStepUrl)}
+      onClick={() => onStepChange(CreateProposalSteps.METADATA)}
     >
       <Icon
         bg="transparent"
@@ -28,28 +46,6 @@ export function PreviousButton({ prevStepUrl }: { prevStepUrl: string }) {
         color="lilac-0"
       />
       {t('back', { ns: 'common' })}
-    </Button>
-  );
-}
-
-export function NextButton({
-  nextStepUrl,
-  isDisabled,
-}: {
-  nextStepUrl: string;
-  isDisabled: boolean;
-}) {
-  const navigate = useNavigate();
-  const { t } = useTranslation(['common', 'proposal']);
-
-  return (
-    <Button
-      onClick={() => navigate(nextStepUrl)}
-      isDisabled={isDisabled}
-      px="2rem"
-    >
-      {t('next', { ns: 'common' })}
-      <CaretRight />
     </Button>
   );
 }
@@ -70,7 +66,7 @@ export function CreateProposalButton({ isDisabled }: { isDisabled: boolean }) {
 
 export default function StepButtons(props: StepButtonsProps) {
   const { safe } = useDaoInfoStore();
-  const { metadataStepButtons, transactionsStepButtons } = props;
+  const { metadataStepButtons, transactionsStepButtons, currentStep } = props;
 
   if (!safe?.address) {
     return null;
@@ -84,16 +80,7 @@ export default function StepButtons(props: StepButtonsProps) {
       justifyContent="flex-end"
       width="100%"
     >
-      <Routes>
-        <Route
-          path={CreateProposalSteps.METADATA}
-          element={metadataStepButtons}
-        />
-        <Route
-          path={CreateProposalSteps.TRANSACTIONS}
-          element={transactionsStepButtons}
-        />
-      </Routes>
+      {currentStep === CreateProposalSteps.METADATA ? metadataStepButtons : transactionsStepButtons}
     </Flex>
   );
 }

--- a/src/components/ProposalBuilder/StepButtons.tsx
+++ b/src/components/ProposalBuilder/StepButtons.tsx
@@ -8,6 +8,7 @@ interface StepButtonsProps {
   renderButtons: (currentStep: CreateProposalSteps) => React.ReactNode;
   currentStep: CreateProposalSteps;
   onStepChange: (step: CreateProposalSteps) => void;
+  createProposalBlocked: boolean;
 }
 
 interface StepButtonBaseProps {
@@ -68,6 +69,7 @@ export default function StepButtons({
   renderButtons,
   currentStep,
   onStepChange,
+  createProposalBlocked,
 }: StepButtonsProps) {
   const { safe } = useDaoInfoStore();
 
@@ -87,6 +89,9 @@ export default function StepButtons({
         <PreviousButton onStepChange={onStepChange} />
       )}
       {renderButtons(currentStep)}
+      {currentStep === CreateProposalSteps.TRANSACTIONS && (
+        <CreateProposalButton isDisabled={createProposalBlocked} />
+      )}
     </Flex>
   );
 }

--- a/src/components/ProposalBuilder/StepButtons.tsx
+++ b/src/components/ProposalBuilder/StepButtons.tsx
@@ -7,6 +7,7 @@ import { CreateProposalSteps } from '../../types';
 interface StepButtonsProps {
   renderButtons: (currentStep: CreateProposalSteps) => React.ReactNode;
   currentStep: CreateProposalSteps;
+  onStepChange: (step: CreateProposalSteps) => void;
 }
 
 interface StepButtonBaseProps {
@@ -63,7 +64,11 @@ export function CreateProposalButton({ isDisabled }: { isDisabled: boolean }) {
   );
 }
 
-export default function StepButtons({ renderButtons, currentStep }: StepButtonsProps) {
+export default function StepButtons({
+  renderButtons,
+  currentStep,
+  onStepChange,
+}: StepButtonsProps) {
   const { safe } = useDaoInfoStore();
 
   if (!safe?.address) {
@@ -78,6 +83,9 @@ export default function StepButtons({ renderButtons, currentStep }: StepButtonsP
       justifyContent="flex-end"
       width="100%"
     >
+      {currentStep === CreateProposalSteps.TRANSACTIONS && (
+        <PreviousButton onStepChange={onStepChange} />
+      )}
       {renderButtons(currentStep)}
     </Flex>
   );

--- a/src/components/ProposalBuilder/StepButtons.tsx
+++ b/src/components/ProposalBuilder/StepButtons.tsx
@@ -5,8 +5,7 @@ import { useDaoInfoStore } from '../../store/daoInfo/useDaoInfoStore';
 import { CreateProposalSteps } from '../../types';
 
 interface StepButtonsProps {
-  metadataStepButtons: React.ReactNode;
-  transactionsStepButtons: React.ReactNode;
+  renderButtons: (currentStep: CreateProposalSteps) => React.ReactNode;
   currentStep: CreateProposalSteps;
 }
 
@@ -64,9 +63,8 @@ export function CreateProposalButton({ isDisabled }: { isDisabled: boolean }) {
   );
 }
 
-export default function StepButtons(props: StepButtonsProps) {
+export default function StepButtons({ renderButtons, currentStep }: StepButtonsProps) {
   const { safe } = useDaoInfoStore();
-  const { metadataStepButtons, transactionsStepButtons, currentStep } = props;
 
   if (!safe?.address) {
     return null;
@@ -80,7 +78,7 @@ export default function StepButtons(props: StepButtonsProps) {
       justifyContent="flex-end"
       width="100%"
     >
-      {currentStep === CreateProposalSteps.METADATA ? metadataStepButtons : transactionsStepButtons}
+      {renderButtons(currentStep)}
     </Flex>
   );
 }

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -74,18 +74,18 @@ export const DAO_ROUTES = {
   },
   proposalNew: {
     relative: (addressPrefix: string, safeAddress: string) =>
-      `/proposals/new/metadata${getDaoQueryParam(addressPrefix, safeAddress)}`,
-    path: 'proposals/new/metadata',
+      `/proposals/new${getDaoQueryParam(addressPrefix, safeAddress)}`,
+    path: 'proposals/new',
   },
   proposalWithActionsNew: {
     relative: (addressPrefix: string, daoAddress: string) =>
-      `/proposals/actions/new/metadata${getDaoQueryParam(addressPrefix, daoAddress)}`,
-    path: 'proposals/actions/new/metadata',
+      `/proposals/actions/new${getDaoQueryParam(addressPrefix, daoAddress)}`,
+    path: 'proposals/actions/new',
   },
   proposalSablierNew: {
     relative: (addressPrefix: string, daoAddress: string) =>
-      `/proposals/new/sablier/metadata${getDaoQueryParam(addressPrefix, daoAddress)}`,
-    path: 'proposals/new/sablier/metadata',
+      `/proposals/new/sablier${getDaoQueryParam(addressPrefix, daoAddress)}`,
+    path: 'proposals/new/sablier',
   },
   settings: {
     relative: (addressPrefix: string, safeAddress: string) =>
@@ -129,7 +129,7 @@ export const DAO_ROUTES = {
   },
   proposalTemplateNew: {
     relative: (addressPrefix: string, safeAddress: string) =>
-      `/proposal-templates/new/metadata${getDaoQueryParam(addressPrefix, safeAddress)}`,
-    path: 'proposal-templates/new/metadata',
+      `/proposal-templates/new${getDaoQueryParam(addressPrefix, safeAddress)}`,
+    path: 'proposal-templates/new',
   },
 };

--- a/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
+++ b/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
@@ -2,20 +2,14 @@ import * as amplitude from '@amplitude/analytics-browser';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import {
-  ProposalBuilder,
-  ShowNonceInputOnMultisig,
-} from '../../../../components/ProposalBuilder/ProposalBuilder';
+import { ProposalBuilder } from '../../../../components/ProposalBuilder/ProposalBuilder';
 import {
   TemplateDetails,
   TransactionsDetails,
 } from '../../../../components/ProposalBuilder/ProposalDetails';
 import { TEMPLATE_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../components/ProposalBuilder/ProposalMetadata';
 import ProposalTransactionsForm from '../../../../components/ProposalBuilder/ProposalTransactionsForm';
-import {
-  CreateProposalButton,
-  NextButton,
-} from '../../../../components/ProposalBuilder/StepButtons';
+import { NextButton } from '../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_PROPOSAL } from '../../../../components/ProposalBuilder/constants';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { logError } from '../../../../helpers/errorLogging';
@@ -97,23 +91,17 @@ export function SafeCreateProposalTemplatePage() {
 
   const stepButtons = ({
     formErrors,
-    createProposalBlocked,
     onStepChange,
   }: {
     formErrors: boolean;
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
-  }) => {
-    return {
-      metadataStepButtons: (
-        <NextButton
-          isDisabled={formErrors}
-          onStepChange={onStepChange}
-        />
-      ),
-      transactionsStepButtons: <CreateProposalButton isDisabled={createProposalBlocked} />,
-    };
-  };
+  }) => (
+    <NextButton
+      isDisabled={formErrors}
+      onStepChange={onStepChange}
+    />
+  );
 
   return (
     <ProposalBuilder

--- a/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
+++ b/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
@@ -15,7 +15,6 @@ import ProposalTransactionsForm from '../../../../components/ProposalBuilder/Pro
 import {
   CreateProposalButton,
   NextButton,
-  PreviousButton,
 } from '../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_PROPOSAL } from '../../../../components/ProposalBuilder/constants';
 import { DAO_ROUTES } from '../../../../constants/routes';
@@ -112,12 +111,7 @@ export function SafeCreateProposalTemplatePage() {
           onStepChange={onStepChange}
         />
       ),
-      transactionsStepButtons: (
-        <>
-          <PreviousButton onStepChange={onStepChange} />
-          <CreateProposalButton isDisabled={createProposalBlocked} />
-        </>
-      ),
+      transactionsStepButtons: <CreateProposalButton isDisabled={createProposalBlocked} />,
     };
   };
 

--- a/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
+++ b/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../../components/ProposalBuilder/ProposalDetails';
 import { TEMPLATE_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../components/ProposalBuilder/ProposalMetadata';
 import ProposalTransactionsForm from '../../../../components/ProposalBuilder/ProposalTransactionsForm';
-import { NextButton } from '../../../../components/ProposalBuilder/StepButtons';
+import { GoToTransactionsStepButton } from '../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_PROPOSAL } from '../../../../components/ProposalBuilder/constants';
 import { DAO_ROUTES } from '../../../../constants/routes';
 import { logError } from '../../../../helpers/errorLogging';
@@ -97,7 +97,7 @@ export function SafeCreateProposalTemplatePage() {
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
   }) => (
-    <NextButton
+    <GoToTransactionsStepButton
       isDisabled={formErrors}
       onStepChange={onStepChange}
     />

--- a/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
+++ b/src/pages/dao/proposal-templates/new/SafeCreateProposalTemplatePage.tsx
@@ -131,18 +131,12 @@ export function SafeCreateProposalTemplatePage() {
       mainContent={(formikProps, pendingCreateTx, nonce, currentStep) => {
         if (currentStep !== CreateProposalSteps.TRANSACTIONS) return null;
         return (
-          <>
-            <ProposalTransactionsForm
-              pendingTransaction={pendingCreateTx}
-              safeNonce={safe?.nextNonce}
-              isProposalMode={true}
-              {...formikProps}
-            />
-            <ShowNonceInputOnMultisig
-              nonce={nonce}
-              nonceOnChange={newNonce => formikProps.setFieldValue('nonce', newNonce)}
-            />
-          </>
+          <ProposalTransactionsForm
+            pendingTransaction={pendingCreateTx}
+            safeNonce={safe?.nextNonce}
+            isProposalMode={true}
+            {...formikProps}
+          />
         );
       }}
     />

--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -169,18 +169,12 @@ export function SafeProposalWithActionsCreatePage() {
       mainContent={(formikProps, pendingCreateTx, nonce, currentStep) => {
         if (currentStep !== CreateProposalSteps.TRANSACTIONS) return null;
         return (
-          <>
-            <ProposalTransactionsForm
-              pendingTransaction={pendingCreateTx}
-              safeNonce={safe?.nextNonce}
-              isProposalMode={true}
-              {...formikProps}
-            />
-            <ShowNonceInputOnMultisig
-              nonce={nonce}
-              nonceOnChange={newNonce => formikProps.setFieldValue('nonce', newNonce)}
-            />
-          </>
+          <ProposalTransactionsForm
+            pendingTransaction={pendingCreateTx}
+            safeNonce={safe?.nextNonce}
+            isProposalMode={true}
+            {...formikProps}
+          />
         );
       }}
     />

--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -4,17 +4,11 @@ import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ProposalActionCard } from '../../../../../components/ProposalBuilder/ProposalActionCard';
-import {
-  ProposalBuilder,
-  ShowNonceInputOnMultisig,
-} from '../../../../../components/ProposalBuilder/ProposalBuilder';
+import { ProposalBuilder } from '../../../../../components/ProposalBuilder/ProposalBuilder';
 import { TransactionsDetails } from '../../../../../components/ProposalBuilder/ProposalDetails';
 import { DEFAULT_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../../components/ProposalBuilder/ProposalMetadata';
 import ProposalTransactionsForm from '../../../../../components/ProposalBuilder/ProposalTransactionsForm';
-import {
-  CreateProposalButton,
-  PreviousButton,
-} from '../../../../../components/ProposalBuilder/StepButtons';
+import { CreateProposalButton } from '../../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_PROPOSAL } from '../../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../../components/ui/loaders/BarLoader';
 import { AddActions } from '../../../../../components/ui/modals/AddActions';
@@ -133,21 +127,10 @@ export function SafeProposalWithActionsCreatePage() {
 
   const stepButtons = ({
     createProposalBlocked,
-    onStepChange,
   }: {
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
-  }) => {
-    return {
-      metadataStepButtons: <CreateProposalButton isDisabled={createProposalBlocked} />,
-      transactionsStepButtons: (
-        <>
-          <PreviousButton onStepChange={onStepChange} />
-          <CreateProposalButton isDisabled={createProposalBlocked} />
-        </>
-      ),
-    };
-  };
+  }) => <CreateProposalButton isDisabled={createProposalBlocked} />;
 
   return (
     <ProposalBuilder

--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -2,7 +2,7 @@ import * as amplitude from '@amplitude/analytics-browser';
 import { Center, Flex, Text } from '@chakra-ui/react';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Route, useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ProposalActionCard } from '../../../../../components/ProposalBuilder/ProposalActionCard';
 import {
   ProposalBuilder,
@@ -11,7 +11,7 @@ import {
 import { TransactionsDetails } from '../../../../../components/ProposalBuilder/ProposalDetails';
 import { DEFAULT_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../../components/ProposalBuilder/ProposalMetadata';
 import ProposalTransactionsForm from '../../../../../components/ProposalBuilder/ProposalTransactionsForm';
-import StepButtons, {
+import {
   CreateProposalButton,
   PreviousButton,
 } from '../../../../../components/ProposalBuilder/StepButtons';
@@ -103,7 +103,6 @@ export function SafeProposalWithActionsCreatePage() {
   const { addressPrefix } = useNetworkConfigStore();
 
   const HEADER_HEIGHT = useHeaderHeight();
-  const location = useLocation();
   const { t } = useTranslation('proposal');
   const navigate = useNavigate();
   const { resetActions } = useProposalActionsStore();
@@ -115,8 +114,6 @@ export function SafeProposalWithActionsCreatePage() {
       </Center>
     );
   }
-
-  const prevStepUrl = `${location.pathname.replace(CreateProposalSteps.TRANSACTIONS, CreateProposalSteps.METADATA)}${location.search}`;
 
   const pageHeaderBreadcrumbs = [
     {
@@ -134,18 +131,22 @@ export function SafeProposalWithActionsCreatePage() {
     navigate(DAO_ROUTES.proposals.relative(addressPrefix, safe.address));
   };
 
-  const stepButtons = ({ createProposalBlocked }: { createProposalBlocked: boolean }) => {
-    return (
-      <StepButtons
-        metadataStepButtons={<CreateProposalButton isDisabled={createProposalBlocked} />}
-        transactionsStepButtons={
-          <>
-            <PreviousButton prevStepUrl={prevStepUrl} />
-            <CreateProposalButton isDisabled={createProposalBlocked} />
-          </>
-        }
-      />
-    );
+  const stepButtons = ({
+    createProposalBlocked,
+    onStepChange,
+  }: {
+    createProposalBlocked: boolean;
+    onStepChange: (step: CreateProposalSteps) => void;
+  }) => {
+    return {
+      metadataStepButtons: <CreateProposalButton isDisabled={createProposalBlocked} />,
+      transactionsStepButtons: (
+        <>
+          <PreviousButton onStepChange={onStepChange} />
+          <CreateProposalButton isDisabled={createProposalBlocked} />
+        </>
+      ),
+    };
   };
 
   return (
@@ -165,25 +166,21 @@ export function SafeProposalWithActionsCreatePage() {
       streamsDetails={null}
       proposalMetadataTypeProps={DEFAULT_PROPOSAL_METADATA_TYPE_PROPS(t)}
       prepareProposalData={prepareProposal}
-      contentRoute={(formikProps, pendingCreateTx, nonce) => {
+      mainContent={(formikProps, pendingCreateTx, nonce, currentStep) => {
+        if (currentStep !== CreateProposalSteps.TRANSACTIONS) return null;
         return (
-          <Route
-            path={CreateProposalSteps.TRANSACTIONS}
-            element={
-              <>
-                <ProposalTransactionsForm
-                  pendingTransaction={pendingCreateTx}
-                  safeNonce={safe?.nextNonce}
-                  isProposalMode={true}
-                  {...formikProps}
-                />
-                <ShowNonceInputOnMultisig
-                  nonce={nonce}
-                  nonceOnChange={newNonce => formikProps.setFieldValue('nonce', newNonce)}
-                />
-              </>
-            }
-          />
+          <>
+            <ProposalTransactionsForm
+              pendingTransaction={pendingCreateTx}
+              safeNonce={safe?.nextNonce}
+              isProposalMode={true}
+              {...formikProps}
+            />
+            <ShowNonceInputOnMultisig
+              nonce={nonce}
+              nonceOnChange={newNonce => formikProps.setFieldValue('nonce', newNonce)}
+            />
+          </>
         );
       }}
     />

--- a/src/pages/dao/proposals/new/SafeProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/SafeProposalCreatePage.tsx
@@ -107,18 +107,12 @@ export function SafeProposalCreatePage() {
       mainContent={(formikProps, pendingCreateTx, nonce, currentStep) => {
         if (currentStep !== CreateProposalSteps.TRANSACTIONS) return null;
         return (
-          <>
-            <ProposalTransactionsForm
-              pendingTransaction={pendingCreateTx}
-              safeNonce={safe?.nextNonce}
-              isProposalMode={true}
-              {...formikProps}
-            />
-            <ShowNonceInputOnMultisig
-              nonce={nonce}
-              nonceOnChange={newNonce => formikProps.setFieldValue('nonce', newNonce)}
-            />
-          </>
+          <ProposalTransactionsForm
+            pendingTransaction={pendingCreateTx}
+            safeNonce={safe?.nextNonce}
+            isProposalMode={true}
+            {...formikProps}
+          />
         );
       }}
     />

--- a/src/pages/dao/proposals/new/SafeProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/SafeProposalCreatePage.tsx
@@ -3,18 +3,11 @@ import { Center } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import {
-  ProposalBuilder,
-  ShowNonceInputOnMultisig,
-} from '../../../../components/ProposalBuilder/ProposalBuilder';
+import { ProposalBuilder } from '../../../../components/ProposalBuilder/ProposalBuilder';
 import { TransactionsDetails } from '../../../../components/ProposalBuilder/ProposalDetails';
 import { DEFAULT_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../components/ProposalBuilder/ProposalMetadata';
 import ProposalTransactionsForm from '../../../../components/ProposalBuilder/ProposalTransactionsForm';
-import {
-  CreateProposalButton,
-  NextButton,
-  PreviousButton,
-} from '../../../../components/ProposalBuilder/StepButtons';
+import { NextButton } from '../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_PROPOSAL } from '../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
 import { useHeaderHeight } from '../../../../constants/common';
@@ -68,28 +61,17 @@ export function SafeProposalCreatePage() {
 
   const stepButtons = ({
     formErrors,
-    createProposalBlocked,
     onStepChange,
   }: {
     formErrors: boolean;
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
-  }) => {
-    return {
-      metadataStepButtons: (
-        <NextButton
-          isDisabled={formErrors}
-          onStepChange={onStepChange}
-        />
-      ),
-      transactionsStepButtons: (
-        <>
-          <PreviousButton onStepChange={onStepChange} />
-          <CreateProposalButton isDisabled={createProposalBlocked} />
-        </>
-      ),
-    };
-  };
+  }) => (
+    <NextButton
+      isDisabled={formErrors}
+      onStepChange={onStepChange}
+    />
+  );
 
   return (
     <ProposalBuilder

--- a/src/pages/dao/proposals/new/SafeProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/SafeProposalCreatePage.tsx
@@ -7,7 +7,7 @@ import { ProposalBuilder } from '../../../../components/ProposalBuilder/Proposal
 import { TransactionsDetails } from '../../../../components/ProposalBuilder/ProposalDetails';
 import { DEFAULT_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../components/ProposalBuilder/ProposalMetadata';
 import ProposalTransactionsForm from '../../../../components/ProposalBuilder/ProposalTransactionsForm';
-import { NextButton } from '../../../../components/ProposalBuilder/StepButtons';
+import { GoToTransactionsStepButton } from '../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_PROPOSAL } from '../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../components/ui/loaders/BarLoader';
 import { useHeaderHeight } from '../../../../constants/common';
@@ -67,7 +67,7 @@ export function SafeProposalCreatePage() {
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
   }) => (
-    <NextButton
+    <GoToTransactionsStepButton
       isDisabled={formErrors}
       onStepChange={onStepChange}
     />

--- a/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
@@ -183,17 +183,11 @@ export function SafeSablierProposalCreatePage() {
       mainContent={(formikProps, pendingCreateTx, nonce, currentStep) => {
         if (currentStep !== CreateProposalSteps.TRANSACTIONS) return null;
         return (
-          <>
-            <ProposalStreams
-              pendingTransaction={pendingCreateTx}
-              {...formikProps}
-              values={formikProps.values as CreateSablierProposalForm}
-            />
-            <ShowNonceInputOnMultisig
-              nonce={nonce}
-              nonceOnChange={newNonce => formikProps.setFieldValue('nonce', newNonce)}
-            />
-          </>
+          <ProposalStreams
+            pendingTransaction={pendingCreateTx}
+            {...formikProps}
+            values={formikProps.values as CreateSablierProposalForm}
+          />
         );
       }}
     />

--- a/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
@@ -6,18 +6,11 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Address, encodeFunctionData, erc20Abi, getAddress, Hash, zeroAddress } from 'viem';
 import SablierV2BatchAbi from '../../../../../assets/abi/SablierV2Batch';
-import {
-  ProposalBuilder,
-  ShowNonceInputOnMultisig,
-} from '../../../../../components/ProposalBuilder/ProposalBuilder';
+import { ProposalBuilder } from '../../../../../components/ProposalBuilder/ProposalBuilder';
 import { StreamsDetails } from '../../../../../components/ProposalBuilder/ProposalDetails';
 import { DEFAULT_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../../components/ProposalBuilder/ProposalMetadata';
 import { ProposalStreams } from '../../../../../components/ProposalBuilder/ProposalStreams';
-import {
-  CreateProposalButton,
-  NextButton,
-  PreviousButton,
-} from '../../../../../components/ProposalBuilder/StepButtons';
+import { NextButton } from '../../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_SABLIER_PROPOSAL } from '../../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../../components/ui/loaders/BarLoader';
 import { useHeaderHeight } from '../../../../../constants/common';
@@ -144,28 +137,17 @@ export function SafeSablierProposalCreatePage() {
 
   const stepButtons = ({
     formErrors,
-    createProposalBlocked,
     onStepChange,
   }: {
     formErrors: boolean;
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
-  }) => {
-    return {
-      metadataStepButtons: (
-        <NextButton
-          isDisabled={formErrors}
-          onStepChange={onStepChange}
-        />
-      ),
-      transactionsStepButtons: (
-        <>
-          <PreviousButton onStepChange={onStepChange} />
-          <CreateProposalButton isDisabled={createProposalBlocked} />
-        </>
-      ),
-    };
-  };
+  }) => (
+    <NextButton
+      isDisabled={formErrors}
+      onStepChange={onStepChange}
+    />
+  );
 
   return (
     <ProposalBuilder

--- a/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
+++ b/src/pages/dao/proposals/new/sablier/SafeSablierProposalCreatePage.tsx
@@ -10,7 +10,7 @@ import { ProposalBuilder } from '../../../../../components/ProposalBuilder/Propo
 import { StreamsDetails } from '../../../../../components/ProposalBuilder/ProposalDetails';
 import { DEFAULT_PROPOSAL_METADATA_TYPE_PROPS } from '../../../../../components/ProposalBuilder/ProposalMetadata';
 import { ProposalStreams } from '../../../../../components/ProposalBuilder/ProposalStreams';
-import { NextButton } from '../../../../../components/ProposalBuilder/StepButtons';
+import { GoToTransactionsStepButton } from '../../../../../components/ProposalBuilder/StepButtons';
 import { DEFAULT_SABLIER_PROPOSAL } from '../../../../../components/ProposalBuilder/constants';
 import { BarLoader } from '../../../../../components/ui/loaders/BarLoader';
 import { useHeaderHeight } from '../../../../../constants/common';
@@ -143,7 +143,7 @@ export function SafeSablierProposalCreatePage() {
     createProposalBlocked: boolean;
     onStepChange: (step: CreateProposalSteps) => void;
   }) => (
-    <NextButton
+    <GoToTransactionsStepButton
       isDisabled={formErrors}
       onStepChange={onStepChange}
     />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -133,17 +133,8 @@ export const router = (addressPrefix: string, daoAddress: string | undefined) =>
                   element: <SafeProposalTemplatesPage />,
                 },
                 {
-                  path: 'new/*',
-                  element: <SafeCreateProposalTemplatePage />,
-                },
-                {
                   path: 'new',
-                  loader: () =>
-                    redirect(
-                      daoAddress
-                        ? DAO_ROUTES.proposalTemplateNew.relative(addressPrefix, daoAddress)
-                        : BASE_ROUTES.landing,
-                    ),
+                  element: <SafeCreateProposalTemplatePage />,
                 },
               ],
             },
@@ -164,45 +155,16 @@ export const router = (addressPrefix: string, daoAddress: string | undefined) =>
                   element: <SafeProposalDetailsPage />,
                 },
                 {
-                  path: 'new/*',
+                  path: 'new',
                   element: <SafeProposalCreatePage />,
                 },
                 {
-                  path: 'actions/new/*',
+                  path: 'actions/new',
                   element: <SafeProposalWithActionsCreatePage />,
                 },
                 {
-                  path: 'actions/new',
-                  loader: () =>
-                    redirect(
-                      daoAddress
-                        ? DAO_ROUTES.proposalWithActionsNew.relative(addressPrefix, daoAddress)
-                        : BASE_ROUTES.landing,
-                    ),
-                },
-                {
-                  path: 'new',
-                  loader: () =>
-                    redirect(
-                      daoAddress
-                        ? DAO_ROUTES.proposalNew.relative(addressPrefix, daoAddress)
-                        : BASE_ROUTES.landing,
-                    ),
-                },
-                {
-                  path: 'new/sablier/*',
-                  element: <SafeSablierProposalCreatePage />,
-                },
-                {
                   path: 'new/sablier',
-                  loader: () =>
-                    redirect(
-                      daoAddress
-                        ? DAO_ROUTES.proposalNew
-                            .relative(addressPrefix, daoAddress)
-                            .replace('new', 'new/sablier')
-                        : BASE_ROUTES.landing,
-                    ),
+                  element: <SafeSablierProposalCreatePage />,
                 },
               ],
             },


### PR DESCRIPTION
Closes https://linear.app/decent-labs/issue/ENG-186/remove-url-page-state-from-proposal-builder

refactor: simplify proposal builder step management

- Remove URL path params for managing proposal builder steps
- Replace URL-based navigation with local React state in ProposalBuilder
- Update StepButtons component to use props instead of reading URL
- Rename contentRoute prop to mainContent for clarity
- Remove redundant redirects and path wildcards from router
- Update all proposal creation pages to use new step management pattern

This change simplifies the step management in the proposal creation flow by 
using React state instead of URL parameters. This makes the code more 
maintainable and removes unnecessary URL complexity while keeping the same 
functionality.