### PR TITLE
Fix DeFi Positions fetching and transforming

### DIFF
--- a/functions/balances/index.ts
+++ b/functions/balances/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { TokenBalance } from '../../src/types/daoTreasury';
-import { fetchMoralis } from '../shared/moralisApi';
+import { fetchMoralis, fetchMoralisDefi } from '../shared/moralisApi';
 import { DefiResponse, NFTResponse, TokenResponse } from '../shared/moralisTypes';
 import type { Env } from '../types';
 import { withBalanceCache } from './balanceCache';
@@ -48,7 +48,7 @@ const endpoints = {
     moralisPath: (address: string) => `/wallets/${address}/defi/positions`,
     transform: transformDefiResponse,
     fetch: async ({ chain, address }: { chain: string; address: string }, c: { env: Env }) => {
-      const result = await fetchMoralis<DefiResponse>({
+      const result = await fetchMoralisDefi<DefiResponse>({
         endpoint: endpoints.defi.moralisPath(address),
         chain,
         apiKey: c.env.MORALIS_API_KEY,

--- a/functions/balances/index.ts
+++ b/functions/balances/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { TokenBalance } from '../../src/types/daoTreasury';
-import { fetchMoralis, fetchMoralisDefi } from '../shared/moralisApi';
+import { fetchMoralis } from '../shared/moralisApi';
 import { DefiResponse, NFTResponse, TokenResponse } from '../shared/moralisTypes';
 import type { Env } from '../types';
 import { withBalanceCache } from './balanceCache';
@@ -48,7 +48,8 @@ const endpoints = {
     moralisPath: (address: string) => `/wallets/${address}/defi/positions`,
     transform: transformDefiResponse,
     fetch: async ({ chain, address }: { chain: string; address: string }, c: { env: Env }) => {
-      const result = await fetchMoralisDefi<DefiResponse>({
+      const result = await fetchMoralis<DefiResponse>({
+        isPaginated: false,
         endpoint: endpoints.defi.moralisPath(address),
         chain,
         apiKey: c.env.MORALIS_API_KEY,

--- a/functions/balances/transformers.ts
+++ b/functions/balances/transformers.ts
@@ -32,5 +32,34 @@ export function transformNFTResponse(nft: NFTResponse): NFTBalance {
 }
 
 export function transformDefiResponse(defi: DefiResponse): DefiBalance {
-  return defi;
+  return {
+    protocolName: defi.protocol_name,
+    protocolId: defi.protocol,
+    protocolUrl: defi.protocol_url,
+    protocolLogo: defi.protocol_logo,
+    position: {
+      label: defi.position.label || '',
+      tokens: (defi.position.tokens || []).map(token => ({
+        contractAddress: token.contract_address,
+        tokenType: token.token_type as 'supplied' | 'defi-token',
+        symbol: token.symbol,
+        name: token.name,
+        decimals: token.decimals,
+        balance: token.balance,
+        balanceFormatted: token.balance_formatted,
+        logo: token.logo,
+        thumbnail: token.thumbnail,
+        usdPrice: token.usd_price,
+        usdValue: token.usd_value,
+        nativeToken: false,
+        portfolioPercentage: 0,
+        tokenAddress: token.contract_address || '',
+        verifiedContract: true,
+      })),
+      address: defi.position.address,
+      balanceUsd: defi.position.balance_usd || 0,
+      totalUnclaimedUsdValue: defi.position.total_unclaimed_usd_value || 0,
+      positionDetails: defi.position.position_details || undefined,
+    },
+  };
 }

--- a/functions/shared/moralisApi.ts
+++ b/functions/shared/moralisApi.ts
@@ -75,8 +75,3 @@ export async function fetchMoralis<T>({
 
   return allResults;
 }
-
-// Thin wrapper for DeFi-specific endpoints which don't use pagination
-export async function fetchMoralisDefi<T>(config: MoralisRequestConfig): Promise<T[]> {
-  return fetchMoralis<T>({ ...config, isPaginated: false });
-}

--- a/functions/shared/moralisApi.ts
+++ b/functions/shared/moralisApi.ts
@@ -25,9 +25,12 @@ export async function fetchMoralis<T>({
 }: MoralisRequestConfig): Promise<T[]> {
   let allResults: T[] = [];
   let cursor: string | null = null;
+  let pageCount = 0;
   const limit = 100;
+  const MAX_PAGES = 10; // Safeguard against infinite loops
 
   do {
+    pageCount++;
     const chainHex = toHex(parseInt(chain));
     const url = new URL(`https://deep-index.moralis.io/api/v2.2${endpoint}`);
 
@@ -47,16 +50,34 @@ export async function fetchMoralis<T>({
       url.searchParams.append(key, value);
     });
 
-    const response = await fetch(url, {
-      headers: {
-        Accept: 'application/json',
-        'x-api-key': apiKey,
-      },
-      method: 'GET',
-    });
+    let response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+          'x-api-key': apiKey,
+        },
+        method: 'GET',
+      });
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      if (!response.ok) {
+        console.error('Moralis API HTTP error:', {
+          endpoint,
+          status: response.status,
+          statusText: response.statusText,
+          chain: chainHex,
+          params,
+        });
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+    } catch (error) {
+      console.error('Moralis API fetch error:', {
+        endpoint,
+        chain: chainHex,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        params,
+      });
+      throw error;
     }
 
     const data = await response.json();
@@ -64,12 +85,38 @@ export async function fetchMoralis<T>({
     // Handle paginated vs non-paginated responses
     if (isPaginated) {
       const paginatedData = data as MoralisResponse<T>;
-      if (!paginatedData || !paginatedData.result) break;
+      if (!paginatedData || !paginatedData.result) {
+        console.error('Unexpected Moralis API response structure:', {
+          endpoint,
+          responseData: data,
+          isPaginatedButMissingRequiredFields: true,
+        });
+        break;
+      }
       allResults = allResults.concat(paginatedData.result);
       cursor = paginatedData.cursor;
+
+      // Log if we're hitting pagination limits
+      if (pageCount >= MAX_PAGES && cursor !== null) {
+        console.warn('Moralis API pagination limit reached:', {
+          endpoint,
+          pageCount,
+          totalResultsCount: allResults.length,
+          hasMoreData: true,
+        });
+        break;
+      }
     } else {
       // For non-paginated endpoints, data is the direct array
-      return Array.isArray(data) ? data : [];
+      if (!Array.isArray(data)) {
+        console.error('Unexpected Moralis API response structure:', {
+          endpoint,
+          responseData: data,
+          expectedArray: true,
+        });
+        return [];
+      }
+      return data;
     }
   } while (cursor !== null && isPaginated);
 

--- a/functions/shared/moralisTypes.ts
+++ b/functions/shared/moralisTypes.ts
@@ -1,4 +1,4 @@
-import { DefiPosition, NFTMedia } from '../../src/types/daoTreasury';
+import { NFTMedia } from '../../src/types/daoTreasury';
 
 export type TokenResponse = {
   balance: string;
@@ -54,11 +54,33 @@ export type NFTResponse = {
   floor_price_currency: string | null;
 };
 
-export type DefiResponse = {
-  chain: string;
+interface DefiTokenResponse {
+  contract_address?: string;
+  token_type: 'supplied' | 'defi-token';
+  symbol: string;
+  name: string;
+  decimals: number;
+  balance: string;
+  balance_formatted: string;
+  logo?: string;
+  thumbnail?: string;
+  usd_price?: number;
+  usd_value?: number;
+}
+
+interface DefiPositionResponse {
+  label: string;
+  tokens: DefiTokenResponse[];
+  address?: string;
+  balance_usd: number;
+  total_unclaimed_usd_value: number;
+  position_details?: Record<string, any>;
+}
+
+export interface DefiResponse {
+  protocol_name: string;
   protocol: string;
-  protocolId: string;
-  protocolUrl: string;
-  protocolLogo: string;
-  position: DefiPosition;
-};
+  protocol_url: string;
+  protocol_logo: string;
+  position: DefiPositionResponse;
+}


### PR DESCRIPTION
Closes https://linear.app/decent-labs/issue/ENG-196/moralis-defi-positions-api-is-currently-broken

- Update Moralis API to support non-paginated endpoints
- Enhance DefiResponse transformer to map Moralis response to a more structured format
- Add fetchMoralisDefi helper function for DeFi-specific API calls
- Improve type definitions for DeFi-related responses