### PR TITLE
Eng 292 cleanup

### DIFF
--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -67,7 +67,8 @@ interface ISafeTransaction {
   transaction: ITransaction;
 }
 
-class EnhancedSafeApiKit extends SafeApiKit {
+class EnhancedSafeApiKit {
+  readonly safeApiKit: SafeApiKit;
   readonly publicClient: PublicClient;
   readonly networkConfig: NetworkConfig;
   readonly safeClientBaseUrl: string;
@@ -79,7 +80,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
   requestMap = new Map<string, Promise<any> | null>();
 
   constructor(networkConfig: NetworkConfig) {
-    super({
+    this.safeApiKit = new SafeApiKit({
       chainId: BigInt(networkConfig.chain.id),
       txServiceUrl: `${networkConfig.safeBaseURL}/api`,
     });
@@ -151,11 +152,11 @@ class EnhancedSafeApiKit extends SafeApiKit {
     return undefined;
   }
 
-  override async getSafeInfo(safeAddress: Address): Promise<SafeInfoResponse> {
+  async getSafeInfo(safeAddress: Address): Promise<SafeInfoResponse> {
     const checksummedSafeAddress = getAddress(safeAddress);
 
     try {
-      return await super.getSafeInfo(checksummedSafeAddress);
+      return await this.safeApiKit.getSafeInfo(checksummedSafeAddress);
     } catch (error) {
       console.error('Error fetching getSafeInfo from safe-transaction:', error);
     }
@@ -219,9 +220,9 @@ class EnhancedSafeApiKit extends SafeApiKit {
     throw new Error('Failed to getSafeInfo()');
   }
 
-  override async getNextNonce(safeAddress: Address): Promise<number> {
+  async getNextNonce(safeAddress: Address): Promise<number> {
     try {
-      return await super.getNextNonce(safeAddress);
+      return await this.safeApiKit.getNextNonce(safeAddress);
     } catch (error) {
       console.error('Error fetching getNextNonce from safe-transaction:', error);
     }
@@ -254,9 +255,9 @@ class EnhancedSafeApiKit extends SafeApiKit {
     throw new Error('Failed to getNextNonce()');
   }
 
-  override async getToken(tokenAddress: Address): Promise<TokenInfoResponse> {
+  async getToken(tokenAddress: Address): Promise<TokenInfoResponse> {
     try {
-      return await super.getToken(tokenAddress);
+      return await this.safeApiKit.getToken(tokenAddress);
     } catch (error) {
       console.error('Error fetching getToken from safe-transaction:', error);
     }
@@ -284,12 +285,9 @@ class EnhancedSafeApiKit extends SafeApiKit {
     throw new Error('Failed to getToken()');
   }
 
-  override async confirmTransaction(
-    safeTxHash: string,
-    signature: string,
-  ): Promise<SignatureResponse> {
+  async confirmTransaction(safeTxHash: string, signature: string): Promise<SignatureResponse> {
     try {
-      return await super.confirmTransaction(safeTxHash, signature);
+      return await this.safeApiKit.confirmTransaction(safeTxHash, signature);
     } catch (error) {
       console.error('Error posting confirmTransaction from safe-transaction:', error);
     }
@@ -316,11 +314,11 @@ class EnhancedSafeApiKit extends SafeApiKit {
     throw new Error('Failed to confirmTransaction()');
   }
 
-  override async getMultisigTransactions(
+  async getMultisigTransactions(
     safeAddress: Address,
   ): Promise<SafeMultisigTransactionListResponse> {
     try {
-      return await super.getMultisigTransactions(safeAddress);
+      return await this.safeApiKit.getMultisigTransactions(safeAddress);
     } catch (error) {
       console.error('Error fetching getMultisigTransactions from safe-transaction:', error);
     }
@@ -344,7 +342,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
     };
   }
 
-  override async proposeTransaction({
+  async proposeTransaction({
     safeAddress,
     safeTransactionData,
     safeTxHash,
@@ -353,7 +351,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
     origin,
   }: ProposeTransactionProps): Promise<void> {
     try {
-      return await super.proposeTransaction({
+      return await this.safeApiKit.proposeTransaction({
         safeAddress,
         safeTransactionData,
         safeTxHash,
@@ -390,9 +388,9 @@ class EnhancedSafeApiKit extends SafeApiKit {
     throw new Error('Failed to proposeTransaction()');
   }
 
-  override async decodeData(data: string): Promise<any> {
+  async decodeData(data: string): Promise<any> {
     try {
-      return await super.decodeData(data);
+      return await this.safeApiKit.decodeData(data);
     } catch (error) {
       console.error('Error decoding data from safe-transaction:', error);
     }

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -491,13 +491,6 @@ class EnhancedSafeApiKit extends SafeApiKit {
 
   async getTransfers(safeAddress: Address): Promise<TransferWithTokenInfoResponse[]> {
     try {
-      const allTransactions = await this.getAllTransactions(safeAddress);
-      return this._getTransfersFrom(allTransactions);
-    } catch (err) {
-      console.error('Error fetching getTransfers from safe-transaction:', err);
-    }
-
-    try {
       const response: ListResponse<ISafeTransaction> = await this._safeClientGet(
         safeAddress,
         '/transactions/history',

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -9,7 +9,6 @@ import SafeApiKit, {
   SafeMultisigTransactionWithTransfersResponse,
   SignatureResponse,
   TokenInfoResponse,
-  TransferListResponse,
   TransferWithTokenInfoResponse,
 } from '@safe-global/api-kit';
 import { ListResponse } from '@safe-global/safe-core-sdk-types';
@@ -285,24 +284,6 @@ class EnhancedSafeApiKit extends SafeApiKit {
     }
 
     throw new Error('Failed to getAllTransactions()');
-  }
-
-  override async getIncomingTransactions(safeAddress: string): Promise<TransferListResponse> {
-    try {
-      return await super.getIncomingTransactions(safeAddress);
-    } catch (error) {
-      console.error('Error fetching getIncomingTransactions from safe-transaction:', error);
-    }
-
-    try {
-      const response: any = await this._safeClientGet(safeAddress, '/incoming-transfers');
-      // return response.results.map(transfer => transfer);
-      console.log(response);
-    } catch (error) {
-      console.error('Error fetching getIncomingTransactions from safe-client:', error);
-    }
-
-    throw new Error('Failed to getIncomingTransactions()');
   }
 
   override async getNextNonce(safeAddress: Address): Promise<number> {

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -119,6 +119,93 @@ class EnhancedSafeApiKit extends SafeApiKit {
     });
   }
 
+  private _timestampToString(timestamp: number): string | undefined {
+    try {
+      const date = new Date(timestamp);
+      return date.toISOString();
+    } catch (err) {
+      return undefined;
+    }
+  }
+
+  private _transferOf(transaction: ISafeTransaction): TransferWithTokenInfoResponse | undefined {
+    const transfer = transaction.transaction?.txInfo?.transferInfo;
+    if (transfer) {
+      const timestamp = transaction.transaction?.timestamp;
+      const timeText = timestamp != undefined ? this._timestampToString(timestamp) : undefined;
+      if (timeText) {
+        return {
+          type: transaction.transaction?.txInfo.type,
+          executionDate: timeText,
+          blockNumber: timestamp,
+          transactionHash: transaction.transaction?.txHash,
+          to: transaction.transaction?.txInfo?.recipient?.value ?? '',
+          value: transfer.value,
+          tokenId: transfer.tokenAddress,
+          tokenAddress: transfer.tokenAddress,
+          from: transaction.transaction?.txInfo?.sender?.value ?? '',
+          tokenInfo: {
+            address: transfer.tokenAddress,
+            name: transfer.tokenName,
+            symbol: transfer.tokenSymbol,
+            decimals: transfer.decimals,
+            logoUri: transfer.logoUri,
+          },
+        };
+      }
+    }
+    return undefined;
+  }
+
+  private _getTransfersFrom(
+    transactions: AllTransactionsListResponse,
+  ): TransferWithTokenInfoResponse[] {
+    const groupedTransactions = transactions.results.reduce(
+      (acc, tx) => {
+        const txType = tx.txType || 'UNKNOWN';
+        if (!acc[txType]) {
+          acc[txType] = [];
+        }
+        acc[txType].push(tx);
+        return acc;
+      },
+      {} as Record<
+        string,
+        Array<
+          | SafeModuleTransactionWithTransfersResponse
+          | SafeMultisigTransactionWithTransfersResponse
+          | EthereumTxWithTransfersResponse
+        >
+      >,
+    );
+
+    const moduleTransactions = (groupedTransactions.MODULE_TRANSACTION ||
+      []) as SafeModuleTransactionWithTransfersResponse[];
+    const multisigTransactions = (groupedTransactions.MULTISIG_TRANSACTION ||
+      []) as SafeMultisigTransactionWithTransfersResponse[];
+    const ethereumTransactions = (groupedTransactions.ETHEREUM_TRANSACTION ||
+      []) as EthereumTxWithTransfersResponse[];
+
+    const uniqueModuleTransactions = Array.from(
+      new Map(moduleTransactions.map(tx => [tx.transactionHash, tx])).values(),
+    );
+
+    const uniqueMultisigTransactions = Array.from(
+      new Map(multisigTransactions.map(tx => [tx.transactionHash, tx])).values(),
+    );
+
+    const uniqueEthereumTransactions = Array.from(
+      new Map(ethereumTransactions.map(tx => [tx.txHash, tx])).values(),
+    );
+
+    const flattenedTransfers = [
+      ...uniqueModuleTransactions.flatMap(tx => tx.transfers || []),
+      ...uniqueMultisigTransactions.flatMap(tx => tx.transfers || []),
+      ...uniqueEthereumTransactions.flatMap(tx => tx.transfers || []),
+    ];
+    return flattenedTransfers;
+  }
+
   override async getSafeInfo(safeAddress: Address): Promise<SafeInfoResponse> {
     const checksummedSafeAddress = getAddress(safeAddress);
 
@@ -216,115 +303,6 @@ class EnhancedSafeApiKit extends SafeApiKit {
     }
 
     throw new Error('Failed to getIncomingTransactions()');
-  }
-
-  async getTransfers(safeAddress: Address): Promise<TransferWithTokenInfoResponse[]> {
-    try {
-      const allTransactions = await this.getAllTransactions(safeAddress);
-      return this._getTransfersFrom(allTransactions);
-    } catch (err) {
-      console.error('Error fetching getTransfers from safe-transaction:', err);
-    }
-
-    try {
-      const response: ListResponse<ISafeTransaction> = await this._safeClientGet(
-        safeAddress,
-        '/transactions/history',
-      );
-
-      const transfers = response.results.flatMap(tx => this._transferOf(tx) ?? []);
-
-      return transfers;
-    } catch (error) {
-      console.error('Error fetching getTransfers from safe-client:', error);
-    }
-
-    return [];
-  }
-
-  private _transferOf(transaction: ISafeTransaction): TransferWithTokenInfoResponse | undefined {
-    const transfer = transaction.transaction?.txInfo?.transferInfo;
-    if (transfer) {
-      const timestamp = transaction.transaction?.timestamp;
-      const timeText = timestamp != undefined ? this._timestampToString(timestamp) : undefined;
-      if (timeText) {
-        return {
-          type: transaction.transaction?.txInfo.type,
-          executionDate: timeText,
-          blockNumber: timestamp,
-          transactionHash: transaction.transaction?.txHash,
-          to: transaction.transaction?.txInfo?.recipient?.value ?? '',
-          value: transfer.value,
-          tokenId: transfer.tokenAddress,
-          tokenAddress: transfer.tokenAddress,
-          from: transaction.transaction?.txInfo?.sender?.value ?? '',
-          tokenInfo: {
-            address: transfer.tokenAddress,
-            name: transfer.tokenName,
-            symbol: transfer.tokenSymbol,
-            decimals: transfer.decimals,
-            logoUri: transfer.logoUri,
-          },
-        };
-      }
-    }
-    return undefined;
-  }
-
-  _timestampToString(timestamp: number): string | undefined {
-    try {
-      const date = new Date(timestamp);
-      return date.toISOString();
-    } catch (err) {
-      return undefined;
-    }
-  }
-
-  _getTransfersFrom(transactions: AllTransactionsListResponse): TransferWithTokenInfoResponse[] {
-    const groupedTransactions = transactions.results.reduce(
-      (acc, tx) => {
-        const txType = tx.txType || 'UNKNOWN';
-        if (!acc[txType]) {
-          acc[txType] = [];
-        }
-        acc[txType].push(tx);
-        return acc;
-      },
-      {} as Record<
-        string,
-        Array<
-          | SafeModuleTransactionWithTransfersResponse
-          | SafeMultisigTransactionWithTransfersResponse
-          | EthereumTxWithTransfersResponse
-        >
-      >,
-    );
-
-    const moduleTransactions = (groupedTransactions.MODULE_TRANSACTION ||
-      []) as SafeModuleTransactionWithTransfersResponse[];
-    const multisigTransactions = (groupedTransactions.MULTISIG_TRANSACTION ||
-      []) as SafeMultisigTransactionWithTransfersResponse[];
-    const ethereumTransactions = (groupedTransactions.ETHEREUM_TRANSACTION ||
-      []) as EthereumTxWithTransfersResponse[];
-
-    const uniqueModuleTransactions = Array.from(
-      new Map(moduleTransactions.map(tx => [tx.transactionHash, tx])).values(),
-    );
-
-    const uniqueMultisigTransactions = Array.from(
-      new Map(multisigTransactions.map(tx => [tx.transactionHash, tx])).values(),
-    );
-
-    const uniqueEthereumTransactions = Array.from(
-      new Map(ethereumTransactions.map(tx => [tx.txHash, tx])).values(),
-    );
-
-    const flattenedTransfers = [
-      ...uniqueModuleTransactions.flatMap(tx => tx.transfers || []),
-      ...uniqueMultisigTransactions.flatMap(tx => tx.transfers || []),
-      ...uniqueEthereumTransactions.flatMap(tx => tx.transfers || []),
-    ];
-    return flattenedTransfers;
   }
 
   override async getNextNonce(safeAddress: Address): Promise<number> {
@@ -528,6 +506,30 @@ class EnhancedSafeApiKit extends SafeApiKit {
     const safeInfoResponse = await this.getSafeInfo(checksummedSafeAddress);
     const nextNonce = await this.getNextNonce(checksummedSafeAddress);
     return { ...safeInfoResponse, nextNonce };
+  }
+
+  async getTransfers(safeAddress: Address): Promise<TransferWithTokenInfoResponse[]> {
+    try {
+      const allTransactions = await this.getAllTransactions(safeAddress);
+      return this._getTransfersFrom(allTransactions);
+    } catch (err) {
+      console.error('Error fetching getTransfers from safe-transaction:', err);
+    }
+
+    try {
+      const response: ListResponse<ISafeTransaction> = await this._safeClientGet(
+        safeAddress,
+        '/transactions/history',
+      );
+
+      const transfers = response.results.flatMap(tx => this._transferOf(tx) ?? []);
+
+      return transfers;
+    } catch (error) {
+      console.error('Error fetching getTransfers from safe-client:', error);
+    }
+
+    return [];
   }
 }
 

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -125,7 +125,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
     try {
       return await super.getSafeInfo(checksummedSafeAddress);
     } catch (error) {
-      console.error('Error fetching getSafeInfo from safeAPI:', error);
+      console.error('Error fetching getSafeInfo from safe-transaction:', error);
     }
 
     try {
@@ -194,8 +194,9 @@ class EnhancedSafeApiKit extends SafeApiKit {
     try {
       return await super.getAllTransactions(safeAddress, options);
     } catch (error) {
-      console.error('Error fetching getAllTransactions from safeAPI:', error);
+      console.error('Error fetching getAllTransactions from safe-transaction:', error);
     }
+
     throw new Error('Failed to getAllTransactions()');
   }
 
@@ -203,7 +204,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
     try {
       return await super.getIncomingTransactions(safeAddress);
     } catch (error) {
-      console.error('Error fetching getAllTransactions from safeAPI:', error);
+      console.error('Error fetching getIncomingTransactions from safe-transaction:', error);
     }
 
     try {
@@ -211,7 +212,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
       // return response.results.map(transfer => transfer);
       console.log(response);
     } catch (error) {
-      console.error('Error fetching getAllTransactions from safe-client:', error);
+      console.error('Error fetching getIncomingTransactions from safe-client:', error);
     }
 
     throw new Error('Failed to getIncomingTransactions()');
@@ -222,7 +223,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
       const allTransactions = await this.getAllTransactions(safeAddress);
       return this._getTransfersFrom(allTransactions);
     } catch (err) {
-      console.log(err);
+      console.error('Error fetching getTransfers from safe-transaction:', err);
     }
 
     try {
@@ -235,13 +236,13 @@ class EnhancedSafeApiKit extends SafeApiKit {
 
       return transfers;
     } catch (error) {
-      console.error('Error fetching getAllTransactions from safe-client:', error);
+      console.error('Error fetching getTransfers from safe-client:', error);
     }
 
     return [];
   }
 
-  _transferOf(transaction: ISafeTransaction): TransferWithTokenInfoResponse | undefined {
+  private _transferOf(transaction: ISafeTransaction): TransferWithTokenInfoResponse | undefined {
     const transfer = transaction.transaction?.txInfo?.transferInfo;
     if (transfer) {
       const timestamp = transaction.transaction?.timestamp;
@@ -330,7 +331,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
     try {
       return await super.getNextNonce(safeAddress);
     } catch (error) {
-      console.error('Error fetching getNextNonce from safeAPI:', error);
+      console.error('Error fetching getNextNonce from safe-transaction:', error);
     }
 
     try {
@@ -365,8 +366,10 @@ class EnhancedSafeApiKit extends SafeApiKit {
     try {
       return await super.getToken(tokenAddress);
     } catch (error) {
-      console.error('Error fetching getToken from safeAPI:', error);
+      console.error('Error fetching getToken from safe-transaction:', error);
+    }
 
+    try {
       const [name, symbol, decimals] = await this.publicClient.multicall({
         contracts: [
           { address: tokenAddress, abi: erc20Abi, functionName: 'name' },
@@ -382,7 +385,11 @@ class EnhancedSafeApiKit extends SafeApiKit {
         symbol,
         decimals,
       };
+    } catch (error) {
+      console.error('Error fetching getToken from contract:', error);
     }
+
+    throw new Error('Failed to getToken()');
   }
 
   override async confirmTransaction(
@@ -392,7 +399,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
     try {
       return await super.confirmTransaction(safeTxHash, signature);
     } catch (error) {
-      console.error('Error posting confirmTransaction from safeAPI:', error);
+      console.error('Error posting confirmTransaction from safe-transaction:', error);
     }
 
     try {
@@ -423,7 +430,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
     try {
       return await super.getMultisigTransactions(safeAddress);
     } catch (error) {
-      console.error('Error fetching getMultisigTransactions from safeAPI:', error);
+      console.error('Error fetching getMultisigTransactions from safe-transaction:', error);
     }
 
     // /multisig-transactions/raw response matches SafeMultisigTransactionListResponse
@@ -463,7 +470,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
         origin,
       });
     } catch (error) {
-      console.error('Error posting proposeTransaction from safeAPI:', error);
+      console.error('Error posting proposeTransaction from safe-transaction:', error);
     }
 
     try {
@@ -495,7 +502,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
     try {
       return await super.decodeData(data);
     } catch (error) {
-      console.error('Error decoding data from safeAPI:', error);
+      console.error('Error decoding data from safe-transaction:', error);
     }
 
     try {

--- a/src/providers/App/hooks/useSafeAPI.ts
+++ b/src/providers/App/hooks/useSafeAPI.ts
@@ -468,7 +468,7 @@ class EnhancedSafeApiKit extends SafeApiKit {
       const body = {
         data: data,
       };
-      const value = await axios.post<any>(`${this.safeClientBaseUrl}/data-decoder`, body, {
+      const value = await axios.post(`${this.safeClientBaseUrl}/data-decoder`, body, {
         headers: {
           accept: 'application/json',
         },


### PR DESCRIPTION
This PR builds on https://github.com/decentdao/decent-interface/pull/2762, which has already been merged.

Notable changes:
- fixed some incorrect error messages, standardized the rest to follow the same format.
- added `private` modifiers to private functions, so autocomplete doesn't pick them up (outside of the `EnhancedSafeApi` class).
- deleted unused function: `getIncomingTransactions`.
- remove `getAllTransactions` call (and subsequent `_getTransfersFrom` call) from `getTransfers`, since it's not an overridden function and `this.getAllTransactions` is not a super call (which is the pattern in place in the file).
- remove the actual implementations of `getAllTransactions` and `_getTransfersFrom`, because now they're unused.
- `EnhancedSafeApiKit` no longer extends `SafeApiKit`, for better safety elsewhere in the codebase (can't accidentally call a function on `SafeApiKit` which is not overridden).