### PR TITLE
`[ENG-90]`  Resetting ABI selector state on failure

### DIFF
--- a/src/components/ui/forms/ABISelector.tsx
+++ b/src/components/ui/forms/ABISelector.tsx
@@ -49,10 +49,15 @@ export default function ABISelector({ target, onChange }: IABISelector) {
           if (responseData.status === '1') {
             const fetchedABI = JSON.parse(responseData.result);
             setABI(fetchedABI);
+          } else {
+            setABI([]);
           }
         } catch (e) {
+          setABI([]);
           logError(e, 'Error fetching ABI for smart contract');
         }
+      } else {
+        setABI([]);
       }
     };
     loadABI();


### PR DESCRIPTION
Closes [ENG-90](https://linear.app/decent-labs/issue/ENG-90/proposal-builder-target-address)

![abi-selector-reset](https://github.com/user-attachments/assets/9d89e6ed-d185-467d-b9c0-5249734e9ffb)
