### PR TITLE
`[ENG-71]` Role Term 'pending' Showing incorrectly

### DIFF
--- a/src/components/Roles/RoleCard.tsx
+++ b/src/components/Roles/RoleCard.tsx
@@ -188,7 +188,6 @@ function Payment({ payment }: { payment: SablierPaymentFormValues }) {
 export function RoleCard({
   name,
   wearerAddress,
-  isTermed,
   paymentsCount,
   handleRoleClick,
   isCurrentTermActive,
@@ -205,9 +204,7 @@ export function RoleCard({
           name={name}
           paymentsCount={paymentsCount}
         />
-        {isTermed && (
-          <EditBadge editStatus={!isCurrentTermActive ? EditBadgeStatus.Inactive : undefined} />
-        )}
+        <EditBadge editStatus={!isCurrentTermActive ? EditBadgeStatus.Inactive : undefined} />
       </Flex>
     </Card>
   );

--- a/src/components/Roles/RolesTable.tsx
+++ b/src/components/Roles/RolesTable.tsx
@@ -105,8 +105,10 @@ function MemberColumn({
   const avatarURL = useAvatar(accountDisplayName);
 
   const { t } = useTranslation('roles');
-  const memberTextColor = isCurrentTermActive === false ? 'neutral-6' : 'white-0';
-  const isPendingText = isMemberTermPending === true ? t('wearerPending') : '';
+
+  // @dev undefined = not termed
+  const memberTextColor = !isCurrentTermActive ? 'neutral-6' : 'white-0';
+  const isPendingText = isMemberTermPending ? t('wearerPending') : '';
 
   const wearerAddressText = wearerAddress
     ? `${accountDisplayName} ${isPendingText}`

--- a/src/components/Roles/RolesTable.tsx
+++ b/src/components/Roles/RolesTable.tsx
@@ -342,17 +342,17 @@ export function RolesEditTable({ handleRoleClick }: { handleRoleClick: (hatId: H
           {values.hats.map(role => {
             const existingRole = getHat(role.id);
             const isCurrentTermActive = existingRole?.roleTerms.currentTerm?.isActive;
+            const roleTermNominee = role.roleTerms?.[0].nominee;
             const isMemberTermPending =
-              !isCurrentTermActive && existingRole?.wearerAddress !== role.roleTerms?.[0].nominee;
-
+              !isCurrentTermActive && existingRole?.wearerAddress !== roleTermNominee;
             return (
               <RolesRowEdit
                 key={role.id}
                 name={role.name}
                 wearerAddress={
                   role.isTermed
-                    ? role.roleTerms?.[0].nominee
-                      ? getAddress(role.roleTerms?.[0].nominee)
+                    ? roleTermNominee
+                      ? getAddress(roleTermNominee)
                       : undefined
                     : role.resolvedWearer
                 }

--- a/src/pages/dao/roles/SafeRolesPage.tsx
+++ b/src/pages/dao/roles/SafeRolesPage.tsx
@@ -94,7 +94,6 @@ export function SafeRolesPage() {
                 <RoleCard
                   key={roleHat.id}
                   name={roleHat.name}
-                  isTermed={roleHat.isTermed}
                   wearerAddress={
                     roleHat.roleTerms.currentTerm?.isActive
                       ? roleHat.roleTerms.currentTerm?.nominee

--- a/src/pages/dao/roles/edit/SafeRolesEditPage.tsx
+++ b/src/pages/dao/roles/edit/SafeRolesEditPage.tsx
@@ -34,7 +34,7 @@ export function SafeRolesEditPage() {
 
   const { values, setFieldValue } = useFormikContext<RoleFormValues>();
 
-  const { hatsTree } = useRolesStore();
+  const { hatsTree, getHat } = useRolesStore();
 
   const navigate = useNavigate();
 
@@ -127,20 +127,28 @@ export function SafeRolesEditPage() {
               emptyTextNotProposer="noRolesNotProposer"
             />
           )}
-          {values.hats.map(hat => (
-            <RoleCardEdit
-              key={hat.id}
-              name={hat.name}
-              wearerAddress={hat.resolvedWearer}
-              editStatus={hat.editedRole?.status}
-              handleRoleClick={() => {
-                setFieldValue('roleEditing', hat);
-                showRoleEditDetails(hat.id);
-              }}
-              payments={hat.payments}
-              isTermed={!!hat.isTermed}
-            />
-          ))}
+          {values.hats.map(hat => {
+            const existingRole = getHat(hat.id);
+            const isCurrentTermActive = existingRole?.roleTerms.currentTerm?.isActive;
+            const isMemberTermPending =
+              !isCurrentTermActive && existingRole?.wearerAddress !== hat.roleTerms?.[0].nominee;
+            return (
+              <RoleCardEdit
+                key={hat.id}
+                name={hat.name}
+                wearerAddress={hat.resolvedWearer}
+                editStatus={hat.editedRole?.status}
+                handleRoleClick={() => {
+                  setFieldValue('roleEditing', hat);
+                  showRoleEditDetails(hat.id);
+                }}
+                payments={hat.payments}
+                isTermed={!!hat.isTermed}
+                isCurrentTermActive={isCurrentTermActive}
+                isMemberTermPending={isMemberTermPending}
+              />
+            );
+          })}
         </Show>
       </Box>
       <Flex

--- a/src/pages/dao/roles/edit/SafeRolesEditPage.tsx
+++ b/src/pages/dao/roles/edit/SafeRolesEditPage.tsx
@@ -143,7 +143,6 @@ export function SafeRolesEditPage() {
                   showRoleEditDetails(hat.id);
                 }}
                 payments={hat.payments}
-                isTermed={!!hat.isTermed}
                 isCurrentTermActive={isCurrentTermActive}
                 isMemberTermPending={isMemberTermPending}
               />

--- a/src/types/roles.tsx
+++ b/src/types/roles.tsx
@@ -81,8 +81,7 @@ export interface RoleProps {
   name: string;
   wearerAddress?: Address;
   paymentsCount?: number;
-  isTermed?: boolean;
-  isCurrentTermActive: boolean | undefined;
+  isCurrentTermActive?: boolean | undefined;
   isMemberTermPending?: boolean;
 }
 

--- a/src/types/roles.tsx
+++ b/src/types/roles.tsx
@@ -81,7 +81,7 @@ export interface RoleProps {
   name: string;
   wearerAddress?: Address;
   paymentsCount?: number;
-  isCurrentTermActive?: boolean | undefined;
+  isCurrentTermActive?: boolean;
   isMemberTermPending?: boolean;
 }
 

--- a/src/types/roles.tsx
+++ b/src/types/roles.tsx
@@ -81,8 +81,9 @@ export interface RoleProps {
   name: string;
   wearerAddress?: Address;
   paymentsCount?: number;
-  isTermed: boolean;
-  isCurrentTermActive?: boolean;
+  isTermed?: boolean;
+  isCurrentTermActive: boolean | undefined;
+  isMemberTermPending?: boolean;
 }
 
 export interface RoleEditProps


### PR DESCRIPTION
Closes [ENG-71](https://linear.app/decent-labs/issue/ENG-71/bugfix-member-field-pending-when-no-terms)

I don't have the before shot, but the logic was missing and was missing an update.

![localhost_3000_roles_edit_dao=sep_0x908c810A53D634E82FE810407e97C3c9073545c4(Desktop) (1)](https://github.com/user-attachments/assets/19d5f70b-c13c-481b-aefe-1c767363aae4)
