### PR TITLE
`[ENG-190] | Hotfix v0.5.2` Nonce typing from Safe incorrect

### DIFF
--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -89,6 +89,8 @@ class EnhancedSafeApiKit extends SafeApiKit {
     const nextNonce = await this.getNextNonce(checksummedSafeAddress);
     const safeInfo = {
       ...safeInfoResponse,
+      // @dev response from safe; nonce is string, typed as number
+      nonce: Number(safeInfoResponse.nonce),
       nextNonce,
     };
     return safeInfo;


### PR DESCRIPTION
Closes [ENG-190](https://linear.app/decent-labs/issue/ENG-190/multisig-cannot-execute-proposal)

Traced the weird conditional failure all the way back to the nonce we receive from Safe's API. The API's `SafeInfoResponse` type for nonce `number` but actually typed a `string` on the response...Something has changed as of like yesterday?

This change is basically causing any `===` comparison to fail comparing against the proposal's nonce

Edit: Updated the SafeApi SDK to latest reveals this change to `SafeInfoResponse`. nonce is indeed a string