### PR TITLE
`[ENG-180 | ENG-182]` Unsupported ENS networks

### DIFF
--- a/src/hooks/useNetworkEnsAddress.ts
+++ b/src/hooks/useNetworkEnsAddress.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
 import { useEnsAddress } from 'wagmi';
 import {
   supportedEnsNetworks,
@@ -13,13 +14,18 @@ interface UseNetworkEnsAddressProps {
 
 export function useNetworkEnsAddress(props?: UseNetworkEnsAddressProps) {
   const { chain } = useNetworkConfigStore();
-  const propsOrFallbackChainId = props?.chainId ?? chain.id;
 
-  if (!supportedEnsNetworks.includes(propsOrFallbackChainId)) {
-    throw new Error(`ENS is not supported for chain ${propsOrFallbackChainId}`);
+  let effectiveChainId: number;
+  if (props?.chainId !== undefined) {
+    if (!supportedEnsNetworks.includes(props.chainId)) {
+      throw new Error(`ENS is not supported for chain ${props.chainId}`);
+    }
+    effectiveChainId = props.chainId;
+  } else {
+    effectiveChainId = supportedEnsNetworks.includes(chain.id) ? chain.id : mainnet.id;
   }
 
-  return useEnsAddress({ name: props?.name, chainId: propsOrFallbackChainId });
+  return useEnsAddress({ name: props?.name, chainId: effectiveChainId });
 }
 
 export function useNetworkEnsAddressAsync() {
@@ -27,12 +33,17 @@ export function useNetworkEnsAddressAsync() {
 
   const getEnsAddress = useCallback(
     (args: { name: string; chainId?: number }) => {
-      const propsOrFallbackChainId = args?.chainId ?? chain.id;
-      if (!supportedEnsNetworks.includes(propsOrFallbackChainId)) {
-        throw new Error(`ENS is not supported for chain ${propsOrFallbackChainId}`);
+      let effectiveChainId: number;
+      if (args.chainId !== undefined) {
+        if (!supportedEnsNetworks.includes(args.chainId)) {
+          throw new Error(`ENS is not supported for chain ${args.chainId}`);
+        }
+        effectiveChainId = args.chainId;
+      } else {
+        effectiveChainId = supportedEnsNetworks.includes(chain.id) ? chain.id : mainnet.id;
       }
 
-      const networkConfig = getConfigByChainId(propsOrFallbackChainId);
+      const networkConfig = getConfigByChainId(effectiveChainId);
       const publicClient = createPublicClient({
         chain: networkConfig.chain,
         transport: http(networkConfig.rpcEndpoint),

--- a/src/hooks/useNetworkEnsAvatar.ts
+++ b/src/hooks/useNetworkEnsAvatar.ts
@@ -1,3 +1,4 @@
+import { mainnet } from 'viem/chains';
 import { useEnsAvatar } from 'wagmi';
 import {
   supportedEnsNetworks,
@@ -11,11 +12,18 @@ interface UseNetworkEnsAvatarProps {
 
 export function useNetworkEnsAvatar(props?: UseNetworkEnsAvatarProps) {
   const { chain } = useNetworkConfigStore();
-  const propsOrFallbackChainId = props?.chainId ?? chain.id;
 
-  if (!supportedEnsNetworks.includes(propsOrFallbackChainId)) {
-    throw new Error(`ENS is not supported for chain ${propsOrFallbackChainId}`);
+  let effectiveChainId: number;
+
+  if (props?.chainId !== undefined) {
+    if (!supportedEnsNetworks.includes(props.chainId)) {
+      throw new Error(`ENS is not supported for chain ${props.chainId}`);
+    }
+    effectiveChainId = props.chainId;
+  } else {
+    // Use the network's chain id if supported, otherwise fallback to mainnet.
+    effectiveChainId = supportedEnsNetworks.includes(chain.id) ? chain.id : mainnet.id;
   }
 
-  return useEnsAvatar({ name: props?.name, chainId: propsOrFallbackChainId });
+  return useEnsAvatar({ name: props?.name, chainId: effectiveChainId });
 }

--- a/src/hooks/useNetworkEnsName.ts
+++ b/src/hooks/useNetworkEnsName.ts
@@ -14,13 +14,20 @@ interface UseNetworkEnsNameProps {
 
 export function useNetworkEnsName(props?: UseNetworkEnsNameProps) {
   const { chain } = useNetworkConfigStore();
-  const propsOrFallbackChainId = props?.chainId ?? chain.id;
 
-  if (!supportedEnsNetworks.includes(propsOrFallbackChainId)) {
-    throw new Error(`ENS is not supported for chain ${propsOrFallbackChainId}`);
+  let effectiveChainId: number;
+
+  if (props?.chainId !== undefined) {
+    if (!supportedEnsNetworks.includes(props.chainId)) {
+      throw new Error(`ENS is not supported for chain ${props.chainId}`);
+    }
+    effectiveChainId = props.chainId;
+  } else {
+    // No explicit chainId: use network chain id if supported, otherwise fallback to mainnet.
+    effectiveChainId = supportedEnsNetworks.includes(chain.id) ? chain.id : mainnet.id;
   }
 
-  return useEnsName({ address: props?.address, chainId: propsOrFallbackChainId });
+  return useEnsName({ address: props?.address, chainId: effectiveChainId });
 }
 
 export function useNetworkEnsNameAsync() {

--- a/src/hooks/useNetworkEnsName.ts
+++ b/src/hooks/useNetworkEnsName.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { Address, createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
 import { useEnsName } from 'wagmi';
 import {
   supportedEnsNetworks,
@@ -27,12 +28,19 @@ export function useNetworkEnsNameAsync() {
 
   const getEnsName = useCallback(
     (args: { address: Address; chainId?: number }) => {
-      const propsOrFallbackChainId = args?.chainId ?? chain.id;
-      if (!supportedEnsNetworks.includes(propsOrFallbackChainId)) {
-        throw new Error(`ENS is not supported for chain ${propsOrFallbackChainId}`);
+      let effectiveChainId: number;
+
+      if (args.chainId !== undefined) {
+        if (!supportedEnsNetworks.includes(args.chainId)) {
+          throw new Error(`ENS is not supported for chain ${args.chainId}`);
+        }
+        effectiveChainId = args.chainId;
+      } else {
+        // No chain id provided: try to use network chain id, otherwise fallback to mainnet.
+        effectiveChainId = supportedEnsNetworks.includes(chain.id) ? chain.id : mainnet.id;
       }
 
-      const networkConfig = getConfigByChainId(propsOrFallbackChainId);
+      const networkConfig = getConfigByChainId(effectiveChainId);
       const publicClient = createPublicClient({
         chain: networkConfig.chain,
         transport: http(networkConfig.rpcEndpoint),


### PR DESCRIPTION
sorry @DarksightKellar 

Closes [ENG-180](https://linear.app/decent-labs/issue/ENG-180/deployed-a-base-dao-doesnt-load)
Closes [ENG-182](https://linear.app/decent-labs/issue/ENG-182/deployed-a-polygon-dao-does-not-load)

@adamgall Called out about the fallback to mainnet, but I pushed back only thinking about the argument `chainId` and protecting against unintentionally setting it to call an unsupported network.

## Screenshots

![localhost_3000_home_dao=matic%3A0x9Ad33122747aFE4d9AB2b51e048985549c64603a page=1 size=10(Desktop)](https://github.com/user-attachments/assets/2d5f2436-760c-4bbf-b989-c3ae3f5e2dd1)
