### PR TITLE
`[ENG-199]` Prevent proposal submission when selecting term

### DIFF
--- a/src/components/Roles/forms/RoleFormPaymentStreamTermed.tsx
+++ b/src/components/Roles/forms/RoleFormPaymentStreamTermed.tsx
@@ -247,6 +247,7 @@ function TermSelectorMenu({ paymentIndex }: { paymentIndex: number }) {
               _hover={{ bg: 'neutral-3' }}
               _active={{ bg: 'neutral-2' }}
               transition="all ease-out 300ms"
+              type="button"
             >
               {!!selectedTerm && (
                 <Flex


### PR DESCRIPTION
Closes [ENG-199](https://linear.app/decent-labs/issue/ENG-199/selecting-a-term-in-role-payments-workflow-triggers-proposal-creation)

Before:
![before termed payment bug](https://github.com/user-attachments/assets/05632123-45ef-4165-aacc-f44c17a3dca8)

After:
![after termed payment bug](https://github.com/user-attachments/assets/5b939e27-4903-418b-9ca2-c252e8695364)

## Changes

Scratched my head a little, it APPEARS when a type is not defined for the `MenuButton` it gives it the `submit` type. which in this case as this `Menu` is nested within a `form`, tries to submit the form. Defining it as type button seems to work with no side-effects