### PR TITLE
`[ENG-266]` Fix Native token transfer

### DIFF
--- a/src/hooks/DAO/useSendAssetsActionModal.tsx
+++ b/src/hooks/DAO/useSendAssetsActionModal.tsx
@@ -30,7 +30,7 @@ export default function useSendAssetsActionModal() {
     const isNative = isNativeAsset(sendAssetsData.asset);
     const transactionData = prepareSendAssetsActionData(sendAssetsData);
     addAction({
-      actionType: ProposalActionType.TRANSFER,
+      actionType: isNative ? ProposalActionType.TRANSFER_NATIVE : ProposalActionType.TRANSFER,
       content: <></>,
       transactions: [
         {

--- a/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
+++ b/src/pages/dao/proposals/actions/new/SafeProposalWithActionsCreatePage.tsx
@@ -28,27 +28,35 @@ import { useNetworkConfigStore } from '../../../../../providers/NetworkConfig/us
 import { useProposalActionsStore } from '../../../../../store/actions/useProposalActionsStore';
 import { useDaoInfoStore } from '../../../../../store/daoInfo/useDaoInfoStore';
 import { CreateProposalSteps, ProposalActionType } from '../../../../../types';
+import {
+  isNativeAsset,
+  prepareSendAssetsActionData,
+} from '../../../../../utils/dao/prepareSendAssetsActionData';
 
 function ActionsExperience() {
   const { t } = useTranslation('actions');
   const { actions, addAction } = useProposalActionsStore();
 
   const handleAddSendAssetsAction = (data: SendAssetsData) => {
+    const isNative = isNativeAsset(data.asset);
+    const transactionData = prepareSendAssetsActionData(data);
     addAction({
-      actionType: ProposalActionType.TRANSFER,
+      actionType: isNative ? ProposalActionType.TRANSFER_NATIVE : ProposalActionType.TRANSFER,
       content: <></>,
       transactions: [
         {
-          targetAddress: data.asset.tokenAddress,
+          targetAddress: transactionData.target,
           ethValue: {
-            bigintValue: 0n,
-            value: '0',
+            bigintValue: transactionData.value,
+            value: transactionData.value.toString(),
           },
-          functionName: 'transfer',
-          parameters: [
-            { signature: 'address', value: data.destinationAddress },
-            { signature: 'uint256', value: data.transferAmount.toString() },
-          ],
+          functionName: isNative ? '' : 'transfer',
+          parameters: isNative
+            ? []
+            : [
+                { signature: 'address', value: data.destinationAddress },
+                { signature: 'uint256', value: data.transferAmount.toString() },
+              ],
         },
       ],
     });

--- a/src/types/proposalBuilder.ts
+++ b/src/types/proposalBuilder.ts
@@ -58,6 +58,7 @@ export enum ProposalActionType {
   EDIT = 'edit',
   DELETE = 'delete',
   TRANSFER = 'transfer',
+  TRANSFER_NATIVE = 'transfer_native',
   AIRDROP = 'airdrop',
 }
 


### PR DESCRIPTION
Closes [ENG-266](https://linear.app/decent-labs/issue/ENG-226/app-crash-when-creating-proposal-requesting-eth-payment)

## Changes

- `[main fix]` - Add 'ProposalActionType` - `NATIVE_TRANSFER` to be able to correctly identify and handle native token transfers
- `[main fix]` - clean up code in `SendAssetsAction` to handle undefined values.
- sync implementation of `handleAddSendAssetsAction` in `useSendAssetsActionModal` and `ActionsExperience`