### PR TITLE
Fix role form save logic

### DIFF
--- a/src/components/Roles/forms/RoleFormPaymentStream.tsx
+++ b/src/components/Roles/forms/RoleFormPaymentStream.tsx
@@ -254,7 +254,7 @@ export function RoleFormPaymentStream({ formIndex }: { formIndex: number }) {
                   setFieldValue(`roleEditing.payments.${formIndex}.isValidatedAndSaved`, true);
                 }}
               >
-                {t('save')}
+                {t('savePayment')}
               </Button>
             )}
             {canBeCancelled && (

--- a/src/components/Roles/forms/RoleFormPaymentStream.tsx
+++ b/src/components/Roles/forms/RoleFormPaymentStream.tsx
@@ -245,7 +245,7 @@ export function RoleFormPaymentStream({ formIndex }: { formIndex: number }) {
           </Show>
         )}
         <Flex justifyContent="flex-end">
-          {!streamId && (
+          {/* {!streamId && (
             <Button
               variant="tertiary"
               onClick={() => {
@@ -260,7 +260,7 @@ export function RoleFormPaymentStream({ formIndex }: { formIndex: number }) {
             >
               {t('cancel', { ns: 'common' })}
             </Button>
-          )}
+          )} */}
           {!streamId && (
             <Button
               isDisabled={!!roleEditingPaymentsErrors}

--- a/src/components/Roles/forms/RoleFormPaymentStream.tsx
+++ b/src/components/Roles/forms/RoleFormPaymentStream.tsx
@@ -244,35 +244,33 @@ export function RoleFormPaymentStream({ formIndex }: { formIndex: number }) {
             <PaymentCancelHint />
           </Show>
         )}
-        {(canBeCancelled || !streamId) && (
-          <Flex justifyContent="flex-end">
-            {!streamId && (
+        <Flex justifyContent="flex-end">
+          {!streamId && (
+            <Button
+              isDisabled={!!roleEditingPaymentsErrors}
+              onClick={() => {
+                setFieldValue('roleEditing.roleEditingPaymentIndex', undefined);
+                setFieldValue(`roleEditing.payments.${formIndex}.isValidatedAndSaved`, true);
+              }}
+            >
+              {t('savePayment')}
+            </Button>
+          )}
+          {canBeCancelled && (
+            <Show above="md">
               <Button
-                isDisabled={!!roleEditingPaymentsErrors}
-                onClick={() => {
-                  setFieldValue('roleEditing.roleEditingPaymentIndex', undefined);
-                  setFieldValue(`roleEditing.payments.${formIndex}.isValidatedAndSaved`, true);
-                }}
+                color="red-1"
+                borderColor="red-1"
+                _hover={{ color: 'red-0', borderColor: 'red-0' }}
+                variant="secondary"
+                leftIcon={<Trash />}
+                onClick={confirmCancelPayment}
               >
-                {t('savePayment')}
+                {t('cancelPayment')}
               </Button>
-            )}
-            {canBeCancelled && (
-              <Show above="md">
-                <Button
-                  color="red-1"
-                  borderColor="red-1"
-                  _hover={{ color: 'red-0', borderColor: 'red-0' }}
-                  variant="secondary"
-                  leftIcon={<Trash />}
-                  onClick={confirmCancelPayment}
-                >
-                  {t('cancelPayment')}
-                </Button>
-              </Show>
-            )}
-          </Flex>
-        )}
+            </Show>
+          )}
+        </Flex>
       </Box>
 
       <Show below="md">

--- a/src/components/Roles/forms/RoleFormPaymentStream.tsx
+++ b/src/components/Roles/forms/RoleFormPaymentStream.tsx
@@ -247,6 +247,22 @@ export function RoleFormPaymentStream({ formIndex }: { formIndex: number }) {
         <Flex justifyContent="flex-end">
           {!streamId && (
             <Button
+              variant="tertiary"
+              onClick={() => {
+                setFieldValue('roleEditing.roleEditingPaymentIndex', undefined);
+                // @todo: fix this doesn't work
+                const paymentIndex = values.roleEditing?.roleEditingPaymentIndex;
+                if (paymentIndex !== undefined) {
+                  setFieldValue(`roleEditing.payments.${paymentIndex}`, undefined);
+                }
+              }}
+              mr={2}
+            >
+              {t('cancel', { ns: 'common' })}
+            </Button>
+          )}
+          {!streamId && (
+            <Button
               isDisabled={!!roleEditingPaymentsErrors}
               onClick={() => {
                 setFieldValue('roleEditing.roleEditingPaymentIndex', undefined);

--- a/src/components/Roles/forms/RoleFormTabs.tsx
+++ b/src/components/Roles/forms/RoleFormTabs.tsx
@@ -92,7 +92,9 @@ export function RoleFormTabs({
         my="1rem"
       >
         <Button
-          isDisabled={!!errors.roleEditing}
+          isDisabled={
+            !!errors.roleEditing || values.roleEditing?.roleEditingPaymentIndex !== undefined
+          }
           onClick={() => {
             if (!values.roleEditing) return;
             const roleUpdated = { ...values.roleEditing, editedRole: editedRoleData };

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -138,5 +138,6 @@
   "startTermPendingToastMessage": "Starting term",
   "startTermSuccessToastMessage": "Term started successfully",
   "startTermFailureToastMessage": "Failed to start term",
-  "invalidHatsTreeIdMessage": "Hats Tree ID is not valid"
+  "invalidHatsTreeIdMessage": "Hats Tree ID is not valid",
+  "savePayment": "Add Payment"
 }


### PR DESCRIPTION
Closes [ENG-304](https://linear.app/decent-labs/issue/ENG-304/remove-the-bottom-save-button-when-user-is-add-a-payment)

When adding or editing a payment, visually there are 2 "Save" buttons. One to save the current payment edit, and the other to save the WHOLE role edit. This PR updates this UX to so the difference is much clearer
<img width="1329" alt="Screenshot 2025-03-03 at 16 00 27" src="https://github.com/user-attachments/assets/5e0702c7-3745-437d-a9fd-eace946c3d11" />
