### PR TITLE
`[ENG-165]` Attempted fix for the issue of setting incorrect governance type

### DIFF
--- a/src/hooks/DAO/loaders/useFractalGovernance.ts
+++ b/src/hooks/DAO/loaders/useFractalGovernance.ts
@@ -107,8 +107,10 @@ export const useFractalGovernance = () => {
       linearVotingErc20WithHatsWhitelistingAddress,
       linearVotingErc721WithHatsWhitelistingAddress,
     } = governanceContracts;
+    if (isLoaded) {
+      // Reset loadKey to guarantee re-loading proposals after setting / updating governance type
+      loadKey.current = undefined;
 
-    if (isLoaded && !type) {
       if (moduleAzoriusAddress) {
         if (linearVotingErc20Address || linearVotingErc20WithHatsWhitelistingAddress) {
           action.dispatch({
@@ -143,7 +145,6 @@ export const useFractalGovernance = () => {
     loadERC721Strategy,
     loadERC721Tokens,
     action,
-    type,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Changes

- Change logic of loading / setting governance type so that governance type could change in the middle (seems like that is happening when governance contracts weren't loaded from on-chain due to RPC / network issues)
- Reload proposals when setting governance type via resetting loading key

## Issues
- `ENG-165`

## Testing

Unfortunately, there's no way to reproduce the issue - it seems like it's rather occurring when reloading page multiple times so that you start hitting the limit either on RPC side or Safe API side. So eventually, these changes might lead to flickering when governance contracts weren't loaded properly at first try. So, the way to test it would be to open prod site and HIT DA RELOAD BUTTON MANY MANY TIMES - until you'll catch the issue of wrongly displayed governance information and missing proposals (for ERC-20 / ERC-721 DAOs)

Now, try the same tactic with these changes - make sure you ain't ever ending up in "locked" state - aka governance is always eventually loads, even if there's some flickering in between.

@decentdao/engineering this is rather debatable solution - flickering page looks bad, but even worse when customer is present with completely wrong state of the application. I'm happy to discuss and brainstorm better ideas